### PR TITLE
fix(starter): ensure linebreak-style is disabled

### DIFF
--- a/tmpl/_eslintrc
+++ b/tmpl/_eslintrc
@@ -3,6 +3,7 @@
   "rules": {
     "import/extensions": 0,
     "import/no-extraneous-dependencies": 0,
-    "import/no-unresolved": [2, { "ignore": ["electron"] }]
+    "import/no-unresolved": [2, { "ignore": ["electron"] }],
+    "linebreak-style": 0
   }
 }


### PR DESCRIPTION
See https://github.com/airbnb/javascript/pull/1224, https://github.com/sindresorhus/eslint-config-xo/pull/35, and https://github.com/eslint/eslint/pull/7823 for the sad details.

This doesn't completely solve the greater issue, but should at least help a little bit to ensure new Electron projects can be used on Windows