### PR TITLE
Upgrade `electron-installer-redhat` to v0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
   "optionalDependencies": {
     "electron-installer-debian": "^0.5.0",
     "electron-installer-flatpak": "^0.4.0",
-    "electron-installer-redhat": "^0.3.0"
+    "electron-installer-redhat": "^0.4.0"
   },
   "engines": {
     "node": ">= 6.0"


### PR DESCRIPTION
The electron-installer-redhat package was recently updated with some improvements including:

* Better handling of `package.json` `author` string
* Hyphen characters (`-`) in version string now automatiacally converted to dots (`.`) in RPM version field since they are not allowed there


**Summarize your changes:**
Updated `package.json` to use `^0.4.0` instead of `^0.3.0` for the `electron-installer-redhat` package.



* [X] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [X] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [X] The changes are appropriately documented (if applicable).
* [X] The changes have sufficient test coverage (if applicable).
* [X] The testsuite passes successfully on my local machine (if applicable).
