### PR TITLE
electron-forge publish

### DIFF
--- a/.cz.js
+++ b/.cz.js
@@ -18,6 +18,7 @@ module.exports = {
     { name: 'starter' },
     { name: 'tests' },
     { name: 'initializer' },
+    { name: 'publisher' },
     { name: 'generic' },
   ],
   allowCustomScopes: true,

--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ current platform.
 electron-forge lint
 ```
 
+## Publishing your Project
+
+```bash
+electron-forge publish
+```
+
+This will `make` your project and publish any generated artifacts.  By default it will publish to GitHub but you can change the publish target with `--target=YourTarget`.
+
 # Config
 
 Once you have generated a project, your `package.json` file will have some
@@ -125,7 +133,7 @@ config object:
 You can set `electronPackagerConfig` with **any** of the options from
 [Electron Packager](https://github.com/electron-userland/electron-packager/blob/master/docs/api.md).
 
-**NOTE:** You can also set your `forge` config property of your package.json to point to a JS file the exports the config object:
+**NOTE:** You can also set your `forge` config property of your package.json to point to a JS file that exports the config object:
 
 ```js
 {
@@ -140,3 +148,37 @@ You can set `electronPackagerConfig` with **any** of the options from
 **NOTE:** If you use the JSON object then the `afterCopy` and `afterExtract` options are mapped to `require`
 calls internally, so provide a path to a file that exports your hooks and they will still run.  If you use
 the JS file method mentioned above then you can use functions normally.
+
+## Possible `publish` targets
+
+| Target Name | Description | Required Config |
+|-------------|-------------|-----------------|
+| github      | Makes a new release for the current version (if required) and uploads the make artifacts as release assets | `process.env.GITHUB_TOKEN` - A personal access token with access to your releases <br />`forge.github_repository.owner` - The owner of the GitHub repository<br />`forge.github_repository.name` - The name of the GitHub repository |
+
+## Custom `make` and `publish` targets
+
+You can make your own custom targets for the `make` and `publish` targets.  If you publish them as `electron-forge-publisher-{name}` or `electron-forge-maker-{name}` you can then just specify `{name}` as your make / publish target.  The API for each is documented below.
+
+### API for `make` targets
+
+You must export a Function that returns a Promise.  Your function will be called with the following parameters.
+
+* `appDir` - The directory containing the packaged application
+* `appName` - The productName of the application
+* `targetArch` - The target architecture of the make command
+* `forgeConfig` - An object representing the users forgeConfig
+* `packageJSON` - An object representing the users package.json file
+
+Your promise must resolve with an array of the artifacts you generated.
+
+### API for `publish` targets
+
+You must export a Function that returns a Promise.  Your function will be called with the following parameters.
+
+* artifactPaths - An array of absolute paths to artifacts to publish
+* packageJSON - An object representing the users package.json file
+* forgeConfig - An object representing the users forgeConfig
+* authToken - The value of `--auth-token`
+* tag - The value of `--tag`
+
+You should use `ora` to indicate your publish progress.

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "electron-packager": "^8.4.0",
     "electron-winstaller": "^2.5.0",
     "fs-promise": "^1.0.0",
+    "github": "^7.2.0",
     "inquirer": "^2.0.0",
     "log-symbols": "^1.0.2",
     "node-gyp": "^3.4.0",

--- a/src/electron-forge-publish.js
+++ b/src/electron-forge-publish.js
@@ -63,6 +63,9 @@ const main = async () => {
       repo: forgeConfig.github_repository.name,
       per_page: 100,
     })).find(testRelease => testRelease.tag_name === program.tag || `v${packageJSON.version}`);
