### PR TITLE
feat(packager): default packageManager in config to be the value of yarn-or-npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "electron-forge-template-react": "^1.0.2",
     "electron-forge-template-react-typescript": "^1.0.3",
     "electron-forge-template-vue": "^1.0.2",
-    "electron-packager": "^8.5.2",
+    "electron-packager": "^8.7.0",
     "electron-rebuild": "^1.5.7",
     "electron-sudo": "malept/electron-sudo#fix-linux-sudo-detection",
     "form-data": "^2.1.4",

--- a/src/api/package.js
+++ b/src/api/package.js
@@ -5,6 +5,7 @@ import glob from 'glob';
 import path from 'path';
 import pify from 'pify';
 import packager from 'electron-packager';
+import yarnOrNpm from 'yarn-or-npm';
 
 import electronHostArch from '../util/electron-host-arch';
 import getForgeConfig from '../util/forge-config';
@@ -64,6 +65,7 @@ export default async (providedOptions = {}) => {
   const packageOpts = Object.assign({
     asar: false,
     overwrite: true,
+    packageManager: yarnOrNpm(),
   }, forgeConfig.electronPackagerConfig, {
     afterCopy: [async (buildPath, electronVersion, pPlatform, pArch, done) => {
       if (packagerSpinner) {


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* <del>The changes are appropriately documented</del> (not applicable).
* ? The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

The `packageManager` option is a new feature as of Electron Packager 8.7.0.

I'm wondering if it actually needs to have test coverage.