### PR TITLE
refactor(generic): move ora.ora to an ora helper for ease of submodule use

### DIFF
--- a/src/api/package.js
+++ b/src/api/package.js
@@ -5,10 +5,10 @@ import glob from 'glob';
 import path from 'path';
 import pify from 'pify';
 import packager from 'electron-packager';
-import ora from 'ora';
 
 import electronHostArch from '../util/electron-host-arch';
 import getForgeConfig from '../util/forge-config';
+import ora from '../util/ora';
 import packagerCompileHook from '../util/compile-hook';
 import readPackageJSON from '../util/read-package-json';
 import rebuildHook from '../util/rebuild';
@@ -40,7 +40,7 @@ export default async (providedOptions = {}) => {
     platform: process.platform,
   }, providedOptions);
 
-  let prepareSpinner = ora.ora(`Preparing to Package Application for arch: ${(arch === 'all' ? 'ia32' : arch).cyan}`).start();
+  let prepareSpinner = ora(`Preparing to Package Application for arch: ${(arch === 'all' ? 'ia32' : arch).cyan}`).start();
   let prepareCounter = 0;
 
   dir = await resolveDir(dir);
@@ -66,7 +66,7 @@ export default async (providedOptions = {}) => {
       if (packagerSpinner) {
         packagerSpinner.succeed();
         prepareCounter += 1;
-        prepareSpinner = ora.ora(`Preparing to Package Application for arch: ${(prepareCounter === 2 ? 'armv7l' : 'x64').cyan}`).start();
+        prepareSpinner = ora(`Preparing to Package Application for arch: ${(prepareCounter === 2 ? 'armv7l' : 'x64').cyan}`).start();
       }
       await fs.remove(path.resolve(buildPath, 'node_modules/electron-compile/test'));
       const bins = await pify(glob)(path.join(buildPath, '**/.bin/**/*'));
@@ -79,7 +79,7 @@ export default async (providedOptions = {}) => {
       await packagerCompileHook(dir, ...args);
     }, async (buildPath, electronVersion, pPlatform, pArch, done) => {
       await rebuildHook(buildPath, electronVersion, pPlatform, pArch);
-      packagerSpinner = ora.ora('Packaging Application').start();
+      packagerSpinner = ora('Packaging Application').start();
       done();
     }].concat(forgeConfig.electronPackagerConfig.afterCopy ? forgeConfig.electronPackagerConfig.afterCopy.map(item =>
       (typeof item === 'string' ? requireSearch(dir, [item]) : item)

--- a/src/init/init-custom.js
+++ b/src/init/init-custom.js
@@ -2,12 +2,12 @@ import debug from 'debug';
 import fs from 'fs-promise';
 import glob from 'glob';
 import resolvePackage from 'resolve-package';
-import ora from 'ora';
 import path from 'path';
 
 import { copy } from './init-starter-files';
 import asyncOra from '../util/ora-handler';
 import installDepList from '../util/install-dependencies';
+import ora from '../util/ora';
 
 const d = debug('electron-forge:init:custom');
 
@@ -57,6 +57,6 @@ export default async (dir, template, lintStyle) => {
   });
 
   if (typeof templateModule.postCopy === 'function') {
-    await Promise.resolve(templateModule.postCopy(dir, ora.ora, lintStyle));
+    await Promise.resolve(templateModule.postCopy(dir, ora, lintStyle));
   }
 };

--- a/src/util/ora-handler.js
+++ b/src/util/ora-handler.js
@@ -1,5 +1,5 @@
 import colors from 'colors';
-import ora from 'ora';
+import ora from './ora';
 
 class MockOra {
   succeed() { return this; }
@@ -11,7 +11,7 @@ class MockOra {
 const asyncOra = (initalOraValue, asyncFn) => {
   let fnOra = new MockOra();
   if (asyncOra.interactive) {
-    fnOra = ora.ora(initalOraValue).start();
+    fnOra = ora(initalOraValue).start();
   }
   return new Promise((resolve, reject) => {
     asyncFn(fnOra).then(() => {

--- a/src/util/ora.js
+++ b/src/util/ora.js
@@ -1,0 +1,32 @@
+import debug from 'debug';
+import realOra from 'ora';
+
+const d = debug('electron-forge:lifecycle');
+
+const useFakeOra = (process.env.DEBUG && process.env.DEBUG.includes('electron-forge'));
+
+if (useFakeOra) {
+  console.warn('WARNING: DEBUG environment variable detected.  Progress indicators will be sent over electron-forge:lifecycle'.red);
+}
+
+export default useFakeOra ? (name) => {
+  const fake = {
+    start: () => {
+      d('Process Started:', name);
+      return fake;
+    },
+    fail: () => {
+      d(`Process Failed: ${name}`.red);
+      return fake;
+    },
+    succeed: () => {
+      d('Process Succeeded:', name);
+      return fake;
+    },
+    stop: () => {
+      d('Process Stopped:', name);
+      return fake;
+    },
+  };
+  return fake;
+} : realOra;

--- a/src/util/terminate.js
+++ b/src/util/terminate.js
@@ -1,8 +1,4 @@
 import colors from 'colors';
-import debug from 'debug';
-import ora from 'ora';
-
-const d = debug('electron-forge:lifecycle');
 
 process.on('unhandledRejection', (err) => {
   if (err && err.message && err.stack) {
@@ -27,30 +23,3 @@ process.on('uncaughtException', (err) => {
   }
   process.exit(1);
 });
-
-if (process.env.DEBUG && process.env.DEBUG.includes('electron-forge')) {
-  console.warn('WARNING: DEBUG environment variable detected.  Progress indicators will be sent over electron-forge:lifecycle'.red);
-  ora.ora = (name) => {
-    const fake = {
-      start: () => {
-        d('Process Started:', name);
-        return fake;
-      },
-      fail: () => {
-        d(`Process Failed: ${name}`.red);
-        return fake;
-      },
-      succeed: () => {
-        d('Process Succeeded:', name);
-        return fake;
-      },
-      stop: () => {
-        d('Process Stopped:', name);
-        return fake;
-      },
-    };
-    return fake;
-  };
-} else {
-  ora.ora = ora;
-}

--- a/test/slow/rebuild_spec_slow.js
+++ b/test/slow/rebuild_spec_slow.js
@@ -1,14 +1,11 @@
 import fs from 'fs-promise';
 import path from 'path';
 import os from 'os';
-import ora from 'ora';
 import { spawn as yarnOrNPMSpawn, hasYarn } from 'yarn-or-npm';
 
 import { expect } from 'chai';
 
 import rebuild from '../../src/util/rebuild';
-
-ora.ora = ora;
 
 describe('rebuilder', () => {
   const testModulePath = path.resolve(os.tmpdir(), 'electron-forge-rebuild-test');


### PR DESCRIPTION
ISSUES CLOSED: #100

**Have you read the [section in CONTRIBUTING.md about pull requests](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md#filing-pull-requests)?**

Yes

**Are your changes appropriately documented?**

N/A

**Do your changes have sufficient test coverage?**

N/A

**Does the testsuite pass successfully on your local machine?**

Yes

**Summarize your changes:**

Remove the `ora.ora` patch and instead use an ora util