### PR TITLE
feat(publisher): add draft and prerelease options for publishing to github

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ the JS file method mentioned above then you can use functions normally.
 
 | Target Name | Description | Required Config |
 |-------------|-------------|-----------------|
-| github      | Makes a new release for the current version (if required) and uploads the make artifacts as release assets | `process.env.GITHUB_TOKEN` - A personal access token with access to your releases <br />`forge.github_repository.owner` - The owner of the GitHub repository<br />`forge.github_repository.name` - The name of the GitHub repository |
+| github      | Makes a new release for the current version (if required) and uploads the make artifacts as release assets | `process.env.GITHUB_TOKEN` - A personal access token with access to your releases <br />`forge.github_repository.owner` - The owner of the GitHub repository<br />`forge.github_repository.name` - The name of the GitHub repository <br />`forge.github_repository.draft` - Create the release as a draft, defaults to `true` <br />`forge.github_repository.prerelease` - Identify the release as a prerelease, defaults to `false` |
 
 ## Custom `make` and `publish` targets
 

--- a/src/publishers/github.js
+++ b/src/publishers/github.js
@@ -31,7 +31,8 @@ export default async (artifacts, packageJSON, forgeConfig, authToken, tag) => {
           repo: forgeConfig.github_repository.name,
           tag_name: tag || `v${packageJSON.version}`,
           name: tag || `v${packageJSON.version}`,
-          draft: true,
+          draft: forgeConfig.github_repository.draft !== false,
+          prerelease: forgeConfig.github_repository.prerelease === true,
         });
       } else {
         // Unknown error


### PR DESCRIPTION
## Summary
Adds support for two additional options on GitHub's release API, the ability to control whether the release is a pre-release, and also the ability to publish immediately rather than always use the draft option (current behavior).

## Question Answers:
- Are your changes appropriately documented?
  **Yes, I have updated the README**
- Do your changes have sufficient test coverage? 
  **No, but this file does not appear to have existing tests.  My guess is this would be too much overhead based upon needing to either (1) mock out github's api or (2) talk to the actual github api with a real repository.**
- Does the testsuite pass successfully on your local machine? 
  **Yes, I also tested this manually by forking @MarshallOfSound's [demo repository here](https://github.com/stanlemon/electron-forge-demo123/releases)**