### PR TITLE
Publish to GitHub docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,18 @@ the JS file method mentioned above then you can use functions normally.
 |-------------|-------------|-----------------|
 | github      | Makes a new release for the current version (if required) and uploads the make artifacts as release assets | `process.env.GITHUB_TOKEN` - A personal access token with access to your releases <br />`forge.github_repository.owner` - The owner of the GitHub repository<br />`forge.github_repository.name` - The name of the GitHub repository <br />`forge.github_repository.draft` - Create the release as a draft, defaults to `true` <br />`forge.github_repository.prerelease` - Identify the release as a prerelease, defaults to `false` |
 
+For example:
+
+```javascript
+{
+  // Assume the GitHub repository is at https://github.com/username/repo
+  "github_repository": {
+    "owner": "username",
+    "name": "repo"
+  }
+}
+```
+
 ## Custom `make` and `publish` targets
 
 You can make your own custom targets for the `make` and `publish` targets.  If you publish them as `electron-forge-publisher-{name}` or `electron-forge-maker-{name}` you can then just specify `{name}` as your make / publish target.  The API for each is documented below.

--- a/tmpl/package.json
+++ b/tmpl/package.json
@@ -26,7 +26,8 @@
       "electronInstallerDebian": {},
       "electronInstallerRedhat": {},
       "github_repository": {
-        "owner": ""
+        "owner": "",
+        "name": ""
       },
       "windowsStoreConfig": {
         "packageName": ""


### PR DESCRIPTION
**Have you read the [section in CONTRIBUTING.md about pull requests](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md#filing-pull-requests)?**

Yes

**Are your changes appropriately documented?**

Um, yes 😄 

**Do your changes have sufficient test coverage?**

N/A

**Does the testsuite pass successfully on your local machine?**

N/A

**Summarize your changes:**

Adds an example for the GitHub publish target, and also adds `github_repository.name` to the default `package.json`. I've seen two questions about this in the Atom #electron room separately, so I figured the docs needed updating 😄 
