### PR TITLE
use updated node-github response API for github publisher

### DIFF
--- a/src/publishers/github.js
+++ b/src/publishers/github.js
@@ -18,21 +18,21 @@ export default async (artifacts, packageJSON, forgeConfig, authToken, tag) => {
         owner: forgeConfig.github_repository.owner,
         repo: forgeConfig.github_repository.name,
         per_page: 100,
-      })).find(testRelease => testRelease.tag_name === (tag || `v${packageJSON.version}`));
+      })).data.find(testRelease => testRelease.tag_name === (tag || `v${packageJSON.version}`));
       if (!release) {
         throw { code: 404 };
       }
     } catch (err) {
       if (err.code === 404) {
         // Release does not exist, let's make it
-        release = await github.getGitHub().repos.createRelease({
+        release = (await github.getGitHub().repos.createRelease({
           owner: forgeConfig.github_repository.owner,
           repo: forgeConfig.github_repository.name,
           tag_name: tag || `v${packageJSON.version}`,
           name: tag || `v${packageJSON.version}`,
           draft: forgeConfig.github_repository.draft !== false,
           prerelease: forgeConfig.github_repository.prerelease === true,
-        });
+        })).data;
       } else {
         // Unknown error
         throw err;


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This PR fixes #156. The `node-github` client made a recent change where all responses return a `meta` and `data` field instead of just returning the `data`: https://github.com/mikedeboer/node-github/commit/ceeefb2c478ca4302e1fe60dece10bc40075eaaf

This was causing errors in the github publisher, using the updated API solved the problem. 
