### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "devDependencies": {
     "babel-eslint": "^7.0.0",
-    "babel-plugin-istanbul": "^3.1.2",
+    "babel-plugin-istanbul": "^4.0.0",
     "babel-plugin-syntax-async-functions": "^6.13.0",
     "babel-plugin-transform-async-to-module-method": "^6.16.0",
     "babel-plugin-transform-runtime": "^6.15.0",
@@ -49,7 +49,7 @@
     "esdoc-importpath-plugin": "^0.1.0",
     "eslint": "^3.7.1",
     "eslint-config-airbnb-base": "^8.0.0",
-    "eslint-plugin-import": "^1.16.0",
+    "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-mocha": "^4.8.0",
     "fetch-mock": "^5.8.1",
     "generate-changelog": "^1.0.2",
@@ -106,13 +106,13 @@
     "electron-forge-template-react-typescript": "^1.0.0",
     "electron-forge-template-vue": "^1.0.0",
     "electron-installer-dmg": "^0.2.0",
-    "electron-packager": "^8.5.0",
+    "electron-packager": "^8.5.2",
     "electron-rebuild": "^1.5.7",
     "electron-sudo": "malept/electron-sudo#fix-linux-sudo-detection",
     "electron-windows-store": "^0.9.3",
     "electron-winstaller": "^2.5.0",
-    "fs-promise": "^1.0.0",
-    "github": "^8.1.1",
+    "fs-promise": "^2.0.0",
+    "github": "^9.0.0",
     "glob": "^7.1.1",
     "inquirer": "^3.0.1 ",
     "lodash.template": "^4.4.0",
@@ -142,7 +142,7 @@
     }
   },
   "optionalDependencies": {
-    "electron-installer-debian": "^0.4.0",
+    "electron-installer-debian": "^0.5.0",
     "electron-installer-flatpak": "^0.4.0",
     "electron-installer-redhat": "^0.3.0"
   },


### PR DESCRIPTION
* [X] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [X] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* <del>The changes are appropriately documented</del> (not applicable).
* [X] The changes have sufficient test coverage (if applicable).
* [X] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

* Upgrade Electron Packager to force users to get the [Docker fix](https://github.com/electron-userland/electron-packager/pull/596)
* Upgrade `electron-installer-debian` to get the [dependencies changes](https://github.com/unindented/electron-installer-debian/pull/53)
* Upgrade `fs-promise` (the breaking change is the same as fs-extra 2.0.0, which we've already upgraded)
* Upgrade `babel-plugin-istanbul` (the breaking change drops Node versions we don't support)
* Upgrade `eslint-plugin-import` (the breaking change deals with defaults - we don't seem to be affected)
* Upgrade `github` (the breaking change is that API calls always return a data object - shouldn't make a difference?)
