### PR TITLE
fix: regression in istanbul-lib-instrument around export const foo = () => {} now addressed

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "devDependencies": {
     "babel-eslint": "^7.0.0",
-    "babel-plugin-istanbul": "3.0.0",
+    "babel-plugin-istanbul": "^3.1.2-candidate.0",
     "babel-plugin-syntax-async-functions": "^6.13.0",
     "babel-plugin-transform-async-to-module-method": "^6.16.0",
     "babel-plugin-transform-runtime": "^6.15.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "generate-changelog": "^1.0.2",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
-    "istanbul-lib-instrument": "^1.4.2",
     "mocha": "^3.2.0",
     "nodemon": "^1.11.0",
     "nyc": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "devDependencies": {
     "babel-eslint": "^7.0.0",
-    "babel-plugin-istanbul": "^3.1.2-candidate.0",
+    "babel-plugin-istanbul": "^3.1.2",
     "babel-plugin-syntax-async-functions": "^6.13.0",
     "babel-plugin-transform-async-to-module-method": "^6.16.0",
     "babel-plugin-transform-runtime": "^6.15.0",
@@ -50,7 +50,7 @@
     "generate-changelog": "^1.0.2",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
-    "istanbul-lib-instrument": "1.3.0",
+    "istanbul-lib-instrument": "^1.4.2",
     "mocha": "^3.2.0",
     "nodemon": "^1.11.0",
     "nyc": "^10.0.0",


### PR DESCRIPTION
The regression discussed [here](https://github.com/istanbuljs/babel-plugin-istanbul/issues/78) should now be addressed.