### PR TITLE
Upgrade to Electron Packager 8.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "commander": "^2.9.0",
     "debug": "^2.3.3",
     "electron-installer-dmg": "^0.1.2",
-    "electron-packager": "^8.4.0",
+    "electron-packager": "^8.5.0",
     "electron-rebuild": "^1.5.5",
     "electron-sudo": "malept/electron-sudo#fix-linux-sudo-detection",
     "electron-windows-store": "^0.7.2",

--- a/src/api/package.js
+++ b/src/api/package.js
@@ -92,7 +92,7 @@ export default async (providedOptions = {}) => {
     arch,
     platform,
     out: path.resolve(dir, 'out'),
-    version: packageJSON.devDependencies['electron-prebuilt-compile'],
+    electronVersion: packageJSON.devDependencies['electron-prebuilt-compile'],
   });
   packageOpts.quiet = true;
   if (typeof packageOpts.asar === 'object' && packageOpts.asar.unpack) {

--- a/src/api/package.js
+++ b/src/api/package.js
@@ -95,7 +95,7 @@ export default async (providedOptions = {}) => {
     version: packageJSON.devDependencies['electron-prebuilt-compile'],
   });
   packageOpts.quiet = true;
-  if (typeof packageOpts.asar === 'object' && packageOpts.unpack) {
+  if (typeof packageOpts.asar === 'object' && packageOpts.asar.unpack) {
     packagerSpinner.fail();
     throw new Error('electron-compile does not support asar.unpack yet.  Please use asar.unpackDir');
   }


### PR DESCRIPTION
**Have you read the [section in CONTRIBUTING.md about pull requests](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md#filing-pull-requests)?**

Yes

**Are your changes appropriately documented?**

N/A

**Do your changes have sufficient test coverage?**

Yes

**Does the testsuite pass successfully on your local machine?**

Yes

**Summarize your changes:**

* Fixes a bug with detecting `asar.unpack`
* Upgrades Electron Packager to 8.5.0. Normally an upgrade is not particularly noteworthy, but this release deprecates the `version` option in favor of `electronVersion`, for clarity purposes.