### PR TITLE
feat(starter): provide an executable to start forge in a vscode debugger compatible way

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Debugging your Electron main process through VS Code is ridiculously
 easy with Forge.  Simply add this as a launch config in VSCode and you're
 good to go.
 
-```json
+```js
 {
   "type": "node",
   "request": "launch",
@@ -248,6 +248,7 @@ good to go.
   "runtimeArgs": [
     "foo",
     "bar"
-  ]
+  ],
+  "cwd": "${workspaceRoot}"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -228,3 +228,26 @@ You must export a Function that returns a Promise.  Your function will be called
 * tag - The value of `--tag`
 
 You should use `ora` to indicate your publish progress.
+
+## Debugging your application through VS Code
+
+Debugging your Electron main process through VS Code is ridiculously
+easy with Forge.  Simply add this as a launch config in VSCode and you're
+good to go.
+
+```json
+{
+  "type": "node",
+  "request": "launch",
+  "name": "Electron Main",
+  "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron-forge-vscode-nix",
+  "windows": {
+    "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron-forge-vscode-win.cmd"
+  },
+  // runtimeArgs will be passed directly to your Electron application
+  "runtimeArgs": [
+    "foo",
+    "bar"
+  ]
+}
+```

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "bin": {
     "electron-forge": "dist/electron-forge.js",
     "forge": "dist/electron-forge.js",
-    "electron-forge-vscode-nix": "script/vscode.sh"
+    "electron-forge-vscode-nix": "script/vscode.sh",
+    "electron-forge-vscode-win": "script/vscode.cmd"
   },
   "scripts": {
     "build": "gulp build",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "dist/api/index.js",
   "bin": {
     "electron-forge": "dist/electron-forge.js",
-    "forge": "dist/electron-forge.js"
+    "forge": "dist/electron-forge.js",
+    "electron-forge-vscode-nix": "script/vscode.sh"
   },
   "scripts": {
     "build": "gulp build",

--- a/script/vscode.cmd
+++ b/script/vscode.cmd
@@ -1,0 +1,9 @@
+@echo off
+
+SETLOCAL
+SET FORGE_ARGS=%*
+
+SET FORGE_ARGS=%FORGE_ARGS: =~ ~%
+node "%~dp0/../../electron-forge/dist/electron-forge-start.js" --vscode --- ~%FORGE_ARGS%~
+
+ENDLOCAL

--- a/script/vscode.sh
+++ b/script/vscode.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+ARGS=$@
+ARGS=${ARGS// /\~ \~}
+
+node $DIR/../electron-forge/dist/electron-forge-start --vscode --- \~$ARGS\~

--- a/src/electron-forge-start.js
+++ b/src/electron-forge-start.js
@@ -49,8 +49,8 @@ import { start } from './api';
   };
 
   if (program.vscode && appArgs) {
+    // Args are in the format ~arg~ so we need to strip the "~"
     appArgs = appArgs
-      // Args are in the format ~arg~ so we need to strip the "~"
       .map(arg => arg.substr(1, arg.length - 2))
       .filter(arg => arg.length > 0);
   }

--- a/src/electron-forge-start.js
+++ b/src/electron-forge-start.js
@@ -22,6 +22,7 @@ import { start } from './api';
     .option('-p, --app-path <path>', "Override the path to the Electron app to launch (defaults to '.')")
     .option('-l, --enable-logging', 'Enable advanced logging.  This will log internal Electron things')
     .option('-n, --run-as-node', 'Run the Electron app as a Node.JS script')
+    .option('--vscode', 'Used to enable arg transformation for debugging Electron through VSCode.  Do not use yourself.')
     .action((cwd) => {
       if (!cwd) return;
       if (path.isAbsolute(cwd) && fs.existsSync(cwd)) {
@@ -46,6 +47,13 @@ import { start } from './api';
     enableLogging: !!program.enableLogging,
     runAsNode: !!program.runAsNode,
   };
+
+  if (program.vscode && appArgs) {
+    appArgs = appArgs
+      // Args are in the format ~arg~ so we need to strip the "~"
+      .map(arg => arg.substr(1, arg.length - 2))
+      .filter(arg => arg.length > 0);
+  }
 
   if (program.appPath) opts.appPath = program.appPath;
   if (appArgs) opts.args = appArgs;

--- a/test/fast/start_spec.js
+++ b/test/fast/start_spec.js
@@ -122,4 +122,28 @@ describe('start', () => {
       enableLogging: true,
     })).to.eventually.equal('child');
   });
+
+  describe('cli', () => {
+    let argv;
+    beforeEach(() => {
+      argv = process.argv;
+    });
+
+    it('should remove all "~" from args when in VSCode debug mode', (done) => {
+      process.argv = ['--vscode', '---', '--foo', 'bar', 'this arg exists'];
+      proxyquire.noCallThru().load('../../src/electron-forge-start', {
+        './api': {
+          start: (startOptions) => {
+            expect(startOptions.args).to.deep.equal(['--foo', 'bar', 'this arg exists']);
+            done();
+            return Promise.resolve();
+          },
+        },
+      });
+    });
+
+    afterEach(() => {
+      process.argv = argv;
+    });
+  });
 });


### PR DESCRIPTION
Currently only on Darwin and Linux, win32 implementation to come

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Basically adds a new binary to target with VS Code that mangles the args so we can pass node debug args through node without them making the forge host process enter debugging mode. 😆 
