### PR TITLE
GitHub template enhancements

### DIFF
--- a/issue_template.md
+++ b/issue_template.md
@@ -1,3 +1,20 @@
+<!--
+Thanks for filing an issue!
+
+If you have a question, consider searching and asking in other Electron community sites,
+so that more people have a chance to help you: https://github.com/electron/electron#community
+
+Specific issues about the templates that are available by default when creating a new
+Electron Forge project should be filed in its GitHub repository:
+https://github.com/electron-userland/electron-forge-templates
+
+Please check off all of the steps as they are completed by replacing [ ] with [x].
+-->
+
+* [ ] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
+* [ ] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
+* [ ] I have searched the issue tracker for an issue that matches the one I want to file, without success.
+
 **Please describe your issue:**
 
 

--- a/issue_template.md
+++ b/issue_template.md
@@ -3,7 +3,7 @@
 
 <!-- For bugs and questions, please answer these questions to the best of your ability. -->
 
-**Console output when you run `electron-forge` with the environment variable `DEBUG=electron-forge:*`. (Instructions on how to do so [here](https://www.npmjs.com/package/debug#usage). Please include the stack trace if one exists.**
+**Console output when you run `electron-forge` with the environment variable `DEBUG=electron-forge:*`. (Instructions on how to do so [here](https://www.npmjs.com/package/debug#usage)). Please include the stack trace if one exists.**
 
 ```
 Put the console output here

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,18 +1,13 @@
-**Have you read the [section in CONTRIBUTING.md about pull requests](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md#filing-pull-requests)?**
+<!--
+Thanks for filing a pull request!
+Please check off all of the steps as they are completed by replacing [ ] with [x].
+-->
 
-
-
-**Are your changes appropriately documented?**
-
-
-
-**Do your changes have sufficient test coverage?**
-
-
-
-**Does the testsuite pass successfully on your local machine?**
-
-
+* [ ] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
+* [ ] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
+* [ ] The changes are appropriately documented (if applicable).
+* [ ] The changes have sufficient test coverage (if applicable).
+* [ ] The testsuite passes successfully on my local machine (if applicable).
 
 **Summarize your changes:**
 


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [X] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [X] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [X] The changes are appropriately documented (if applicable).
* <del>The changes have sufficient test coverage</del> (not applicable).
* <del>The testsuite passes successfully on my local machine</del> (not applicable).

**Summarize your changes:**

* Fixes a formatting typo in the issue template
* Add checkboxes and user-visible preambles to both templates
* The preamble in the issue template encourages template-specific issues to be filed in the templates repo

Similar changes in the Packager issue template hasn't produced any changes in issue reporter behavior, but one can hope :pray: