### PR TITLE
[BREAKING] refactor(starter): use double dash instead of triple dash to pass args through

### DIFF
--- a/script/vscode.cmd
+++ b/script/vscode.cmd
@@ -4,6 +4,6 @@ SETLOCAL
 SET FORGE_ARGS=%*
 
 SET FORGE_ARGS=%FORGE_ARGS: =~ ~%
-node "%~dp0/../../electron-forge/dist/electron-forge-start.js" --vscode --- ~%FORGE_ARGS%~
+node "%~dp0/../../electron-forge/dist/electron-forge-start.js" --vscode -- ~%FORGE_ARGS%~
 
 ENDLOCAL

--- a/script/vscode.sh
+++ b/script/vscode.sh
@@ -4,4 +4,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ARGS=$@
 ARGS=${ARGS// /\~ \~}
 
-node $DIR/../electron-forge/dist/electron-forge-start --vscode --- \~$ARGS\~
+node $DIR/../electron-forge/dist/electron-forge-start --vscode -- \~$ARGS\~

--- a/src/electron-forge-start.js
+++ b/src/electron-forge-start.js
@@ -9,10 +9,10 @@ import { start } from './api';
   let commandArgs = process.argv;
   let appArgs;
 
-  const tripleDashIndex = process.argv.indexOf('---');
-  if (tripleDashIndex !== -1) {
-    commandArgs = process.argv.slice(0, tripleDashIndex);
-    appArgs = process.argv.slice(tripleDashIndex + 1);
+  const doubleDashIndex = process.argv.indexOf('--');
+  if (doubleDashIndex !== -1) {
+    commandArgs = process.argv.slice(0, doubleDashIndex);
+    appArgs = process.argv.slice(doubleDashIndex + 1);
   }
 
   let dir = process.cwd();
@@ -34,9 +34,9 @@ import { start } from './api';
     .parse(commandArgs);
 
   program.on('--help', () => {
-    console.log("  Any arguments found after '---' will be passed to the Electron app, e.g.");
+    console.log("  Any arguments found after '--' will be passed to the Electron app, e.g.");
     console.log('');
-    console.log('    $ electron-forge /path/to/project -l --- -d -f foo.txt');
+    console.log('    $ electron-forge /path/to/project -l -- -d -f foo.txt');
     console.log('');
     console.log("  will pass the arguments '-d -f foo.txt' to the Electron app");
   });

--- a/test/fast/electron_forge_start_spec.js
+++ b/test/fast/electron_forge_start_spec.js
@@ -86,7 +86,7 @@ describe('electron-forge start', () => {
   });
 
   it('should handle app args', async () => {
-    await runCommand(['-l', '---', '-a', 'foo', '-l']);
+    await runCommand(['-l', '--', '-a', 'foo', '-l']);
     expect(startStub.callCount).to.equal(1);
     expect(startStub.firstCall.args[0]).to.deep.equal({
       dir: process.cwd(),

--- a/test/fast/start_spec.js
+++ b/test/fast/start_spec.js
@@ -131,7 +131,7 @@ describe('start', () => {
     });
 
     it('should remove all "~" from args when in VSCode debug mode', (done) => {
-      process.argv = ['--vscode', '---', '--foo', 'bar', 'this arg exists'];
+      process.argv = ['--vscode', '--', '--foo', 'bar', 'this arg exists'];
       proxyquire.noCallThru().load('../../src/electron-forge-start', {
         './api': {
           start: (startOptions) => {


### PR DESCRIPTION
BREAKING CHANGE

<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

s/---/--