### PR TITLE
[BREAKING CHANGE] Ensure all assets outputted by make are versioned

### DIFF
--- a/src/makers/darwin/dmg.js
+++ b/src/makers/darwin/dmg.js
@@ -8,10 +8,10 @@ import configFn from '../../util/config-fn';
 // appdmg, which is darwin-only
 export const isSupportedOnCurrentPlatform = async () => process.platform === 'darwin';
 
-export default async ({ dir, appName, targetArch, forgeConfig }) => {
+export default async ({ dir, appName, targetArch, forgeConfig, packageJSON }) => {
   const electronDMG = require('electron-installer-dmg');
 
-  const outPath = path.resolve(dir, '../make', `${appName}.dmg`);
+  const outPath = path.resolve(dir, '../make', `${appName}-${packageJSON.version}.dmg`);
   await ensureFile(outPath);
   const dmgConfig = Object.assign({
     overwrite: true,

--- a/src/makers/generic/zip.js
+++ b/src/makers/generic/zip.js
@@ -21,10 +21,10 @@ const zipPromise = (from, to) =>
     });
   });
 
-export default async ({ dir, appName, targetPlatform }) => {
+export default async ({ dir, appName, targetPlatform, packageJSON }) => {
   const zipFolder = require('zip-folder');
 
-  const zipPath = path.resolve(dir, '../make', `${path.basename(dir)}.zip`);
+  const zipPath = path.resolve(dir, '../make', `${path.basename(dir)}-${packageJSON.version}.zip`);
   await ensureFile(zipPath);
   switch (targetPlatform) {
     // This case is tested but not on the coverage reporting platform

--- a/src/makers/win32/squirrel.js
+++ b/src/makers/win32/squirrel.js
@@ -17,12 +17,14 @@ export default async ({ dir, appName, targetArch, forgeConfig, packageJSON }) =>
     name: appName,
     noMsi: true,
     exe: `${appName}.exe`,
+    setupExe: `${appName}-${packageJSON.version} Setup.exe`,
   }, configFn(forgeConfig.electronWinstallerConfig, targetArch), {
     appDirectory: dir,
     outputDirectory: outPath,
   });
 
   await createWindowsInstaller(winstallerConfig);
+
   const artifacts = [
     path.resolve(outPath, 'RELEASES'),
     path.resolve(outPath, winstallerConfig.setupExe || `${appName}Setup.exe`),


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This makes all makers include the version in their artifact output, breaking change, should be included the the make platform breaking change bump