### PR TITLE
chore(tests): run flatpak runtime install in local Dockerfile

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,6 +1,8 @@
 FROM malept/electron-forge-container:latest
 
-RUN apt-get install --no-install-recommends -y g++
+RUN flatpak remote-add --from gnome https://sdk.gnome.org/gnome.flatpakrepo && \
+    flatpak install --runtime gnome org.freedesktop.Platform//1.4
+
 RUN mkdir /code
 WORKDIR /code
 ADD . /code/


### PR DESCRIPTION
**Have you read the [section in CONTRIBUTING.md about pull requests](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md#filing-pull-requests)?**

Yes

**Are your changes appropriately documented?**

N/A

**Do your changes have sufficient test coverage?**

N/A

**Does the testsuite pass successfully on your local machine?**

N/A

**Summarize your changes:**

Needs to be here (instead of electron-forge-container) because the command causes Docker Hub's build workers to time out.