### PR TITLE
Hooks :tada:

### DIFF
--- a/src/api/package.js
+++ b/src/api/package.js
@@ -8,6 +8,7 @@ import packager from 'electron-packager';
 
 import electronHostArch from '../util/electron-host-arch';
 import getForgeConfig from '../util/forge-config';
+import runHook from '../util/hook';
 import ora from '../util/ora';
 import packagerCompileHook from '../util/compile-hook';
 import readPackageJSON from '../util/read-package-json';
@@ -108,9 +109,14 @@ export default async (providedOptions = {}) => {
     throw new Error('electron-compile does not support asar.unpack yet.  Please use asar.unpackDir');
   }
 
+  await runHook(forgeConfig, 'generateAssets');
+  await runHook(forgeConfig, 'prePackage');
+
   d('packaging with options', packageOpts);
 
   await pify(packager)(packageOpts);
+
+  await runHook(forgeConfig, 'postPackage');
 
   packagerSpinner.succeed();
 };

--- a/src/api/start.js
+++ b/src/api/start.js
@@ -6,6 +6,8 @@ import asyncOra from '../util/ora-handler';
 import readPackageJSON from '../util/read-package-json';
 import rebuild from '../util/rebuild';
 import resolveDir from '../util/resolve-dir';
+import getForgeConfig from '../util/forge-config';
+import runHook from '../util/hook';
 
 /**
  * @typedef {Object} StartOptions
@@ -61,6 +63,9 @@ export default async (providedOptions = {}) => {
   }
 
   let spawned;
+
+  const forgeConfig = await getForgeConfig(dir);
+  await runHook(forgeConfig, 'generateAssets');
 
   await asyncOra('Launching Application', async () => {
     /* istanbul ignore if  */

--- a/src/makers/darwin/dmg.js
+++ b/src/makers/darwin/dmg.js
@@ -10,9 +10,9 @@ export default async (dir, appName, targetArch, forgeConfig, packageJSON) => { /
   await ensureFile(outPath);
   const dmgConfig = Object.assign({
     overwrite: true,
+    name: appName,
   }, configFn(forgeConfig.electronInstallerDMG, targetArch), {
     appPath: path.resolve(dir, `${appName}.app`),
-    name: appName,
     out: path.dirname(outPath),
   });
   await pify(electronDMG)(dmgConfig);

--- a/src/util/hook.js
+++ b/src/util/hook.js
@@ -1,0 +1,13 @@
+import debug from 'debug';
+
+const d = debug('electron-forge:hook');
+
+export default async (forgeConfig, hookName, ...hookArgs) => {
+  const hooks = forgeConfig.hooks || {};
+  if (typeof hooks[hookName] === 'function') {
+    d('calling hook:', hookName, 'with args:', hookArgs);
+    await hooks[hookName](forgeConfig, ...hookArgs);
+  } else {
+    d('could not find hook:', hookName);
+  }
+};

--- a/test/fast/hook_spec.js
+++ b/test/fast/hook_spec.js
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import { stub } from 'sinon';
+
+import runHook from '../../src/util/hook';
+
+describe('runHook', () => {
+  it('should not error when running non existent hooks', async () => {
+    await runHook({}, 'magic');
+  });
+
+  it('should not error when running a hook that is not a function', async () => {
+    await runHook({ hooks: { myHook: 'abc' } }, 'abc');
+  });
+
+  it('should run the hook if it is provided as a function', async () => {
+    const myStub = stub();
+    myStub.returns(Promise.resolve());
+    await runHook({ hooks: { myHook: myStub } }, 'myHook');
+    expect(myStub.callCount).to.equal(1);
+  });
+});

--- a/test/fast/start_spec.js
+++ b/test/fast/start_spec.js
@@ -14,6 +14,7 @@ describe('start', () => {
     resolveStub = sinon.stub();
     spawnStub = sinon.stub();
     start = proxyquire.noCallThru().load('../../src/api/start', {
+      '../util/forge-config': async () => ({}),
       '../util/resolve-dir': async dir => resolveStub(dir),
       '../util/read-package-json': () => Promise.resolve(require('../fixture/dummy_app/package.json')),
       '../util/rebuild': () => Promise.resolve(),


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

This adds super basic hooks in the codebase, they are noops if the hook doesn't exist.  Documentation for these hooks will go up on the site after this PR is merged.

Fixes #197 