+    if (!release) {
+      throw { code: 404 }; // eslint-disable-line
+    }
   } catch (err) {
     if (err.code === 404) {
       // Release does not exist, let's make it

--- a/src/electron-forge-publish.js
+++ b/src/electron-forge-publish.js
@@ -1,0 +1,117 @@
+import 'colors';
+import fs from 'fs-promise';
+import path from 'path';
+import program from 'commander';
+import ora from 'ora';
+
+import './util/terminate';
+import getForgeConfig from './util/forge-config';
+import GitHub from './util/github';
+import readPackageJSON from './util/read-package-json';
+import resolveDir from './util/resolve-dir';
+
+import make from './electron-forge-make';
+
+const main = async () => {
+  const makeResults = await make();
+
+  let dir = process.cwd();
+  program
+    .version(require('../package.json').version)
+    .arguments('[cwd]')
+    .option('--auth-token', 'Provided GitHub authorization token')
+    .option('-t, --tag', 'The tag to publish to on GitHub')
+    .allowUnknownOption(true)
+    .action((cwd) => {
+      if (!cwd) return;
+      if (path.isAbsolute(cwd) && fs.existsSync(cwd)) {
+        dir = cwd;
+      } else if (fs.existsSync(path.resolve(dir, cwd))) {
+        dir = path.resolve(dir, cwd);
+      }
+    })
+    .parse(process.argv);
+
+  dir = await resolveDir(dir);
+  if (!dir) {
+    console.error('Failed to locate publishable Electron application'.red);
+    if (global._resolveError) global._resolveError();
+    process.exit(1);
+  }
+
+  const artifacts = makeResults.reduce((accum, arr) => {
+    accum.push(...arr);
+    return accum;
+  }, []);
+
+  const packageJSON = await readPackageJSON(dir);
+
+  const forgeConfig = await getForgeConfig(dir);
+
+  if (!(forgeConfig.github_repository && typeof forgeConfig.github_repository === 'object' &&
+    forgeConfig.github_repository.owner && forgeConfig.github_repository.name)) {
+    console.error('In order to publish you must set the "github_repository.owner" and "github_repository.name" properties in your forge config. See the docs for more info'.red); // eslint-disable-line
+    process.exit(1);
+  }
+
+  const github = new GitHub(program.authToken);
+
+  let release;
+  try {
+    release = (await github.getGitHub().repos.getReleases({
+      owner: forgeConfig.github_repository.owner,
+      repo: forgeConfig.github_repository.name,
+      per_page: 100,
+    })).find(testRelease => testRelease.tag_name === program.tag || `v${packageJSON.version}`);
+  } catch (err) {
+    if (err.code === 404) {
+      // Release does not exist, let's make it
+      release = await github.getGitHub().repos.createRelease({
+        owner: forgeConfig.github_repository.owner,
+        repo: forgeConfig.github_repository.name,
+        tag_name: program.tag || `v${packageJSON.version}`,
+        name: program.tag || `v${packageJSON.version}`,
+        draft: true,
+      });
+    } else {
+      // Unknown error
+      throw err;
+    }
+  }
+
+  let uploaded = 0;
+  const uploadSpinner = ora.ora(`Uploading Artifacts ${uploaded}/${artifacts.length}`).start();
+  const updateSpinner = () => {
+    uploadSpinner.text = `Uploading Artifacts ${uploaded}/${artifacts.length}`;
+  };
+
+  try {
+    await Promise.all(artifacts.map(artifactPath =>
+      new Promise(async (resolve) => {
+        const done = () => {
+          uploaded += 1;
+          updateSpinner();
+          resolve();
+        };
+        if (release.assets.find(asset => asset.name === path.basename(artifactPath))) {
+          return done();
+        }
+        await github.getGitHub().repos.uploadAsset({
+          owner: forgeConfig.github_repository.owner,
+          repo: forgeConfig.github_repository.name,
+          id: release.id,
+          filePath: artifactPath,
+          name: path.basename(artifactPath),
+        });
+        return done();
+      })
+    ));
+  } catch (err) {
+    updateSpinner.fail();
+    throw err;
+  }
+
+  uploadSpinner.succeed();
+};
+
+main();

--- a/src/electron-forge-publish.js
+++ b/src/electron-forge-publish.js
@@ -62,7 +62,7 @@ const main = async () => {
       owner: forgeConfig.github_repository.owner,
       repo: forgeConfig.github_repository.name,
       per_page: 100,
-    })).find(testRelease => testRelease.tag_name === program.tag || `v${packageJSON.version}`);
+    })).find(testRelease => testRelease.tag_name === (program.tag || `v${packageJSON.version}`));
     if (!release) {
       throw { code: 404 }; // eslint-disable-line
     }

