### PR TITLE
feat(generic): allow JS files to provide the config object

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,15 @@ You can set `electronPackagerConfig` with **any** of the options from
 **NOTE:** The `afterCopy` and `afterExtract` options are mapped to `require`
 calls internally, so provide a path to a file that exports your hooks and they
 will still run.
+
+**NOTE:** You can also set your `forge` config property of your package.json to point to a JS file the exports the config object like so.
+
+```js
+{
+  ...
+  "config": {
+    "forge": "./forge.config.js"
+  }
+  ...
+}
+```

--- a/README.md
+++ b/README.md
@@ -125,11 +125,7 @@ config object:
 You can set `electronPackagerConfig` with **any** of the options from
 [Electron Packager](https://github.com/electron-userland/electron-packager/blob/master/docs/api.md).
 
-**NOTE:** The `afterCopy` and `afterExtract` options are mapped to `require`
-calls internally, so provide a path to a file that exports your hooks and they
-will still run.
-
-**NOTE:** You can also set your `forge` config property of your package.json to point to a JS file the exports the config object like so.
+**NOTE:** You can also set your `forge` config property of your package.json to point to a JS file the exports the config object:
 
 ```js
 {
@@ -140,3 +136,7 @@ will still run.
   ...
 }
 ```
+
+**NOTE:** If you use the JSON object then the `afterCopy` and `afterExtract` options are mapped to `require`
+calls internally, so provide a path to a file that exports your hooks and they will still run.  If you use
+the JS file method mentioned above then you can use functions normally.

--- a/src/electron-forge-package.js
+++ b/src/electron-forge-package.js
@@ -73,8 +73,12 @@ const main = async () => {
       await rebuildHook(buildPath, electronVersion, pPlatform, pArch);
       packagerSpinner = ora.ora('Packaging Application').start();
       done();
-    }].concat(forgeConfig.electronPackagerConfig.afterCopy ? forgeConfig.electronPackagerConfig.afterCopy.map(item => require(item)) : []),
-    afterExtract: forgeConfig.electronPackagerConfig.afterExtract ? forgeConfig.electronPackagerConfig.afterExtract.map(item => require(item)) : [],
+    }].concat(forgeConfig.electronPackagerConfig.afterCopy ? forgeConfig.electronPackagerConfig.afterCopy.map(item =>
+      (typeof item === 'string' ? require(item) : item)
+    ) : []),
+    afterExtract: forgeConfig.electronPackagerConfig.afterExtract ? forgeConfig.electronPackagerConfig.afterExtract.map(item =>
+      (typeof item === 'string' ? require(item) : item)
+    ) : [],
     dir,
     arch,
     platform,

