### PR TITLE
fix(maker): detect out path of package step correctly

### DIFF
--- a/src/api/make.js
+++ b/src/api/make.js
@@ -92,7 +92,7 @@ export default async (providedOptions = {}) => {
   }
 
   const packageJSON = await readPackageJSON(dir);
-  const appName = packageJSON.productName || packageJSON.name;
+  const appName = forgeConfig.electronPackagerConfig.name || packageJSON.productName || packageJSON.name;
   const outputs = [];
 
   for (const targetArch of targetArchs) {


### PR DESCRIPTION
Check the 'name' property of electronPackagerConfig to determine the out path

ISSUES CLOSED: #102

**Have you read the [section in CONTRIBUTING.md about pull requests](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md#filing-pull-requests)?**

Yes

**Are your changes appropriately documented?**

N/A

**Do your changes have sufficient test coverage?**

N/A

**Does the testsuite pass successfully on your local machine?**

Yes

**Summarize your changes:**

See above