### PR TITLE
Use babel-preset-env in 'init'

### DIFF
--- a/src/electron-forge-init.js
+++ b/src/electron-forge-init.js
@@ -42,8 +42,8 @@ const main = async () => {
 
   await initDirectory(dir);
   await initGit(dir);
-  await initNPM(dir, program.template ? undefined : program.lintstyle);
   await initStarter(dir, program.template ? undefined : program.lintstyle);
+  await initNPM(dir, program.template ? undefined : program.lintstyle);
   if (!program.template) {
     if (program.lintstyle === 'standard') {
       await initStandardFix(dir);

--- a/src/init/init-npm.js
+++ b/src/init/init-npm.js
@@ -10,7 +10,7 @@ import asyncOra from '../util/ora-handler';
 const d = debug('electron-forge:init:npm');
 
 export const deps = ['electron-compile'];
-export const devDeps = ['babel-preset-stage-0'];
+export const devDeps = ['babel-preset-env', 'babel-preset-react', 'babel-plugin-transform-async-to-generator'];
 export const exactDevDeps = ['electron-prebuilt-compile'];
 export const standardDeps = ['standard'];
 export const airbnDeps = ['eslint', 'eslint-config-airbnb', 'eslint-plugin-import',
@@ -22,6 +22,7 @@ export default async (dir, lintStyle) => {
     packageJSON.productName = packageJSON.name = path.basename(dir).toLowerCase();
     packageJSON.config.forge.electronWinstallerConfig.name = packageJSON.name.replace(/-/g, '_');
     packageJSON.author = await username();
+
     switch (lintStyle) {
       case 'standard':
         packageJSON.scripts.lint = 'standard';
@@ -40,12 +41,15 @@ export default async (dir, lintStyle) => {
   await asyncOra('Installing NPM Dependencies', async () => {
     d('installing dependencies');
     await installDepList(dir, deps);
+
     d('installing devDependencies');
     await installDepList(dir, devDeps, true);
+
     d('installing exact dependencies');
     for (const packageName of exactDevDeps) {
       await installDepList(dir, [packageName], true, true);
     }
+
     switch (lintStyle) {
       case 'standard':
         d('installing standard linting dependencies');
@@ -59,5 +63,18 @@ export default async (dir, lintStyle) => {
         d('not installing linting deps');
         break;
     }
+
+    // NB: For babel-preset-env to work correctly, it needs to know the
+    // actual version of Electron that we installed
+    const content = JSON.parse(await fs.readFile(path.join(dir, '.compilerc'), 'utf8'));
+    const electronPrebuilt = require(
+      path.join(dir, 'node_modules', 'electron-prebuilt-compile', 'package.json'));
+
+    for (const profile of ['development', 'production']) {
+      const envTarget = content.env[profile]['application/javascript'].presets.find(x => x[0] === 'env');
+      envTarget[1].targets.electron = electronPrebuilt.version;
+    }
+
+    await fs.writeFile(path.join(dir, '.compilerc'), JSON.stringify(content, null, 2), 'utf8');
   });
 };

--- a/src/init/init-starter-files.js
+++ b/src/init/init-starter-files.js
@@ -30,7 +30,7 @@ export default async (dir, lintStyle) => {
 
     d('creating directory:', path.resolve(dir, 'src'));
     await fs.mkdirs(path.resolve(dir, 'src'));
-    const rootFiles = ['_gitignore'];
+    const rootFiles = ['_gitignore', '_compilerc'];
     if (lintStyle === 'airbnb') rootFiles.push('_eslintrc');
     const srcFiles = ['index.js', 'index.html'];
 

--- a/tmpl/_compilerc
+++ b/tmpl/_compilerc
@@ -1,0 +1,24 @@
+{
+  "env": {
+    "development": {
+      "application/javascript": {
+        "presets": [
+          ["env", { "targets": { "electron": "1.4.0" } }],
+          "react"
+        ],
+        "plugins": ["transform-async-to-generator"],
+        "sourceMaps": "inline"
+      }
+    },
+    "production": {
+      "application/javascript": {
+        "presets": [
+          ["env", { "targets": { "electron": "1.4.0" } }],
+          "react"
+        ],
+        "plugins": ["transform-async-to-generator"],
+        "sourceMaps": "none"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR switches the default Babel preset to use [babel-preset-env](https://github.com/babel/babel-preset-env) - this preset adjusts based on the current Electron version which Babel plugins to use. This PR also enables async/await and React by default, since these features are super common and don't have any overhead to enable if not in-use.