--- a/src/util/forge-config.js
+++ b/src/util/forge-config.js
@@ -3,6 +3,16 @@ import path from 'path';
 
 export default async (dir) => {
   let forgeConfig = JSON.parse(await fs.readFile(path.resolve(dir, 'package.json'))).config.forge;
+  if (typeof forgeConfig === 'string' && (await fs.exists(path.resolve(dir, forgeConfig)) || await fs.exists(path.resolve(dir, `${forgeConfig}.js`)))) {
+    try {
+      forgeConfig = require(path.resolve(dir, forgeConfig));
+    } catch (err) {
+      console.error(`Failed to load: ${path.resolve(dir, forgeConfig)}`);
+      throw err;
+    }
+  } else if (typeof forgeConfig !== 'object') {
+    throw new Error('Expected packageJSON.config.forge to be an object or point to a requirable JS file');
+  }
   forgeConfig = Object.assign({
     make_targets: {},
     electronPackagerConfig: {},

--- a/test/fixture/dummy_app/package.json
+++ b/test/fixture/dummy_app/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "",
+  "productName": "",
+  "version": "1.0.0",
+  "description": "",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "electron-forge start"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "config": {
+    "forge": {
+      "make_targets": {
+        "win32": ["squirrel"],
+        "darwin": ["zip"],
+        "linux": ["deb", "rpm"]
+      },
+      "electronPackagerConfig": {},
+      "electronInstallerRedhat": {},
+      "electronInstallerDebian": {},
+      "electronWinstallerConfig": { "windows": "magic" }
+    }
+  },
+  "devDependencies": {
+    "electron-prebuilt-compile": "9.9.9"
+  }
+}

--- a/test/fixture/dummy_js_conf/forge.config.js
+++ b/test/fixture/dummy_js_conf/forge.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  make_targets: {
+    win32: ['squirrel'],
+    darwin: ['zip'],
+    linux: ['deb', 'rpm'],
+    mas: ['zip'],
+  },
+  electronPackagerConfig: { foo: 'bar' },
+  electronWinstallerConfig: {},
+  electronInstallerDebian: {},
+  electronInstallerRedhat: {},
+  magicFn: () => 'magic result',
+};

--- a/test/fixture/dummy_js_conf/package.json
+++ b/test/fixture/dummy_js_conf/package.json
@@ -11,17 +11,7 @@
   "author": "",
   "license": "MIT",
   "config": {
-    "forge": {
-      "make_targets": {
-        "win32": ["squirrel"],
-        "darwin": ["zip"],
-        "linux": ["deb", "rpm"]
-      },
-      "electronPackagerConfig": {},
-      "electronWinstallerConfig": {},
-      "electronInstallerDebian": {},
-      "electronInstallerRedhat": {}
-    }
+    "forge": "./forge.config.js"
   },
   "devDependencies": {
     "electron-prebuilt-compile": "9.9.9"

--- a/test/util_spec.js
+++ b/test/util_spec.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import path from 'path';
 
 import resolveDir from '../src/util/resolve-dir';
+import findConfig from '../src/util/forge-config';
 
 describe('resolve-dir', () => {
   it('should return null if a valid dir can not be found', async () => {
@@ -9,7 +10,41 @@ describe('resolve-dir', () => {
   });
 
   it('should return a directory if it finds a node module', async () => {
-    expect(await resolveDir(path.resolve(__dirname, 'fixture/foo'))).to.not.be.equal(null);
-    expect(await resolveDir(path.resolve(__dirname, 'fixture/foo'))).to.be.equal(path.resolve(__dirname, 'fixture'));
+    expect(await resolveDir(path.resolve(__dirname, 'fixture/dummy_app/foo'))).to.not.be.equal(null);
+    expect(await resolveDir(path.resolve(__dirname, 'fixture/dummy_app/foo'))).to.be.equal(path.resolve(__dirname, 'fixture/dummy_app'));
+  });
+});
+
+const defaults = {
+  make_targets: {
+    win32: ['squirrel'],
+    darwin: ['zip'],
+    linux: ['deb', 'rpm'],
+    mas: ['zip'],
+  },
+  electronInstallerDMG: {},
+  electronPackagerConfig: {},
+  electronWinstallerConfig: {},
+  electronInstallerDebian: {},
+  electronInstallerRedhat: {},
+};
+
+describe('forge-config', () => {
+  it('should resolve the object in package.json with defaults  if one exists', async () => {
+    expect(await findConfig(path.resolve(__dirname, 'fixture/dummy_app'))).to.be.deep.equal(Object.assign({}, defaults, {
+      electronWinstallerConfig: { windows: 'magic' },
+    }));
+  });
+
+  it('should resolve the JS file exports in config.forge points to a JS file', async () => {
+    expect(JSON.parse(JSON.stringify(await findConfig(path.resolve(__dirname, 'fixture/dummy_js_conf'))))).to.be.deep.equal(Object.assign({}, defaults, {
+      electronPackagerConfig: { foo: 'bar' },
+    }));
+  });
+
+  it('should resolve the JS file exports in config.forge points to a JS file and maintain functions', async () => {
+    const conf = await findConfig(path.resolve(__dirname, 'fixture/dummy_js_conf'));
+    expect(conf.magicFn).to.be.a('function');
+    expect(conf.magicFn()).to.be.equal('magic result');
   });
 });


### PR DESCRIPTION
**Have you read the [section in CONTRIBUTING.md about pull requests](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md#filing-pull-requests)?**

Yes

**Are your changes appropriately documented?**

Yes

**Do your changes have sufficient test coverage?**

Yes

**Does the testsuite pass successfully on your local machine?**

Yes

**Summarize your changes:**

Allow the `config.forge` prop in your package.json to point to a JS file that provides the config.

ISSUES CLOSED: #21