### PR TITLE
Feat/make platforms

### DIFF
--- a/src/api/package.js
+++ b/src/api/package.js
@@ -22,7 +22,7 @@ const d = debug('electron-forge:packager');
  * @property {string} [dir=process.cwd()] The path to the app to package
  * @property {boolean} [interactive=false] Whether to use sensible defaults or prompt the user visually
  * @property {string} [arch=process.arch] The target arch
- * @property {string} [platform=process.platform] The target platform.  NOTE: This is limited to be the current platform at the moment
+ * @property {string} [platform=process.platform] The target platform.
  * @property {string} [outDir=`${dir}/out`] The path to the output directory for packaged apps
  */
 

--- a/src/makers/darwin/dmg.js
+++ b/src/makers/darwin/dmg.js
@@ -3,6 +3,9 @@ import path from 'path';
 import pify from 'pify';
 
 import { ensureFile } from '../../util/ensure-output';
+import { checkSupportedPlatforms } from '../../util/check-supported-platforms';
+
+export const supportedPlatforms = checkSupportedPlatforms('electron-installer-dmg');
 
 export default async (dir, appName, targetArch, forgeConfig, packageJSON) => { // eslint-disable-line
   const outPath = path.resolve(dir, '../make', `${appName}.dmg`);

--- a/src/makers/generic/zip.js
+++ b/src/makers/generic/zip.js
@@ -4,6 +4,9 @@ import pify from 'pify';
 import zipFolder from 'zip-folder';
 
 import { ensureFile } from '../../util/ensure-output';
+import { checkSupportedPlatforms } from '../../util/check-supported-platforms';
+
+export const supportedPlatforms = checkSupportedPlatforms('zip-folder');
 
 const zipPromise = (from, to) =>
   new Promise((resolve, reject) => {

--- a/src/makers/linux/deb.js
+++ b/src/makers/linux/deb.js
@@ -14,6 +14,11 @@ function debianArch(nodeArch) {
   }
 }
 
+export const supportedPlatforms = [
+  'darwin',
+  'linux',
+];
+
 export default async (dir, appName, targetArch, forgeConfig, packageJSON) => { // eslint-disable-line
   const arch = debianArch(targetArch);
   const outPath = path.resolve(dir, '../make', `${packageJSON.name}_${packageJSON.version}_${arch}.deb`);

--- a/src/makers/linux/deb.js
+++ b/src/makers/linux/deb.js
@@ -1,8 +1,12 @@
 import installer from 'electron-installer-debian';
+
 import path from 'path';
 import pify from 'pify';
 
 import { ensureFile } from '../../util/ensure-output';
+import { checkSupportedPlatforms } from '../../util/check-supported-platforms';
+
+export const supportedPlatforms = checkSupportedPlatforms('electron-installer-debian');
 
 function debianArch(nodeArch) {
   switch (nodeArch) {
@@ -13,11 +17,6 @@ function debianArch(nodeArch) {
     default: return nodeArch;
   }
 }
-
-export const supportedPlatforms = [
-  'darwin',
-  'linux',
-];
 
 export default async (dir, appName, targetArch, forgeConfig, packageJSON) => { // eslint-disable-line
   const arch = debianArch(targetArch);

--- a/src/makers/linux/flatpak.js
+++ b/src/makers/linux/flatpak.js
@@ -3,6 +3,9 @@ import path from 'path';
 import pify from 'pify';
 
 import { ensureFile } from '../../util/ensure-output';
+import { checkSupportedPlatforms } from '../../util/check-supported-platforms';
+
+export const supportedPlatforms = checkSupportedPlatforms('electron-installer-flatpak');
 
 function flatpakArch(nodeArch) {
   switch (nodeArch) {

--- a/src/makers/linux/rpm.js
+++ b/src/makers/linux/rpm.js
@@ -3,6 +3,9 @@ import path from 'path';
 import pify from 'pify';
 
 import { ensureFile } from '../../util/ensure-output';
+import { checkSupportedPlatforms } from '../../util/check-supported-platforms';
+
+export const supportedPlatforms = checkSupportedPlatforms('electron-installer-redhat');
 
 function rpmArch(nodeArch) {
   switch (nodeArch) {

--- a/src/makers/win32/appx.js
+++ b/src/makers/win32/appx.js
@@ -4,6 +4,9 @@ import path from 'path';
 import { spawnPromise, findActualExecutable } from 'spawn-rx';
 
 import { ensureDirectory } from '../../util/ensure-output';
+import { checkSupportedPlatforms } from '../../util/check-supported-platforms';
+
+export const supportedPlatforms = checkSupportedPlatforms('electron-windows-store');
 
 // NB: This is not a typo, we require AppXs to be built on 64-bit
 // but if we're running in a 32-bit node.js process, we're going to

--- a/src/makers/win32/squirrel.js
+++ b/src/makers/win32/squirrel.js
@@ -3,6 +3,9 @@ import fs from 'fs-promise';
 import path from 'path';
 
 import { ensureDirectory } from '../../util/ensure-output';
+import { checkSupportedPlatforms } from '../../util/check-supported-platforms';
+
+export const supportedPlatforms = checkSupportedPlatforms('electron-winstaller');
 
 export default async (dir, appName, targetArch, forgeConfig, packageJSON) => { // eslint-disable-line
   const outPath = path.resolve(dir, `../make/squirrel.windows/${targetArch}`);

--- a/src/util/check-supported-platforms.js
+++ b/src/util/check-supported-platforms.js
@@ -1,0 +1,5 @@
+export function checkSupportedPlatforms(pkg) {
+  return require(`${pkg}/package.json`).os || [];
+}
+
+export default checkSupportedPlatforms;

--- a/src/util/check-supported-platforms.js
+++ b/src/util/check-supported-platforms.js
@@ -1,5 +1,7 @@
 export function checkSupportedPlatforms(pkg) {
-  return require(`${pkg}/package.json`).os || [];
+  const osList = require(`${pkg}/package.json`).os || [];
+
+  return osList.filter(os => !os.startsWith('!'));
 }
 
 export default checkSupportedPlatforms;

--- a/src/util/require-search.js
+++ b/src/util/require-search.js
@@ -3,20 +3,23 @@ import path from 'path';
 
 const d = debug('electron-forge:require-search');
 
-export default (relativeTo, paths) => {
+export function requireSearchRaw(relativeTo, paths) {
   const testPaths = paths
     .concat(paths.map(mapPath => path.resolve(relativeTo, mapPath)))
     .concat(paths.map(mapPath => path.resolve(relativeTo, 'node_modules', mapPath)));
   d('searching', testPaths, 'relative to', relativeTo);
-  let result;
   for (const testPath of testPaths) {
     try {
       d('testing', testPath);
-      result = require(testPath);
-      return typeof result === 'object' && result && result.default ? result.default : result;
+      return require(testPath);
     } catch (err) {
       // Ignore the error
     }
   }
   d('failed to find a module in', testPaths);
+}
+
+export default (relativeTo, paths) => {
+  const result = requireSearchRaw(relativeTo, paths);
+  return typeof result === 'object' && result && result.default ? result.default : result;
 };

--- a/test/fixture/dummy-maker.js
+++ b/test/fixture/dummy-maker.js
@@ -1,0 +1,5 @@
+export const supportedPlatforms = [];
+
+export default async (dir, appName, targetArch, forgeConfig, packageJSON) => { // eslint-disable-line
+  return 'i will resolve, but i\'m supposed to throw upstream';
+};

--- a/test/slow/api_spec_slow.js
+++ b/test/slow/api_spec_slow.js
@@ -227,7 +227,7 @@ describe(`electron-forge API (with installer=${installer.substr(12)})`, () => {
             await fs.writeFile(path.resolve(dir, 'package.json'), JSON.stringify(packageJSON));
           });
 
-          options.forEach((optionsFetcher) => {
+          for (const optionsFetcher of options) {
             if (shouldPass) {
               it(`successfully makes for config: ${JSON.stringify(optionsFetcher(), 2)}`, async () => {
                 await forge.make(optionsFetcher());
@@ -237,24 +237,28 @@ describe(`electron-forge API (with installer=${installer.substr(12)})`, () => {
                 await expect(forge.make(optionsFetcher())).to.eventually.be.rejected;
               });
             }
-          });
+          }
         });
       };
 
-      [].concat(targets).concat(genericTargets).forEach((target) => {
-        const testOptions = [() => ({ dir, skipPackage: true })];
-        testMakeTarget(target, true, ...testOptions);
-      });
+      const targetOptionFetcher = () => ({ dir, skipPackage: true });
+      for (const target of [].concat(targets).concat(genericTargets)) {
+        testMakeTarget(target, true, targetOptionFetcher);
+      }
 
-      testMakeTarget('zip', true, { dir, skipPackage: true, outDir: `${dir}/foo` });
+      testMakeTarget('zip', true, () => ({ dir, skipPackage: true, outDir: `${dir}/foo` }));
 
       const dummyMakerPath = `${process.cwd()}/test/fixture/dummy-maker`;
-      testMakeTarget('dummy', false, {
-        dir,
-        overrideTargets: [dummyMakerPath],
-        platform: process.platform === 'darwin' ? 'linux' : 'darwin',
-        skipPackage: true,
-      });
+      const dummyOptionFetcher = () => (
+        {
+          dir,
+          overrideTargets: [dummyMakerPath],
+          platform: process.platform === 'darwin' ? 'linux' : 'darwin',
+          skipPackage: true,
+        }
+      );
+
+      testMakeTarget('dummy', false, dummyOptionFetcher);
     });
 
     after(() => fs.remove(dir));


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [ ] The changes have sufficient test coverage (if applicable).

Unsure. Do we want to test for this?

* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

The `make` API used to fail when trying to make for a platform other than `process.platform`. This PR allows downstream `maker`s to declare their support for other platforms by exporting a `supportedPlatforms` array.

This PR should be backwards-compatible with all non-conforming makers, i.e. it will throw an error if the passed `platform` differs from `process.platform`.

_n.b. this PR depends on #129, but should be easy to rebase if that one doesn't land_