### PR TITLE
Install from dmg

### DIFF
--- a/src/api/install.js
+++ b/src/api/install.js
@@ -106,7 +106,7 @@ export default async (providedOptions = {}) => {
   if (possibleAssets.length > 1) {
     if (chooseAsset) {
       targetAsset = await Promise.resolve(chooseAsset(possibleAssets));
-    } else if (!interactive) {
+    } else if (interactive) {
       const choices = [];
       possibleAssets.forEach((asset) => {
         choices.push({ name: asset.name, value: asset.id });

--- a/src/api/publish.js
+++ b/src/api/publish.js
@@ -60,7 +60,7 @@ export default async (providedOptions = {}) => {
       `electron-forge-publisher-${target}`,
     ]);
     if (!publisher) {
-      throw `Could not find a publish target with the name: ${target}`; // eslint-disable-line
+      throw `Could not find a publish target with the name: ${target}`;
     }
   });
 

--- a/src/installers/darwin/dmg.js
+++ b/src/installers/darwin/dmg.js
@@ -1,5 +1,32 @@
-import opn from 'opn';
+import { spawn } from 'child_process';
+import fs from 'fs-promise';
+import path from 'path';
 
-export default async (filePath) => {
-  await opn(filePath, { wait: false });
+import { getMountedImages, mountImage, unmountImage } from '../../util/hdiutil';
+import moveApp from '../../util/move-app';
+
+export default async (filePath, installSpinner) => {
+  const mounts = await getMountedImages();
+  let targetMount = mounts.find(mount => mount.imagePath === filePath);
+
+  if (!targetMount) {
+    targetMount = await mountImage(filePath);
+  }
+
+  try {
+    const volumePath = path.resolve('/Volumes', targetMount.mountPath);
+    const appName = (await fs.readdir(volumePath)).find(file => file.endsWith('.app'));
+    if (!appName) {
+      // eslint-disable-next-line no-throw-literal
+      throw 'Failed to find .app file in DMG';
+    }
+    const appPath = path.resolve(volumePath, appName);
+    const targetApplicationPath = `/Applications/${path.basename(appPath)}`;
+
+    await moveApp(appPath, targetApplicationPath, installSpinner, true);
+
+    spawn('open', ['-R', targetApplicationPath], { detached: true });
+  } finally {
+    await unmountImage(targetMount);
+  }
 };

--- a/src/installers/darwin/dmg.js
+++ b/src/installers/darwin/dmg.js
@@ -17,7 +17,6 @@ export default async (filePath, installSpinner) => {
     const volumePath = path.resolve('/Volumes', targetMount.mountPath);
     const appName = (await fs.readdir(volumePath)).find(file => file.endsWith('.app'));
     if (!appName) {
-      // eslint-disable-next-line no-throw-literal
       throw 'Failed to find .app file in DMG';
     }
     const appPath = path.resolve(volumePath, appName);

--- a/src/installers/darwin/zip.js
+++ b/src/installers/darwin/zip.js
@@ -1,9 +1,7 @@
+import { spawn } from 'child_process';
 import fs from 'fs-promise';
-import inquirer from 'inquirer';
 import path from 'path';
-import pify from 'pify';
-import sudo from 'sudo-prompt';
-import { exec, spawn } from 'child_process';
+import moveApp from '../../util/move-app';
 
 export default async (filePath, installSpinner) => {
   await new Promise((resolve) => {
@@ -14,40 +12,14 @@ export default async (filePath, installSpinner) => {
     child.stderr.on('data', () => {});
     child.on('exit', () => resolve());
   });
-  let writeAccess = true;
-  try {
-    await fs.access('/Applications', fs.W_OK);
-  } catch (err) {
-    writeAccess = false;
-  }
+
   const appPath = (await fs.readdir(path.dirname(filePath))).filter(file => file.endsWith('.app'))
     .map(file => path.resolve(path.dirname(filePath), file))
     .sort((fA, fB) => fs.statSync(fA).ctime.getTime() - fs.statSync(fB).ctime.getTime())[0];
 
   const targetApplicationPath = `/Applications/${path.basename(appPath)}`;
-  if (await fs.exists(targetApplicationPath)) {
-    installSpinner.stop();
-    const { confirm } = await inquirer.createPromptModule()({
-      type: 'confirm',
-      name: 'confirm',
-      message: `The application "${path.basename(targetApplicationPath)}" appears to already exist in /Applications. Do you want to replace it?`,
-    });
-    if (!confirm) {
-      throw 'Installation stopped by user';
-    } else {
-      installSpinner.start();
-      await fs.remove(targetApplicationPath);
-    }
-  }
 
-  const moveCommand = `mv "${appPath}" "${targetApplicationPath}"`;
-  if (writeAccess) {
-    await pify(exec)(moveCommand);
-  } else {
-    await pify(sudo.exec)(moveCommand, {
-      name: 'Electron Forge',
-    });
-  }
+  await moveApp(appPath, targetApplicationPath, installSpinner);
 
   spawn('open', ['-R', targetApplicationPath], { detached: true });
 };

--- a/src/publishers/github.js
+++ b/src/publishers/github.js
@@ -21,7 +21,7 @@ export default async (artifacts, packageJSON, forgeConfig, authToken, tag) => {
         per_page: 100,
       })).find(testRelease => testRelease.tag_name === (tag || `v${packageJSON.version}`));
       if (!release) {
-        throw { code: 404 }; // eslint-disable-line
+        throw { code: 404 };
       }
     } catch (err) {
       if (err.code === 404) {

--- a/src/util/hdiutil.js
+++ b/src/util/hdiutil.js
@@ -1,0 +1,42 @@
+import { spawnPromise } from 'spawn-rx';
+import debug from 'debug';
+
+const d = debug('electron-forge:hdiutil');
+
+export const getMountedImages = async () => {
+  const output = await spawnPromise('hdiutil', ['info']);
+  const mounts = output.split(/====\n/g);
+  mounts.shift();
+
+  const mountObjects = [];
+
+  for (const mount of mounts) {
+    try {
+      const mountPath = /\/Volumes\/(.+)\n/g.exec(mount)[1];
+      const imagePath = /image-path +: +(.+)\n/g.exec(mount)[1];
+      mountObjects.push({ mountPath, imagePath });
+    } catch (err) {
+      // Ignore
+    }
+  }
+
+  d('identified active mounts', mountObjects);
+  return mountObjects;
+};
+
+export const mountImage = async (filePath) => {
+  d('mounting image:', filePath);
+  const output = await spawnPromise('hdiutil', ['attach', '-noautoopen', '-nobrowse', '-noverify', filePath]);
+  const mountPath = /\/Volumes\/(.+)\n/g.exec(output)[1];
+  d('mounted at:', mountPath);
+
+  return {
+    mountPath,
+    iamgePath: filePath,
+  };
+};
+
+export const unmountImage = async (mount) => {
+  d('unmounting current mount:', mount);
+  await spawnPromise('hdiutil', ['unmount', '-force', `/Volumes/${mount.mountPath}`]);
+};

--- a/src/util/move-app.js
+++ b/src/util/move-app.js
@@ -21,7 +21,6 @@ export default async (appPath, targetApplicationPath, spinner, copyInstead = fal
       message: `The application "${path.basename(targetApplicationPath)}" appears to already exist in /Applications. Do you want to replace it?`,
     });
     if (!confirm) {
-      // eslint-disable-next-line no-throw-literal
       throw 'Installation stopped by user';
     } else {
       spinner.start();

--- a/src/util/move-app.js
+++ b/src/util/move-app.js
@@ -1,0 +1,40 @@
+import fs from 'fs-promise';
+import inquirer from 'inquirer';
+import path from 'path';
+import pify from 'pify';
+import sudo from 'sudo-prompt';
+import { exec } from 'child_process';
+
+export default async (appPath, targetApplicationPath, spinner, copyInstead = false) => {
+  let writeAccess = true;
+  try {
+    await fs.access('/Applications', fs.W_OK);
+  } catch (err) {
+    writeAccess = false;
+  }
+
+  if (await fs.exists(targetApplicationPath)) {
+    spinner.stop();
+    const { confirm } = await inquirer.createPromptModule()({
+      type: 'confirm',
+      name: 'confirm',
+      message: `The application "${path.basename(targetApplicationPath)}" appears to already exist in /Applications. Do you want to replace it?`,
+    });
+    if (!confirm) {
+      // eslint-disable-next-line no-throw-literal
+      throw 'Installation stopped by user';
+    } else {
+      spinner.start();
+      await fs.remove(targetApplicationPath);
+    }
+  }
+
+  const moveCommand = `${copyInstead ? 'cp -r' : 'mv'} "${appPath}" "${targetApplicationPath}"`;
+  if (writeAccess) {
+    await pify(exec)(moveCommand);
+  } else {
+    await pify(sudo.exec)(moveCommand, {
+      name: 'Electron Forge',
+    });
+  }
+};


### PR DESCRIPTION
**Have you read the [section in CONTRIBUTING.md about pull requests](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md#filing-pull-requests)?**

Yes

**Are your changes appropriately documented?**

N/A

**Do your changes have sufficient test coverage?**

N/A (install logic not covered at all, big test PR incoming)

**Does the testsuite pass successfully on your local machine?**

N/A

**Summarize your changes:**

When installing a DMG file we now manually (and secretly) mount it, scan the mount point for `.app` files and then run the same logic on that .app file as the ones in ZIP folders.  This allows seamless no-user-interactive installs of apps packaged in ZIP files.

/cc @zeke 