### PR TITLE
fix(tests): replace intermittently failing to rebuild newrelic module with cld

### DIFF
--- a/test/fixture/native_app/package.json
+++ b/test/fixture/native_app/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "ref": "1.3.3",
     "benchr": "3.2.0",
-    "@newrelic/native-metrics": "1.0.0"
+    "@paulcbetts/cld": "2.4.6"
   },
   "optionalDependencies": {
     "zipfile": "0.5.11"

--- a/test/rebuild_spec.js
+++ b/test/rebuild_spec.js
@@ -44,8 +44,8 @@ describe('rebuilder', () => {
   });
 
   it('should have rebuilt children of scoped top level prod dependencies', async () => {
-    const forgeMeta = path.resolve(testModulePath, 'node_modules', '@newrelic/native-metrics', 'build', 'Release', '.forge-meta');
-    expect(await fs.exists(forgeMeta), '@newrelic/native-metrics build meta should exist').to.equal(true);
+    const forgeMeta = path.resolve(testModulePath, 'node_modules', '@paulcbetts/cld', 'build', 'Release', '.forge-meta');
+    expect(await fs.exists(forgeMeta), '@paulcbetts/cld build meta should exist').to.equal(true);
   });
 
   it('should have rebuilt top level optional dependencies', async () => {

--- a/test/rebuild_spec.js
+++ b/test/rebuild_spec.js
@@ -13,6 +13,11 @@ ora.ora = ora;
 describe('rebuilder', () => {
   const testModulePath = path.resolve(os.tmpdir(), 'electron-forge-rebuild-test');
 
+  async function expectForgeMeta(npmPackage, shouldExist = true) {
+    const forgeMeta = path.resolve(testModulePath, 'node_modules', npmPackage, 'build', 'Release', '.forge-meta');
+    expect(await fs.exists(forgeMeta), `${npmPackage} build meta ${shouldExist ? 'should' : 'should not'} exist`).to.equal(shouldExist);
+  }
+
   before(async () => {
     await fs.remove(testModulePath);
     await fs.mkdirs(testModulePath);
@@ -34,28 +39,23 @@ describe('rebuilder', () => {
   });
 
   it('should have rebuilt top level prod dependencies', async () => {
-    const forgeMeta = path.resolve(testModulePath, 'node_modules', 'ref', 'build', 'Release', '.forge-meta');
-    expect(await fs.exists(forgeMeta), 'ref build meta should exist').to.equal(true);
+    expectForgeMeta('ref');
   });
 
   it('should have rebuilt children of top level prod dependencies', async () => {
-    const forgeMeta = path.resolve(testModulePath, 'node_modules', 'microtime', 'build', 'Release', '.forge-meta');
-    expect(await fs.exists(forgeMeta), 'microtime build meta should exist').to.equal(true);
+    expectForgeMeta('microtime');
   });
 
   it('should have rebuilt children of scoped top level prod dependencies', async () => {
-    const forgeMeta = path.resolve(testModulePath, 'node_modules', '@paulcbetts/cld', 'build', 'Release', '.forge-meta');
-    expect(await fs.exists(forgeMeta), '@paulcbetts/cld build meta should exist').to.equal(true);
+    expectForgeMeta('@paulcbetts/cld');
   });
 
   it('should have rebuilt top level optional dependencies', async () => {
-    const forgeMeta = path.resolve(testModulePath, 'node_modules', 'zipfile', 'build', 'Release', '.forge-meta');
-    expect(await fs.exists(forgeMeta), 'zipfile build meta should exist').to.equal(true);
+    expectForgeMeta('zipfile');
   });
 
   it('should not have rebuilt top level devDependencies', async () => {
-    const forgeMeta = path.resolve(testModulePath, 'node_modules', 'ffi', 'build', 'Release', '.forge-meta');
-    expect(await fs.exists(forgeMeta), 'ffi build meta should not exist').to.equal(false);
+    expectForgeMeta('ffi', false);
   });
 
   after(async () => {


### PR DESCRIPTION
**Have you read the [section in CONTRIBUTING.md about pull requests](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md#filing-pull-requests)?**

Yes

**Are your changes appropriately documented?**

N/A

**Do your changes have sufficient test coverage?**

Yes

**Does the testsuite pass successfully on your local machine?**

Yes

**Summarize your changes:**

* replace the newrelic module with one that hopefully rebuilds more consistently on Windows (and also has a better license)
* DRY up the rebuild tests