--- a/src/electron-forge.js
+++ b/src/electron-forge.js
@@ -25,6 +25,7 @@ checkSystem()
       .command('package', 'Package the current Electron application')
       .command('make', 'Generate distributables for the current Electron application')
       .command('start', 'Start the current Electron application')
+      .command('publish', 'Publish the current Electron application to GitHub')
       .parse(process.argv);
 
     config.reset();

--- a/src/makers/darwin/dmg.js
+++ b/src/makers/darwin/dmg.js
@@ -5,7 +5,7 @@ import pify from 'pify';
 import { ensureFile } from '../../util/ensure-output';
 
 export default async (dir, appName, targetArch, forgeConfig, packageJSON) => { // eslint-disable-line
-  const outPath = path.resolve(dir, '../make', `${path.basename(dir)}.dmg`);
+  const outPath = path.resolve(dir, '../make', `${appName}.dmg`);
   await ensureFile(outPath);
   const dmgConfig = Object.assign({
     overwrite: true,
@@ -15,4 +15,5 @@ export default async (dir, appName, targetArch, forgeConfig, packageJSON) => { /
     out: path.dirname(outPath),
   });
   await pify(electronDMG)(dmgConfig);
+  return [outPath];
 };

--- a/src/makers/generic/zip.js
+++ b/src/makers/generic/zip.js
@@ -36,4 +36,5 @@ export default async (dir, appName, targetArch, forgeConfig, packageJSON) => { /
     default:
       throw new Error('Unrecognized platform');
   }
+  return [zipPath];
 };

--- a/src/makers/linux/deb.js
+++ b/src/makers/linux/deb.js
@@ -27,4 +27,5 @@ export default async (dir, appName, targetArch, forgeConfig, packageJSON) => { /
   const debianConfig = Object.assign({}, forgeConfig.electronInstallerDebian, debianDefaults);
 
   await pify(installer)(debianConfig);
+  return [outPath];
 };

--- a/src/makers/linux/flatpak.js
+++ b/src/makers/linux/flatpak.js
@@ -27,4 +27,5 @@ export default async (dir, appName, targetArch, forgeConfig, packageJSON) => { /
   const flatpakConfig = Object.assign({}, forgeConfig.electronInstallerFlatpak, flatpakDefaults);
 
   await pify(installer)(flatpakConfig);
+  return [outPath];
 };

--- a/src/makers/linux/rpm.js
+++ b/src/makers/linux/rpm.js
@@ -27,4 +27,5 @@ export default async (dir, appName, targetArch, forgeConfig, packageJSON) => { /
   const rpmConfig = Object.assign({}, forgeConfig.electronInstallerRedhat, rpmDefaults);
 
   await pify(installer)(rpmConfig);
+  return [outPath];
 };

