### PR TITLE
Add `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[{*.html,*.js,*.json,*.md,*.yml,*eslintrc}]
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+max_line_length = 160
+trim_trailing_whitespace = true
+
+[*.sh]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
Adds an `.editorconfig` file to the project that should be consistent with the rules being enforced by the `eslint` configuration. This makes it easier for people using editors with [EditorConfig](http://editorconfig.org/) support to follow some of the code conventions defined for this project.

Closes #173