### PR TITLE
feat(starter): automatically wipe the ELECTRON_RUN_AS_NODE variable unless specified

### DIFF
--- a/src/api/start.js
+++ b/src/api/start.js
@@ -24,12 +24,13 @@ import resolveDir from '../util/resolve-dir';
  */
 export default async (providedOptions = {}) => {
   // eslint-disable-next-line prefer-const, no-unused-vars
-  let { dir, interactive, enableLogging, appPath, args } = Object.assign({
+  let { dir, interactive, enableLogging, appPath, args, runAsNode } = Object.assign({
     dir: process.cwd(),
     appPath: '.',
     interactive: false,
     enableLogging: false,
     args: [],
+    runAsNode: false,
   }, providedOptions);
   asyncOra.interactive = interactive;
 
@@ -52,6 +53,12 @@ export default async (providedOptions = {}) => {
       ELECTRON_ENABLE_STACK_DUMPING: true,
     } : {}),
   };
+
+  if (runAsNode) {
+    spawnOpts.env.ELECTRON_RUN_AS_NODE = true;
+  } else {
+    delete spawnOpts.env.ELECTRON_RUN_AS_NODE;
+  }
 
   let spawned;
 

--- a/src/electron-forge-start.js
+++ b/src/electron-forge-start.js
@@ -6,12 +6,11 @@ import './util/terminate';
 import { start } from './api';
 
 (async () => {
-  let commandArgs;
+  let commandArgs = process.argv;
   let appArgs;
+
   const tripleDashIndex = process.argv.indexOf('---');
-  if (tripleDashIndex === -1) {
-    commandArgs = process.argv;
-  } else {
+  if (tripleDashIndex !== -1) {
     commandArgs = process.argv.slice(0, tripleDashIndex);
     appArgs = process.argv.slice(tripleDashIndex + 1);
   }
@@ -22,6 +21,7 @@ import { start } from './api';
     .arguments('[cwd]')
     .option('-p, --app-path <path>', "Override the path to the Electron app to launch (defaults to '.')")
     .option('-l, --enable-logging', 'Enable advanced logging.  This will log internal Electron things')
+    .option('-n, --run-as-node', 'Run the Electron app as a Node.JS script')
     .action((cwd) => {
       if (!cwd) return;
       if (path.isAbsolute(cwd) && fs.existsSync(cwd)) {
@@ -43,17 +43,12 @@ import { start } from './api';
   const opts = {
     dir,
     interactive: true,
+    enableLogging: !!program.enableLogging,
+    runAsNode: !!program.runAsNode,
   };
 
-  if (program.appPath) {
-    opts.appPath = program.appPath;
-  }
-  if (program.enableLogging) {
-    opts.enableLogging = program.enableLogging;
-  }
-  if (appArgs) {
-    opts.args = appArgs;
-  }
+  if (program.appPath) opts.appPath = program.appPath;
+  if (appArgs) opts.args = appArgs;
 
   await start(opts);
 })();

--- a/test/fast/electron_forge_start_spec.js
+++ b/test/fast/electron_forge_start_spec.js
@@ -35,6 +35,8 @@ describe('electron-forge start', () => {
     expect(startStub.firstCall.args[0]).to.deep.equal({
       dir: process.cwd(),
       interactive: true,
+      enableLogging: false,
+      runAsNode: false,
     });
   });
 
@@ -44,6 +46,8 @@ describe('electron-forge start', () => {
     expect(startStub.firstCall.args[0]).to.deep.equal({
       dir: path.join(process.cwd(), 'test', 'fixture', 'dummy_app'),
       interactive: true,
+      enableLogging: false,
+      runAsNode: false,
     });
   });
 
@@ -53,6 +57,8 @@ describe('electron-forge start', () => {
     expect(startStub.firstCall.args[0]).to.deep.equal({
       dir: path.join(process.cwd(), 'test', 'fixture', 'dummy_app'),
       interactive: true,
+      enableLogging: false,
+      runAsNode: false,
     });
   });
 
@@ -63,6 +69,8 @@ describe('electron-forge start', () => {
       dir: process.cwd(),
       appPath: path.join('foo', 'electron.js'),
       interactive: true,
+      enableLogging: false,
+      runAsNode: false,
     });
   });
 
@@ -73,6 +81,7 @@ describe('electron-forge start', () => {
       dir: process.cwd(),
       enableLogging: true,
       interactive: true,
+      runAsNode: false,
     });
   });
 
@@ -84,6 +93,18 @@ describe('electron-forge start', () => {
       enableLogging: true,
       interactive: true,
       args: ['-a', 'foo', '-l'],
+      runAsNode: false,
+    });
+  });
+
+  it('should handle run-as-node', async () => {
+    await runCommand(['--run-as-node']);
+    expect(startStub.callCount).to.equal(1);
+    expect(startStub.firstCall.args[0]).to.deep.equal({
+      dir: process.cwd(),
+      enableLogging: false,
+      interactive: true,
+      runAsNode: true,
     });
   });
 });

--- a/test/fast/start_spec.js
+++ b/test/fast/start_spec.js
@@ -68,6 +68,28 @@ describe('start', () => {
     expect(spawnStub.firstCall.args[2].env).to.have.property('ELECTRON_ENABLE_LOGGING', true);
   });
 
+  it('should enable RUN_AS_NODE if runAsNode=true', async () => {
+    resolveStub.returnsArg(0);
+    await start({
+      dir: __dirname,
+      interactive: false,
+      runAsNode: true,
+    });
+    expect(spawnStub.callCount).to.equal(1);
+    expect(spawnStub.firstCall.args[2].env).to.have.property('ELECTRON_RUN_AS_NODE', true);
+  });
+
+  it('should disable RUN_AS_NODE if runAsNode=false', async () => {
+    resolveStub.returnsArg(0);
+    await start({
+      dir: __dirname,
+      interactive: false,
+      runAsNode: false,
+    });
+    expect(spawnStub.callCount).to.equal(1);
+    expect(spawnStub.firstCall.args[2].env).to.not.have.property('ELECTRON_RUN_AS_NODE');
+  });
+
   it('should throw if no dir could be found', async () => {
     resolveStub.returns(null);
 


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

See title 😆 