### PR TITLE
fix(start): exit forge with same status code as Electron if nonzero

### DIFF
--- a/src/api/start.js
+++ b/src/api/start.js
@@ -76,14 +76,5 @@ export default async (providedOptions = {}) => {
     }
   });
 
-  await new Promise((resolve) => {
-    spawned.on('exit', (code) => {
-      if (code !== 0) {
-        process.exit(code);
-      }
-      resolve();
-    });
-  });
-
   return spawned;
 };

--- a/src/api/start.js
+++ b/src/api/start.js
@@ -76,5 +76,14 @@ export default async (providedOptions = {}) => {
     }
   });
 
+  await new Promise((resolve) => {
+    spawned.on('exit', (code) => {
+      if (code !== 0) {
+        process.exit(code);
+      }
+      resolve();
+    });
+  });
+
   return spawned;
 };

--- a/src/electron-forge-start.js
+++ b/src/electron-forge-start.js
@@ -58,5 +58,14 @@ import { start } from './api';
   if (program.appPath) opts.appPath = program.appPath;
   if (appArgs) opts.args = appArgs;
 
-  await start(opts);
+  const spawned = await start(opts);
+
+  await new Promise((resolve) => {
+    spawned.on('exit', (code) => {
+      if (code !== 0) {
+        process.exit(code);
+      }
+      resolve();
+    });
+  });
 })();

--- a/test/fast/electron_forge_start_spec.js
+++ b/test/fast/electron_forge_start_spec.js
@@ -127,7 +127,7 @@ describe('electron-forge start', () => {
       check();
     });
 
-    expect(getExitCode).to.eventually.equal(childExitCode);
+    await expect(getExitCode).to.eventually.equal(childExitCode);
     process.exit = originalExit;
   });
 });

--- a/test/fast/start_spec.js
+++ b/test/fast/start_spec.js
@@ -9,16 +9,10 @@ describe('start', () => {
   let start;
   let resolveStub;
   let spawnStub;
-  let childStub;
-  let childExitCode;
 
   beforeEach(() => {
-    childExitCode = 0;
-    childStub = {
-      on: (event, cb) => cb(childExitCode),
-    };
     resolveStub = sinon.stub();
-    spawnStub = sinon.stub().returns(childStub);
+    spawnStub = sinon.stub();
     start = proxyquire.noCallThru().load('../../src/api/start', {
       '../util/forge-config': async () => ({}),
       '../util/resolve-dir': async dir => resolveStub(dir),
@@ -108,6 +102,7 @@ describe('start', () => {
   it('should pass all args through to the spawned Electron instance', async () => {
     const args = ['magic_arg', 123, 'thingy'];
     resolveStub.returnsArg(0);
+    spawnStub.returns(0);
     await start({
       dir: __dirname,
       interactive: false,
@@ -118,32 +113,15 @@ describe('start', () => {
     expect(spawnStub.firstCall.args[1].slice(1)).to.deep.equal(args);
   });
 
-  it('should exit with the status code of the spawned Electron instance if it is not zero', async () => {
-    resolveStub.returnsArg(0);
-    childExitCode = 1;
-
-    const originalExit = process.exit;
-    process.exit = sinon.stub();
-
-    await start({
-      dir: __dirname,
-      interactive: false,
-      enableLogging: true,
-    });
-
-    expect(process.exit.callCount).to.equal(1);
-    expect(process.exit.firstCall.args[0]).to.equal(childExitCode);
-    process.exit = originalExit;
-  });
-
   it('should resolve with a handle to the spawned instance', async () => {
     resolveStub.returnsArg(0);
+    spawnStub.returns('child');
 
     await expect(start({
       dir: __dirname,
       interactive: false,
       enableLogging: true,
-    })).to.eventually.equal(childStub);
+    })).to.eventually.equal('child');
   });
 
   describe('cli', () => {

--- a/test/fast/start_spec.js
+++ b/test/fast/start_spec.js
@@ -126,8 +126,14 @@ describe('start', () => {
 
   describe('cli', () => {
     let argv;
+    let childExitCode;
+    let childStub;
     beforeEach(() => {
       argv = process.argv;
+      childExitCode = 0;
+      childStub = {
+        on: (event, cb) => cb(childExitCode),
+      };
     });
 
     it('should remove all "~" from args when in VSCode debug mode', (done) => {
@@ -137,7 +143,7 @@ describe('start', () => {
           start: (startOptions) => {
             expect(startOptions.args).to.deep.equal(['--foo', 'bar', 'this arg exists']);
             done();
-            return Promise.resolve();
+            return Promise.resolve(childStub);
           },
         },
       });


### PR DESCRIPTION
* [X] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [X] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [X] The changes are appropriately documented (if applicable).
* [X] The changes have sufficient test coverage (if applicable).
* [X] The testsuite passes successfully on my local machine (if applicable).

I’m working on a project that runs specs when launched with a command-line flag (eg `electron-forge start --- --test`). I like doing it that way because the tests run in exactly the same env as the app, but electron-forge isn’t returning the exit code from `app.exit(1)`.

This PR alters the `start.js` API so that if the Electron child process exits with a non-zero status code, forge exits with the same code (similar to `lint.js`). The existing tests still pass and I've written an additional one for the exit code scenario.