### PR TITLE
Resolve `start` API usage with a handle to the spawned process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 docs
 .nyc_output
 coverage
+npm-debug.log

--- a/src/api/start.js
+++ b/src/api/start.js
@@ -50,12 +50,17 @@ export default async (providedOptions = {}) => {
       ELECTRON_ENABLE_STACK_DUMPING: true,
     } : {}),
   };
+
+  let spawned;
+
   await asyncOra('Launching Application', async () => {
     /* istanbul ignore if  */
     if (process.platform === 'win32') {
-      spawn(path.resolve(dir, 'node_modules/.bin/electron.cmd'), ['.'].concat(args), spawnOpts);
+      spawned = spawn(path.resolve(dir, 'node_modules/.bin/electron.cmd'), ['.'].concat(args), spawnOpts);
     } else {
-      spawn(path.resolve(dir, 'node_modules/.bin/electron'), ['.'].concat(args), spawnOpts);
+      spawned = spawn(path.resolve(dir, 'node_modules/.bin/electron'), ['.'].concat(args), spawnOpts);
     }
   });
+
+  return spawned;
 };

--- a/test/slow/start_spec_slow.js
+++ b/test/slow/start_spec_slow.js
@@ -1,21 +1,24 @@
-import { expect } from 'chai';
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import proxyquire from 'proxyquire';
 import sinon from 'sinon';
+
+chai.use(chaiAsPromised);
 
 describe('start', () => {
   let start;
   let resolveStub;
-  let spawnSpy;
+  let spawnStub;
 
   beforeEach(() => {
     resolveStub = sinon.stub();
-    spawnSpy = sinon.spy();
+    spawnStub = sinon.stub();
     start = proxyquire.noCallThru().load('../../src/api/start', {
       '../util/resolve-dir': async dir => resolveStub(dir),
       '../util/read-package-json': () => Promise.resolve(require('../fixture/dummy_app/package.json')),
       '../util/rebuild': () => Promise.resolve(),
       child_process: {
-        spawn: spawnSpy,
+        spawn: spawnStub,
       },
     }).default;
   });
@@ -26,10 +29,10 @@ describe('start', () => {
       dir: __dirname,
       interactive: false,
     });
-    expect(spawnSpy.callCount).to.equal(1);
-    expect(spawnSpy.firstCall.args[0]).to.contain('electron');
-    expect(spawnSpy.firstCall.args[2]).to.have.property('cwd', __dirname);
-    expect(spawnSpy.firstCall.args[2].env).to.not.have.property('ELECTRON_ENABLE_LOGGING');
+    expect(spawnStub.callCount).to.equal(1);
+    expect(spawnStub.firstCall.args[0]).to.contain('electron');
+    expect(spawnStub.firstCall.args[2]).to.have.property('cwd', __dirname);
+    expect(spawnStub.firstCall.args[2].env).to.not.have.property('ELECTRON_ENABLE_LOGGING');
   });
 
   it('should enable electron logging if enableLogging=true', async () => {
@@ -39,13 +42,14 @@ describe('start', () => {
       interactive: false,
       enableLogging: true,
     });
-    expect(spawnSpy.callCount).to.equal(1);
-    expect(spawnSpy.firstCall.args[0]).to.contain('electron');
-    expect(spawnSpy.firstCall.args[2].env).to.have.property('ELECTRON_ENABLE_LOGGING', true);
+    expect(spawnStub.callCount).to.equal(1);
+    expect(spawnStub.firstCall.args[0]).to.contain('electron');
+    expect(spawnStub.firstCall.args[2].env).to.have.property('ELECTRON_ENABLE_LOGGING', true);
   });
 
   it('should throw if no dir could be found', async () => {
     resolveStub.returns(null);
+
     await expect(start()).to.eventually.be.rejectedWith(
       'Failed to locate startable Electron application'
     );
@@ -54,13 +58,25 @@ describe('start', () => {
   it('should pass all args through to the spawned Electron instance', async () => {
     const args = ['magic_arg', 123, 'thingy'];
     resolveStub.returnsArg(0);
+    spawnStub.returns(0);
     await start({
       dir: __dirname,
       interactive: false,
       args,
     });
-    expect(spawnSpy.callCount).to.equal(1);
-    expect(spawnSpy.firstCall.args[0]).to.contain('electron');
-    expect(spawnSpy.firstCall.args[1].slice(1)).to.deep.equal(args);
+    expect(spawnStub.callCount).to.equal(1);
+    expect(spawnStub.firstCall.args[0]).to.contain('electron');
+    expect(spawnStub.firstCall.args[1].slice(1)).to.deep.equal(args);
+  });
+
+  it('should resolve with a handle to the spawned instance', async () => {
+    resolveStub.returnsArg(0);
+    spawnStub.returns('child');
+
+    await expect(start({
+      dir: __dirname,
+      interactive: false,
+      enableLogging: true,
+    })).to.eventually.equal('child');
   });
 });


### PR DESCRIPTION
**Have you read the [section in CONTRIBUTING.md about pull requests](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md#filing-pull-requests)?** Yes



**Are your changes appropriately documented?** Yes



**Do your changes have sufficient test coverage?** I'd like to add a test to confirm a successful run resolves with the spawned handle in `start_spec_slow.js`, but haven't yet grokked the test setup. Advice very much appreciated if this is blocking :)



**Does the testsuite pass successfully on your local machine?** Yes



**Summarize your changes:** Resolve `start` API usage with a handle to the spawned process


