### PR TITLE
Fix bugs w/ import scripts

### DIFF
--- a/src/api/import.js
+++ b/src/api/import.js
@@ -101,7 +101,7 @@ export default async (providedOptions = {}) => {
     } else if (buildToolPackages[key]) {
       const explanation = buildToolPackages[key];
       // eslint-disable-next-line max-len
-      const shouldRemoveDependency = await confirmIfInteractive(interactive, `Do you want us to remove the "${key}" dependency in package.json? Electron Forge ${explanation}.`, updateScripts);
+      const shouldRemoveDependency = await confirmIfInteractive(interactive, `Do you want us to remove the "${key}" dependency in package.json? Electron Forge ${explanation}.`);
 
       if (shouldRemoveDependency) {
         delete packageJSON.dependencies[key];
@@ -116,7 +116,7 @@ export default async (providedOptions = {}) => {
   const updatePackageScript = async (scriptName, newValue) => {
     if (packageJSON.scripts[scriptName] !== newValue) {
       // eslint-disable-next-line max-len
-      const shouldUpdate = await confirmIfInteractive(interactive, `Do you want us to update the "${scriptName}" script to instead call the electron-forge task "${newValue}"`);
+      const shouldUpdate = await confirmIfInteractive(interactive, `Do you want us to update the "${scriptName}" script to instead call the electron-forge task "${newValue}"`, updateScripts);
       if (shouldUpdate) {
         packageJSON.scripts[scriptName] = newValue;
       }

--- a/src/api/import.js
+++ b/src/api/import.js
@@ -161,7 +161,10 @@ export default async (providedOptions = {}) => {
     d('deleting old dependencies forcefully');
     await fs.remove(path.resolve(dir, 'node_modules/.bin/electron'));
     await fs.remove(path.resolve(dir, 'node_modules/.bin/electron.cmd'));
-    await fs.remove(path.resolve(dir, 'node_modules', electronName));
+
+    if (electronName) {
+      await fs.remove(path.resolve(dir, 'node_modules', electronName));
+    }
 
     d('installing dependencies');
     await installDepList(dir, deps);

--- a/src/api/import.js
+++ b/src/api/import.js
@@ -5,7 +5,7 @@ import path from 'path';
 import { spawn as yarnOrNPMSpawn, hasYarn } from 'yarn-or-npm';
 
 import initGit from '../init/init-git';
-import { deps, devDeps } from '../init/init-npm';
+import { deps, devDeps, exactDevDeps } from '../init/init-npm';
 
 import asyncOra from '../util/ora-handler';
 import { info, warn } from '../util/messages';
@@ -168,10 +168,18 @@ export default async (providedOptions = {}) => {
 
     d('installing dependencies');
     await installDepList(dir, deps);
+
     d('installing devDependencies');
     await installDepList(dir, devDeps, true);
-    d('installing electron-prebuilt-compile');
-    await installDepList(dir, [`electron-prebuilt-compile@${electronVersion || 'latest'}`], false, true);
+
+    d('installing exactDevDependencies');
+    await installDepList(dir, exactDevDeps.map((dep) => {
+      if (dep === 'electron-prebuild-compile') {
+        return `${dep}@${electronVersion || 'latest'}`;
+      }
+
+      return dep;
+    }), true, true);
   });
 
   packageJSON = await readPackageJSON(dir);


### PR DESCRIPTION
**Have you read the [section in CONTRIBUTING.md about pull requests](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md#filing-pull-requests)?**

Yes

**Are your changes appropriately documented?**

Yes

**Do your changes have sufficient test coverage?**

I believe so?

**Does the testsuite pass successfully on your local machine?**

Yes

**Summarize your changes:**

- Consuming `api#import` w/ an undefined `electronName` was throwing. This change checks for its existence before trying to resolve (& rm) its path
- Consuming `api#import` w/ `{ updateScripts: false }` was preventing deps removal and permitting script updates. This change reverses these behaviours
- Consuming `api#import` would install `electron-compile` & `electron-prebuilt-compile` as deps vs. devDeps. This change installs them as devDeps