### PR TITLE
Update electron-windows-store

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "electron-packager": "^8.4.0",
     "electron-rebuild": "^1.5.5",
     "electron-sudo": "malept/electron-sudo#fix-linux-sudo-detection",
-    "electron-windows-store": "^0.6.3",
+    "electron-windows-store": "^0.7.2",
     "electron-winstaller": "^2.5.0",
     "fs-promise": "^1.0.0",
     "github": "^7.2.0",


### PR DESCRIPTION
The new version contains better debugging and logging capabilities, making it way easier for users to understand what's going wrong if things don't work out. The API remains unchanged - one could pass `verbose`, but I don't think that'll be immediately necessary, given that `electron-windows-store` now uses to debug, so that it stops spamming people who don't want verbose output.

cc @paulcbetts @MarshallOfSound 

