### PR TITLE
fix(maker): allow most appx default config to be overridden by the user

### DIFF
--- a/src/makers/win32/appx.js
+++ b/src/makers/win32/appx.js
@@ -47,9 +47,7 @@ export default async (dir, appName, targetArch, forgeConfig, packageJSON) => { /
   const outPath = path.resolve(dir, `../make/appx/${targetArch}`);
   await ensureDirectory(outPath);
 
-  const opts = Object.assign({}, forgeConfig.windowsStoreConfig, {
-    inputDirectory: dir,
-    outputDirectory: outPath,
+  const opts = Object.assign({
     publisher: packageJSON.author,
     flatten: false,
     deploy: false,
@@ -59,6 +57,9 @@ export default async (dir, appName, targetArch, forgeConfig, packageJSON) => { /
     packageDescription: packageJSON.description || appName,
     packageExecutable: `app\\${appName}.exe`,
     windowsKit: path.dirname(findSdkTool('makeappx.exe')),
+  }, forgeConfig.windowsStoreConfig, {
+    inputDirectory: dir,
+    outputDirectory: outPath,
   });
 
   if (!opts.devCert) {

--- a/src/makers/win32/squirrel.js
+++ b/src/makers/win32/squirrel.js
@@ -9,8 +9,9 @@ export default async (dir, appName, targetArch, forgeConfig, packageJSON) => { /
   await ensureDirectory(outPath);
 
   const winstallerConfig = Object.assign({
-    name: packageJSON.name,
+    name: appName,
     noMsi: true,
+    exe: `${appName}.exe`,
   }, forgeConfig.electronWinstallerConfig, {
     appDirectory: dir,
     outputDirectory: outPath,

--- a/test/slow/api_spec_slow.js
+++ b/test/slow/api_spec_slow.js
@@ -152,9 +152,14 @@ describe(`electron-forge API (with installer=${installer.substr(12)})`, () => {
       dir = path.resolve(os.tmpdir(), `electron-forge-test-${dirID}/electron-forge-test`);
       dirID += 1;
       await forge.init({ dir });
-      const newPackageJSON = await readPackageJSON(dir);
-      newPackageJSON.config.forge.electronPackagerConfig.asar = false;
-      await fs.writeFile(path.resolve(dir, 'package.json'), JSON.stringify(newPackageJSON, null, 2));
+
+      const packageJSON = await readPackageJSON(dir);
+      packageJSON.name = 'testapp';
+      packageJSON.productName = 'Test App';
+      packageJSON.config.forge.electronPackagerConfig.asar = false;
+      packageJSON.config.forge.windowsStoreConfig.packageName = 'TestApp';
+      packageJSON.author = 'Test Author';
+      await fs.writeFile(path.resolve(dir, 'package.json'), JSON.stringify(packageJSON, null, 2));
     });
 
     it('can package without errors', async () => {

--- a/test/slow/api_spec_slow.js
+++ b/test/slow/api_spec_slow.js
@@ -158,6 +158,7 @@ describe(`electron-forge API (with installer=${installer.substr(12)})`, () => {
       packageJSON.productName = 'Test App';
       packageJSON.config.forge.electronPackagerConfig.asar = false;
       packageJSON.config.forge.windowsStoreConfig.packageName = 'TestApp';
+      packageJSON.homepage = 'http://www.example.com/';
       packageJSON.author = 'Test Author';
       await fs.writeFile(path.resolve(dir, 'package.json'), JSON.stringify(packageJSON, null, 2));
     });

--- a/test/slow/api_spec_slow.js
+++ b/test/slow/api_spec_slow.js
@@ -173,14 +173,14 @@ describe(`electron-forge API (with installer=${installer.substr(12)})`, () => {
     });
 
     describe('after package', () => {
-      let resourcesPath = 'electron-forge-test.app/Contents/Resources';
+      let resourcesPath = 'Test App.app/Contents/Resources';
       if (process.platform !== 'darwin') {
         resourcesPath = 'resources';
       }
 
       it('should have deleted the forge config from the packaged app', async () => {
         const cleanPackageJSON = await readPackageJSON(
-          path.resolve(dir, 'out', `electron-forge-test-${process.platform}-${process.arch}`, resourcesPath, 'app')
+          path.resolve(dir, 'out', `Test App-${process.platform}-${process.arch}`, resourcesPath, 'app')
         );
         expect(cleanPackageJSON).to.not.have.deep.property('config.forge');
       });


### PR DESCRIPTION
ISSUES CLOSED: #119

**Have you read the [section in CONTRIBUTING.md about pull requests](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md#filing-pull-requests)?**

Yes

**Are your changes appropriately documented?**

Yes (arguably the docs did not match the code)

**Do your changes have sufficient test coverage?**

Yes

**Does the testsuite pass successfully on your local machine?**

Yes

**Summarize your changes:**

Allow users to override most of the default electron-windows-store config set by Forge.

Fixes #119.

@felixrieseberg are there any of the default params aside from `inputDirectory` and `outputDirectory` that we do not want the user to override? FOr instance, perhaps `packageExecutable`?