### PR TITLE
Electron Release Server Publisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,9 @@ the JS file method mentioned above then you can use functions normally.
 
 | Target Name | Description | Required Config |
 |-------------|-------------|-----------------|
-| github      | Makes a new release for the current version (if required) and uploads the make artifacts as release assets | `process.env.GITHUB_TOKEN` - A personal access token with access to your releases <br />`forge.github_repository.owner` - The owner of the GitHub repository<br />`forge.github_repository.name` - The name of the GitHub repository <br />`forge.github_repository.draft` - Create the release as a draft, defaults to `true` <br />`forge.github_repository.prerelease` - Identify the release as a prerelease, defaults to `false` |
-| Amazon S3   | Uploads your artifacts to the given S3 bucket | `process.env.ELECTRON_FORGE_S3_SECRET_ACCESS_KEY` - Your secret access token for your AWS account _(falls back to the standard `AWS_SECRET_ACCESS_KEY` environment variable)_<br />`forge.s3.accessKey` - Your access key for your AWS account _(falls back to the standard `AWS_ACCESS_KEY_ID` environment variable)_<br />`forge.s3.bucket` - The name of the S3 bucket to upload to<br />`forge.s3.folder` - The folder path to upload to inside your bucket, defaults to your application version<br />`forge.s3.public` - Whether to make the S3 upload public, defaults to `false`
+| GitHub Releases - `github` | Makes a new release for the current version (if required) and uploads the make artifacts as release assets | `process.env.GITHUB_TOKEN` - A personal access token with access to your releases <br />`forge.github_repository.owner` - The owner of the GitHub repository<br />`forge.github_repository.name` - The name of the GitHub repository <br />`forge.github_repository.draft` - Create the release as a draft, defaults to `true` <br />`forge.github_repository.prerelease` - Identify the release as a prerelease, defaults to `false` |
+| Amazon S3 - `s3` | Uploads your artifacts to the given S3 bucket | `process.env.ELECTRON_FORGE_S3_SECRET_ACCESS_KEY` - Your secret access token for your AWS account _(falls back to the standard `AWS_SECRET_ACCESS_KEY` environment variable)_<br />`forge.s3.accessKey` - Your access key for your AWS account _(falls back to the standard `AWS_ACCESS_KEY_ID` environment variable)_<br />`forge.s3.bucket` - The name of the S3 bucket to upload to<br />`forge.s3.folder` - The folder path to upload to inside your bucket, defaults to your application version<br />`forge.s3.public` - Whether to make the S3 upload public, defaults to `false` |
+| [Electron Release Server](https://github.com/ArekSredzki/electron-release-server) - `electron-release-server` |  Makes a new release for the current version and uploads the artifacts to the correct platform/arch in the given version.  If the version already exists no upload will be performed.  The channel is determined from the current version. | `forge.electronReleaseServer.baseUrl` - The base URL of your release server, no trailing slash<br />`forge.electronReleaseServer.username` - The username for the admin panel on your server<br />`forge.electronReleaseServer.password` - The password for the admin panel on your server |
 
 For example:
 
@@ -197,6 +198,15 @@ For example:
     "accessKey": "<AWS_ACCESS_KEY>",
     "bucket": "my_bucket_name",
     "public": true
+  }
+}
+
+// Electron Release Server
+{
+  "electronReleaseServer": {
+    "baseUrl": "https://update.mysite.com",
+    "username": "admin",
+    "password": "no_one_will_guess_this"
   }
 }
 ```
@@ -226,6 +236,8 @@ You must export a Function that returns a Promise.  Your function will be called
 * forgeConfig - An object representing the users forgeConfig
 * authToken - The value of `--auth-token`
 * tag - The value of `--tag`
+* platform - The platform you are publishing for
+* arch - The arch you are publishing for
 
 You should use `ora` to indicate your publish progress.
 

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "electron-packager": "^8.5.2",
     "electron-rebuild": "^1.5.7",
     "electron-sudo": "malept/electron-sudo#fix-linux-sudo-detection",
+    "form-data": "^2.1.4",
     "fs-promise": "^2.0.0",
     "github": "^9.0.0",
     "glob": "^7.1.1",

--- a/src/api/publish.js
+++ b/src/api/publish.js
@@ -81,6 +81,6 @@ export default async (providedOptions = {}) => {
       }
     });
 
-    await publisher(artifacts, packageJSON, forgeConfig, authToken, tag);
+    await publisher(artifacts, packageJSON, forgeConfig, authToken, tag, makeOptions.platform || process.platform, makeOptions.arch || process.arch);
   }
 };

--- a/src/publishers/electron-release-server.js
+++ b/src/publishers/electron-release-server.js
@@ -75,7 +75,7 @@ export default async (artifacts, packageJSON, forgeConfig, authToken, tag, platf
     let uploaded = 0;
     await asyncOra(`Uploading Artifacts ${uploaded}/${artifacts.length}`, async (uploadSpinner) => {
       const updateSpinner = () => {
-        uploadSpinner.text = `Uploading Artifacts ${uploaded}/${artifacts.length}`; // eslint-disable-line
+        uploadSpinner.text = `Uploading Artifacts ${uploaded}/${artifacts.length}`; // eslint-disable-line no-param-reassign
       };
 
       await Promise.all(artifacts.map(artifactPath =>
@@ -101,7 +101,7 @@ export default async (artifacts, packageJSON, forgeConfig, authToken, tag, platf
               body: artifactForm,
               headers: artifactForm.getHeaders(),
             });
-            d('upload successfullfor asset:', artifactPath);
+            d('upload successful for asset:', artifactPath);
             uploaded += 1;
             updateSpinner();
           } catch (err) {

--- a/src/publishers/electron-release-server.js
+++ b/src/publishers/electron-release-server.js
@@ -1,0 +1,116 @@
+import debug from 'debug';
+import fetch from 'node-fetch';
+import FormData from 'form-data';
+import fs from 'fs-promise';
+import path from 'path';
+
+import asyncOra from '../util/ora-handler';
+
+const d = debug('electron-forge:publish:ers');
+
+const ersPlatform = (platform, arch) => {
+  switch (platform) {
+    case 'darwin':
+      return 'osx_64';
+    case 'linux':
+      return arch === 'ia32' ? 'linux_32' : 'linux_64';
+    case 'win32':
+      return arch === 'ia32' ? 'windows_32' : 'windows_64';
+    default:
+      return platform;
+  }
+};
+
+export default async (artifacts, packageJSON, forgeConfig, authToken, tag, platform, arch) => {
+  const ersConfig = forgeConfig.electronReleaseServer;
+  if (!(ersConfig.baseUrl && ersConfig.username && ersConfig.password)) {
+    throw 'In order to publish to ERS you must set the "electronReleaseServer.baseUrl", "electronReleaseServer.username" and "electronReleaseServer.password" properties in your forge config. See the docs for more info'; // eslint-disable-line
+  }
+
+  d('attempting to authenticate to ERS');
+
+  const api = apiPath => `${ersConfig.baseUrl}/${apiPath}`;
+
+  const { token } = await (await fetch(api('api/auth/login'), {
+    method: 'POST',
+    body: JSON.stringify({
+      username: ersConfig.username,
+      password: ersConfig.password,
+    }),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })).json();
+
+  const authFetch = (apiPath, options) => fetch(api(apiPath), Object.assign({}, options || {}, {
+    headers: Object.assign({}, (options || {}).headers, { Authorization: `Bearer ${token}` }),
+  }));
+
+  const versions = await (await authFetch('api/version')).json();
+  const existingVersion = versions.find(version => version.name === packageJSON.version);
+
+  let channel = 'stable';
+  if (packageJSON.version.indexOf('beta') !== -1) {
+    channel = 'beta';
+  }
+  if (packageJSON.version.indexOf('alpha') !== -1) {
+    channel = 'alpha';
+  }
+
+  if (!existingVersion) {
+    await authFetch('api/version', {
+      method: 'POST',
+      body: JSON.stringify({
+        channel: {
+          name: channel,
+        },
+        name: packageJSON.version,
+        notes: '',
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    let uploaded = 0;
+    await asyncOra(`Uploading Artifacts ${uploaded}/${artifacts.length}`, async (uploadSpinner) => {
+      const updateSpinner = () => {
+        uploadSpinner.text = `Uploading Artifacts ${uploaded}/${artifacts.length}`; // eslint-disable-line
+      };
+
+      await Promise.all(artifacts.map(artifactPath =>
+        new Promise(async (resolve, reject) => {
+          if (existingVersion) {
+            const existingAsset = existingVersion.assets.find(asset => asset.name === path.basename(artifactPath));
+            if (existingAsset) {
+              d('asset at path:', artifactPath, 'already exists on server');
+              uploaded += 1;
+              updateSpinner();
+              return;
+            }
+          }
+          try {
+            d('attempting to upload asset:', artifactPath);
+            const artifactForm = new FormData();
+            artifactForm.append('token', token);
+            artifactForm.append('version', packageJSON.version);
+            artifactForm.append('platform', ersPlatform(platform, arch));
+            artifactForm.append('file', fs.createReadStream(artifactPath));
+            await authFetch('api/asset', {
+              method: 'POST',
+              body: artifactForm,
+              headers: artifactForm.getHeaders(),
+            });
+            d('upload successfullfor asset:', artifactPath);
+            uploaded += 1;
+            updateSpinner();
+          } catch (err) {
+            reject(err);
+          }
+        })
+      ));
+    });
+  } else {
+    d('version already exists, not publishing');
+  }
+};

--- a/test/fast/install-dependencies_spec.js
+++ b/test/fast/install-dependencies_spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import proxyquire from 'proxyquire';
 import sinon from 'sinon';
 
-describe('GitHub', () => {
+describe('Install dependencies', () => {
   let install;
   let spawnSpy;
   let hasYarnSpy;

--- a/test/fast/publish_spec.js
+++ b/test/fast/publish_spec.js
@@ -55,6 +55,8 @@ describe('publish', () => {
       await require('../../src/util/forge-config').default(path.resolve(__dirname, '../fixture/dummy_app')),
       'my_token',
       'my_special_tag',
+      process.platform,
+      process.arch,
     ]);
   });
 


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This adds a new publish target for the widely used https://github.com/ArekSredzki/electron-release-server

Creates the version and uploads all assets, only config required is username, password and base URL.  If you don't want to put username/password in your forge config you can set them through environment variables.  See https://electronforge.io/config/extra/secure