--- a/src/makers/linux/rpm.js
+++ b/src/makers/linux/rpm.js
@@ -16,7 +16,7 @@ function rpmArch(nodeArch) {
 
 export default async (dir, appName, targetArch, forgeConfig, packageJSON) => { // eslint-disable-line
   const arch = rpmArch(targetArch);
-  const outPath = path.resolve(dir, '../make', `${packageJSON.name}_${packageJSON.version}_${arch}.rpm`);
+  const outPath = path.resolve(dir, '../make', `${packageJSON.name}-${packageJSON.version}.${arch}.rpm`);
 
   await ensureFile(outPath);
   const rpmDefaults = {

--- a/src/makers/win32/squirrel.js
+++ b/src/makers/win32/squirrel.js
@@ -1,4 +1,5 @@
 import { createWindowsInstaller } from 'electron-winstaller';
+import fs from 'fs-promise';
 import path from 'path';
 
 import { ensureDirectory } from '../../util/ensure-output';
@@ -7,9 +8,26 @@ export default async (dir, appName, targetArch, forgeConfig, packageJSON) => { /
   const outPath = path.resolve(dir, `../make/squirrel.windows/${targetArch}`);
   await ensureDirectory(outPath);
 
-  const winstallerConfig = Object.assign({}, forgeConfig.electronWinstallerConfig, {
+  const winstallerConfig = Object.assign({
+    name: packageJSON.name,
+    noMsi: true,
+  }, forgeConfig.electronWinstallerConfig, {
     appDirectory: dir,
     outputDirectory: outPath,
   });
   await createWindowsInstaller(winstallerConfig);
+  const artifacts = [
+    path.resolve(outPath, 'RELEASES'),
+    path.resolve(outPath, winstallerConfig.setupExe || `${appName}Setup.exe`),
+    path.resolve(outPath, `${winstallerConfig.name}-${packageJSON.version}-full.nupkg`),
+  ];
+  const deltaPath = path.resolve(outPath, `${winstallerConfig.name}-${packageJSON.version}-delta.nupkg`);
+  if (winstallerConfig.remoteReleases || await fs.exists(deltaPath)) {
+    artifacts.push(deltaPath);
+  }
+  const msiPath = path.resolve(outPath, winstallerConfig.setupMsi || `${appName}Setup.msi`);
+  if (!winstallerConfig.noMsi && await fs.exists(msiPath)) {
+    artifacts.push(msiPath);
+  }
+  return artifacts;
 };

--- a/src/publishers/github.js
+++ b/src/publishers/github.js
@@ -1,0 +1,73 @@
+import ora from 'ora';
+import path from 'path';
+import GitHub from '../util/github';
+
+export default async (artifacts, packageJSON, forgeConfig, authToken, tag) => {
+  if (!(forgeConfig.github_repository && typeof forgeConfig.github_repository === 'object' &&
+    forgeConfig.github_repository.owner && forgeConfig.github_repository.name)) {
+    console.error('In order to publish to github you must set the "github_repository.owner" and "github_repository.name" properties in your forge config. See the docs for more info'.red); // eslint-disable-line
+    process.exit(1);
+  }
+
+  const github = new GitHub(authToken);
+
+  let release;
+  try {
+    release = (await github.getGitHub().repos.getReleases({
+      owner: forgeConfig.github_repository.owner,
+      repo: forgeConfig.github_repository.name,
+      per_page: 100,
+    })).find(testRelease => testRelease.tag_name === (tag || `v${packageJSON.version}`));
+    if (!release) {
+      throw { code: 404 }; // eslint-disable-line
+    }
+  } catch (err) {
+    if (err.code === 404) {
+      // Release does not exist, let's make it
+      release = await github.getGitHub().repos.createRelease({
+        owner: forgeConfig.github_repository.owner,
+        repo: forgeConfig.github_repository.name,
+        tag_name: tag || `v${packageJSON.version}`,
+        name: tag || `v${packageJSON.version}`,
+        draft: true,
+      });
+    } else {
+      // Unknown error
+      throw err;
+    }
+  }
+
+  let uploaded = 0;
+  const uploadSpinner = ora.ora(`Uploading Artifacts ${uploaded}/${artifacts.length}`).start();
+  const updateSpinner = () => {
+    uploadSpinner.text = `Uploading Artifacts ${uploaded}/${artifacts.length}`;
+  };
+
+  try {
+    await Promise.all(artifacts.map(artifactPath =>
+      new Promise(async (resolve) => {
+        const done = () => {
+          uploaded += 1;
+          updateSpinner();
+          resolve();
+        };
+        if (release.assets.find(asset => asset.name === path.basename(artifactPath))) {
+          return done();
+        }
+        await github.getGitHub().repos.uploadAsset({
+          owner: forgeConfig.github_repository.owner,
+          repo: forgeConfig.github_repository.name,
+          id: release.id,
+          filePath: artifactPath,
+          name: path.basename(artifactPath),
+        });
+        return done();
+      })
+    ));
+  } catch (err) {
+    updateSpinner.fail();
+    throw err;
+  }
+
+  uploadSpinner.succeed();
+};

--- a/src/util/github.js
+++ b/src/util/github.js
@@ -1,0 +1,27 @@
+import GitHubAPI from 'github';
+
+export default class GitHub {
+  constructor(authToken) {
+    if (authToken) {
+      this.token = authToken;
+    } else if (process.env.GITHUB_TOKEN) {
+      this.token = process.env.GITHUB_TOKEN;
+    }
+  }
+
+  getGitHub() {
+    const github = new GitHubAPI({
+      protocol: 'https',
+      headers: {
+        'user-agent': 'Electron Forge',
+      },
+    });
+    if (this.token) {
+      github.authenticate({
+        type: 'token',
+        token: this.token,
+      });
+    }
+    return github;
+  }
+}

--- a/src/util/require-search.js
+++ b/src/util/require-search.js
@@ -1,0 +1,13 @@
+import path from 'path';
+
+export default (relativeTo, paths) => {
+  let result;
+  for (const testPath of paths.concat(paths.map(mapPath => path.resolve(relativeTo, mapPath)))) {
+    try {
+      result = require(testPath);
+      return typeof result === 'object' && result && result.default ? result.default : result;
+    } catch (err) {
+      // Ignore the error
+    }
+  }
+};

--- a/src/util/terminate.js
+++ b/src/util/terminate.js
@@ -6,13 +6,13 @@ const d = debug('electron-forge:lifecycle');
 
 process.on('unhandledRejection', (err) => {
   process.stdout.write('\n\nAn unhandled rejection has occurred inside Forge:\n');
-  console.error(colors.red(err.stack));
+  console.error(colors.red(err.stack || JSON.stringify(err)));
   process.exit(1);
 });
 
 process.on('uncaughtException', (err) => {
   process.stdout.write('\n\nAn unhandled exception has occurred inside Forge:\n');
-  console.error(colors.red(err.stack));
+  console.error(colors.red(err.stack || JSON.stringify(err)));
   process.exit(1);
 });
 

--- a/test/util_spec.js
+++ b/test/util_spec.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import path from 'path';
 
+import requireSearch from '../src/util/require-search';
 import resolveDir from '../src/util/resolve-dir';
 import findConfig from '../src/util/forge-config';
 
@@ -46,5 +47,17 @@ describe('forge-config', () => {
     const conf = await findConfig(path.resolve(__dirname, 'fixture/dummy_js_conf'));
     expect(conf.magicFn).to.be.a('function');
     expect(conf.magicFn()).to.be.equal('magic result');
+  });
+});
+
+describe.only('require-search', () => {
+  it('should resolve undefined if no file exists', () => {
+    const resolved = requireSearch(__dirname, ['../src/util/wizard-secrets']);
+    expect(resolved).to.equal(undefined);
+  });
+
+  it('should resolve a file if it exists', () => {
+    const resolved = requireSearch(__dirname, ['../src/util/forge-config']);
+    expect(resolved).to.equal(findConfig);
   });
 });

--- a/tmpl/package.json
+++ b/tmpl/package.json
@@ -22,7 +22,11 @@
         "name": ""
       },
       "electronInstallerDebian": {},
-      "electronInstallerRedhat": {}
+      "electronInstallerRedhat": {},
+      "github_repository": {
+        "owner": "",
+        "name": ""
+      }
     }
   }
 }


### PR DESCRIPTION
Adds the `electron-forge publish` command

* Adds a new forge config object `github_repository` so we know where to publish to
* All `makers` must now return an array of artifacts so that `publish` knows what to upload
* It creates a release if one does not already exist

An example of this working can be seen here.  I just want to get all three platforms publishing to GitHub through CI at the same time and then I'm super happy with this.

My playground app thing: https://github.com/MarshallOfSound/electron-forge-demo123/releases

/cc @malept