### PR TITLE
test(generic): only skip help spec on Windows

### DIFF
--- a/test/cli_spec.js
+++ b/test/cli_spec.js
@@ -30,7 +30,7 @@ const pSpawn = async (args = [], opts = {
 const installer = process.argv.find(arg => arg.startsWith('--installer=')) || '--installer=system default';
 
 describe(`electron-forge CLI (with installer=${installer.substr(12)})`, () => {
-  it('should output help', async () => {
+  it('should output help', async function helpSpec() {
     if (process.platform === 'win32') {
       this.skip();
     } else {

--- a/test/cli_spec.js
+++ b/test/cli_spec.js
@@ -30,8 +30,12 @@ const pSpawn = async (args = [], opts = {
 const installer = process.argv.find(arg => arg.startsWith('--installer=')) || '--installer=system default';
 
 describe(`electron-forge CLI (with installer=${installer.substr(12)})`, () => {
-  it.skip('should output help', async () => {
-    expect(await pSpawn(['--help'])).to.contain('Usage: electron-forge [options] [command]');
+  it('should output help', async () => {
+    if (process.platform === 'win32') {
+      this.skip();
+    } else {
+      expect(await pSpawn(['--help'])).to.contain('Usage: electron-forge [options] [command]');
+    }
   });
 
   let dirID = Date.now();


### PR DESCRIPTION
**Have you read the [section in CONTRIBUTING.md about pull requests](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md#filing-pull-requests)?**

Yes

**Are your changes appropriately documented?**

N/A

**Do your changes have sufficient test coverage?**

Yes

**Does the testsuite pass successfully on your local machine?**

Yes

**Summarize your changes:**

re-enable the help spec on macOS/Linux, since it works consistently there.