### PR TITLE
refactor(generic): replace fs-promise with fs-extra

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "electron-rebuild": "^1.5.7",
     "electron-sudo": "malept/electron-sudo#fix-linux-sudo-detection",
     "form-data": "^2.1.4",
-    "fs-promise": "^2.0.0",
+    "fs-extra": "^3.0.0",
     "github": "^9.0.0",
     "glob": "^7.1.1",
     "inquirer": "^3.0.1 ",

--- a/src/api/import.js
+++ b/src/api/import.js
@@ -1,5 +1,5 @@
 import debug from 'debug';
-import fs from 'fs-promise';
+import fs from 'fs-extra';
 import inquirer from 'inquirer';
 import path from 'path';
 import { spawn as yarnOrNPMSpawn, hasYarn } from 'yarn-or-npm';
@@ -44,7 +44,7 @@ export default async (providedOptions = {}) => {
   asyncOra.interactive = interactive;
 
   d(`Attempting to import project in: ${dir}`);
-  if (!await fs.exists(dir) || !await fs.exists(path.resolve(dir, 'package.json'))) {
+  if (!await fs.pathExists(dir) || !await fs.pathExists(path.resolve(dir, 'package.json'))) {
     throw `We couldn't find a project in: ${dir}`;
   }
 
@@ -194,7 +194,7 @@ export default async (providedOptions = {}) => {
   await writeChanges();
 
   await asyncOra('Fixing .gitignore', async () => {
-    if (await fs.exists(path.resolve(dir, '.gitignore'))) {
+    if (await fs.pathExists(path.resolve(dir, '.gitignore'))) {
       const gitignore = await fs.readFile(path.resolve(dir, '.gitignore'));
       if (!gitignore.includes(outDir)) {
         await fs.writeFile(path.resolve(dir, '.gitignore'), `${gitignore}\n${outDir}/`);
@@ -204,7 +204,7 @@ export default async (providedOptions = {}) => {
 
   let babelConfig = packageJSON.babel;
   const babelPath = path.resolve(dir, '.babelrc');
-  if (!babelConfig && await fs.exists(babelPath)) {
+  if (!babelConfig && await fs.pathExists(babelPath)) {
     babelConfig = JSON.parse(await fs.readFile(babelPath, 'utf8'));
   }
 
@@ -212,7 +212,7 @@ export default async (providedOptions = {}) => {
     await asyncOra('Porting original babel config', async () => {
       let compileConfig = {};
       const compilePath = path.resolve(dir, '.compilerc');
-      if (await fs.exists(compilePath)) {
+      if (await fs.pathExists(compilePath)) {
         compileConfig = JSON.parse(await fs.readFile(compilePath, 'utf8'));
       }
 

--- a/src/api/install.js
+++ b/src/api/install.js
@@ -1,7 +1,7 @@
 import 'colors';
 import debug from 'debug';
 import fetch from 'node-fetch';
-import fs from 'fs-promise';
+import fs from 'fs-extra';
 import inquirer from 'inquirer';
 import nugget from 'nugget';
 import os from 'os';
@@ -130,7 +130,7 @@ export default async (providedOptions = {}) => {
   const filename = `${pathSafeRepo}-${latestRelease.tag_name}-${targetAsset.name}`;
 
   const fullFilePath = path.resolve(tmpdir, filename);
-  if (!await fs.exists(fullFilePath) || (await fs.stat(fullFilePath)).size !== targetAsset.size) {
+  if (!await fs.pathExists(fullFilePath) || (await fs.stat(fullFilePath)).size !== targetAsset.size) {
     await fs.mkdirs(tmpdir);
 
     const nuggetOpts = {

--- a/src/api/make.js
+++ b/src/api/make.js
@@ -1,5 +1,5 @@
 import 'colors';
-import fs from 'fs-promise';
+import fs from 'fs-extra';
 import path from 'path';
 
 import asyncOra from '../util/ora-handler';
@@ -136,7 +136,7 @@ export default async (providedOptions = {}) => {
 
   for (const targetArch of targetArchs) {
     const packageDir = path.resolve(outDir, `${appName}-${platform}-${targetArch}`);
-    if (!(await fs.exists(packageDir))) {
+    if (!(await fs.pathExists(packageDir))) {
       throw new Error(`Couldn't find packaged app at: ${packageDir}`);
     }
 

--- a/src/api/package.js
+++ b/src/api/package.js
@@ -1,6 +1,6 @@
 import 'colors';
 import debug from 'debug';
-import fs from 'fs-promise';
+import fs from 'fs-extra';
 import glob from 'glob';
 import path from 'path';
 import pify from 'pify';

--- a/src/electron-forge-make.js
+++ b/src/electron-forge-make.js
@@ -1,4 +1,4 @@
-import fs from 'fs-promise';
+import fs from 'fs-extra';
 import path from 'path';
 import program from 'commander';
 

--- a/src/electron-forge-package.js
+++ b/src/electron-forge-package.js
@@ -1,4 +1,4 @@
-import fs from 'fs-promise';
+import fs from 'fs-extra';
 import path from 'path';
 import program from 'commander';
 

--- a/src/electron-forge-publish.js
+++ b/src/electron-forge-publish.js
@@ -1,4 +1,4 @@
-import fs from 'fs-promise';
+import fs from 'fs-extra';
 import path from 'path';
 import program from 'commander';
 

--- a/src/electron-forge-start.js
+++ b/src/electron-forge-start.js
@@ -1,4 +1,4 @@
-import fs from 'fs-promise';
+import fs from 'fs-extra';
 import path from 'path';
 import program from 'commander';
 

--- a/src/init/init-custom.js
+++ b/src/init/init-custom.js
@@ -1,5 +1,5 @@
 import debug from 'debug';
-import fs from 'fs-promise';
+import fs from 'fs-extra';
 import glob from 'glob';
 import resolvePackage from 'resolve-package';
 import path from 'path';

--- a/src/init/init-directory.js
+++ b/src/init/init-directory.js
@@ -1,5 +1,5 @@
 import debug from 'debug';
-import fs from 'fs-promise';
+import fs from 'fs-extra';
 import logSymbols from 'log-symbols';
 
 import asyncOra from '../util/ora-handler';

--- a/src/init/init-git.js
+++ b/src/init/init-git.js
@@ -1,6 +1,6 @@
 import { exec } from 'child_process';
 import debug from 'debug';
-import fs from 'fs-promise';
+import fs from 'fs-extra';
 import path from 'path';
 
 import asyncOra from '../util/ora-handler';
@@ -10,7 +10,7 @@ const d = debug('electron-forge:init:git');
 export default async (dir) => {
   await asyncOra('Initializing Git Repository', async () => {
     await new Promise(async (resolve, reject) => {
-      if (await fs.exists(path.resolve(dir, '.git'))) {
+      if (await fs.pathExists(path.resolve(dir, '.git'))) {
         d('.git directory already exists, skipping git initialization');
         return resolve();
       }

--- a/src/init/init-npm.js
+++ b/src/init/init-npm.js
@@ -1,5 +1,5 @@
 import debug from 'debug';
-import fs from 'fs-promise';
+import fs from 'fs-extra';
 import path from 'path';
 import username from 'username';
 

--- a/src/init/init-starter-files.js
+++ b/src/init/init-starter-files.js
@@ -1,5 +1,5 @@
 import debug from 'debug';
-import fs from 'fs-promise';
+import fs from 'fs-extra';
 import path from 'path';
 
 import asyncOra from '../util/ora-handler';

--- a/src/installers/darwin/dmg.js
+++ b/src/installers/darwin/dmg.js
@@ -1,5 +1,5 @@
 import { spawn } from 'child_process';
-import fs from 'fs-promise';
+import fs from 'fs-extra';
 import path from 'path';
 
 import { getMountedImages, mountImage, unmountImage } from '../../util/hdiutil';

--- a/src/installers/darwin/zip.js
+++ b/src/installers/darwin/zip.js
@@ -1,5 +1,5 @@
 import { spawn } from 'child_process';
-import fs from 'fs-promise';
+import fs from 'fs-extra';
 import path from 'path';
 import moveApp from '../../util/move-app';
 

--- a/src/makers/win32/squirrel.js
+++ b/src/makers/win32/squirrel.js
@@ -1,4 +1,4 @@
-import fs from 'fs-promise';
+import fs from 'fs-extra';
 import path from 'path';
 
 import { ensureDirectory } from '../../util/ensure-output';
@@ -31,11 +31,11 @@ export default async ({ dir, appName, targetArch, forgeConfig, packageJSON }) =>
     path.resolve(outPath, `${winstallerConfig.name}-${packageJSON.version}-full.nupkg`),
   ];
   const deltaPath = path.resolve(outPath, `${winstallerConfig.name}-${packageJSON.version}-delta.nupkg`);
-  if (winstallerConfig.remoteReleases || await fs.exists(deltaPath)) {
+  if (winstallerConfig.remoteReleases || await fs.pathExists(deltaPath)) {
     artifacts.push(deltaPath);
   }
   const msiPath = path.resolve(outPath, winstallerConfig.setupMsi || `${appName}Setup.msi`);
-  if (!winstallerConfig.noMsi && await fs.exists(msiPath)) {
+  if (!winstallerConfig.noMsi && await fs.pathExists(msiPath)) {
     artifacts.push(msiPath);
   }
   return artifacts;

--- a/src/publishers/electron-release-server.js
+++ b/src/publishers/electron-release-server.js
@@ -1,7 +1,7 @@
 import debug from 'debug';
 import fetch from 'node-fetch';
 import FormData from 'form-data';
-import fs from 'fs-promise';
+import fs from 'fs-extra';
 import path from 'path';
 
 import asyncOra from '../util/ora-handler';

--- a/src/util/compile-hook.js
+++ b/src/util/compile-hook.js
@@ -1,4 +1,4 @@
-import fs from 'fs-promise';
+import fs from 'fs-extra';
 import path from 'path';
 
 import asyncOra from './ora-handler';

--- a/src/util/config.js
+++ b/src/util/config.js
@@ -1,5 +1,5 @@
 import debug from 'debug';
-import fs from 'fs-promise';
+import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
 

--- a/src/util/ensure-output.js
+++ b/src/util/ensure-output.js
@@ -1,10 +1,10 @@
-import fs from 'fs-promise';
+import fs from 'fs-extra';
 import path from 'path';
 
 // This is different from fs-extra's ensureDir because it wipes out the existing directory,
 // if it's found.
 async function ensureDirectory(dir) {
-  if (await fs.exists(dir)) {
+  if (await fs.pathExists(dir)) {
     await fs.remove(dir);
   }
   return fs.mkdirs(dir);
@@ -13,7 +13,7 @@ async function ensureDirectory(dir) {
 // This is different from fs-extra's ensureFile because it wipes out the existing file,
 // if it's found.
 async function ensureFile(file) {
-  if (await fs.exists(file)) {
+  if (await fs.pathExists(file)) {
     await fs.remove(file);
   }
   await fs.mkdirs(path.dirname(file));

--- a/src/util/forge-config.js
+++ b/src/util/forge-config.js
@@ -1,4 +1,4 @@
-import fs from 'fs-promise';
+import fs from 'fs-extra';
 import path from 'path';
 import _template from 'lodash.template';
 import readPackageJSON from './read-package-json';
@@ -30,7 +30,7 @@ const proxify = (object, envPrefix) => {
 export default async (dir) => {
   const packageJSON = await readPackageJSON(dir);
   let forgeConfig = packageJSON.config.forge;
-  if (typeof forgeConfig === 'string' && (await fs.exists(path.resolve(dir, forgeConfig)) || await fs.exists(path.resolve(dir, `${forgeConfig}.js`)))) {
+  if (typeof forgeConfig === 'string' && (await fs.pathExists(path.resolve(dir, forgeConfig)) || await fs.pathExists(path.resolve(dir, `${forgeConfig}.js`)))) {
     try {
       forgeConfig = require(path.resolve(dir, forgeConfig));
     } catch (err) {

--- a/src/util/move-app.js
+++ b/src/util/move-app.js
@@ -1,4 +1,4 @@
-import fs from 'fs-promise';
+import fs from 'fs-extra';
 import inquirer from 'inquirer';
 import path from 'path';
 import pify from 'pify';
@@ -13,7 +13,7 @@ export default async (appPath, targetApplicationPath, spinner, copyInstead = fal
     writeAccess = false;
   }
 
-  if (await fs.exists(targetApplicationPath)) {
+  if (await fs.pathExists(targetApplicationPath)) {
     spinner.stop();
     const { confirm } = await inquirer.createPromptModule()({
       type: 'confirm',

--- a/src/util/read-package-json.js
+++ b/src/util/read-package-json.js
@@ -1,4 +1,4 @@
-import fs from 'fs-promise';
+import fs from 'fs-extra';
 import path from 'path';
 
 export default async (dir) => {

--- a/src/util/resolve-dir.js
+++ b/src/util/resolve-dir.js
@@ -1,5 +1,5 @@
 import debug from 'debug';
-import fs from 'fs-promise';
+import fs from 'fs-extra';
 import path from 'path';
 import readPackageJSON from './read-package-json';
 
@@ -12,7 +12,7 @@ export default async (dir) => {
     prevDir = mDir;
     const testPath = path.resolve(mDir, 'package.json');
     d('searching for project in:', mDir);
-    if (await fs.exists(testPath)) {
+    if (await fs.pathExists(testPath)) {
       const packageJSON = await readPackageJSON(mDir);
 
       if (packageJSON.devDependencies && packageJSON.devDependencies['electron-prebuilt-compile']) {

--- a/test/fast/config_spec.js
+++ b/test/fast/config_spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import fs from 'fs-promise';
+import fs from 'fs-extra';
 
 import config from '../../src/util/config';
 

--- a/test/fast/ensure-output_spec.js
+++ b/test/fast/ensure-output_spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import fs from 'fs-promise';
+import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
 
@@ -16,15 +16,15 @@ describe('ensure-output', () => {
     it('should delete the directory contents if it exists', async () => {
       await fs.mkdirs(path.resolve(tmpPath, 'foo'));
       fs.writeFileSync(path.resolve(tmpPath, 'foo', 'touchedFile'));
-      expect(await fs.exists(path.resolve(tmpPath, 'foo', 'touchedFile'))).to.equal(true);
+      expect(await fs.pathExists(path.resolve(tmpPath, 'foo', 'touchedFile'))).to.equal(true);
       await ensureDirectory(path.resolve(tmpPath, 'foo'));
-      expect(await fs.exists(path.resolve(tmpPath, 'foo', 'touchedFile'))).to.equal(false);
+      expect(await fs.pathExists(path.resolve(tmpPath, 'foo', 'touchedFile'))).to.equal(false);
     });
 
     it('should create the directory if it does not exist', async () => {
-      expect(await fs.exists(path.resolve(tmpPath, 'bar'))).to.equal(false);
+      expect(await fs.pathExists(path.resolve(tmpPath, 'bar'))).to.equal(false);
       await ensureDirectory(path.resolve(tmpPath, 'bar'));
-      expect(await fs.exists(path.resolve(tmpPath, 'bar'))).to.equal(true);
+      expect(await fs.pathExists(path.resolve(tmpPath, 'bar'))).to.equal(true);
     });
   });
 
@@ -32,15 +32,15 @@ describe('ensure-output', () => {
     it('should delete the file if it exists', async () => {
       await fs.mkdirs(path.resolve(tmpPath, 'foo'));
       fs.writeFileSync(path.resolve(tmpPath, 'foo', 'touchedFile'));
-      expect(await fs.exists(path.resolve(tmpPath, 'foo', 'touchedFile'))).to.equal(true);
+      expect(await fs.pathExists(path.resolve(tmpPath, 'foo', 'touchedFile'))).to.equal(true);
       await ensureFile(path.resolve(tmpPath, 'foo'));
-      expect(await fs.exists(path.resolve(tmpPath, 'foo', 'touchedFile'))).to.equal(false);
+      expect(await fs.pathExists(path.resolve(tmpPath, 'foo', 'touchedFile'))).to.equal(false);
     });
 
     it('should create the containing directory if it does not exist', async () => {
-      expect(await fs.exists(path.resolve(tmpPath, 'bar'))).to.equal(false);
+      expect(await fs.pathExists(path.resolve(tmpPath, 'bar'))).to.equal(false);
       await ensureFile(path.resolve(tmpPath, 'bar', 'file'));
-      expect(await fs.exists(path.resolve(tmpPath, 'bar'))).to.equal(true);
+      expect(await fs.pathExists(path.resolve(tmpPath, 'bar'))).to.equal(true);
     });
   });
 

--- a/test/slow/api_spec_slow.js
+++ b/test/slow/api_spec_slow.js
@@ -1,5 +1,5 @@
 import { execSync } from 'child_process';
-import fs from 'fs-promise';
+import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
 
@@ -31,18 +31,18 @@ describe(`electron-forge API (with installer=${installer.substr(12)})`, () => {
       });
 
       it('should create a new folder with a npm module inside', async () => {
-        expect(await fs.exists(dir), 'the target dir should have been created').to.equal(true);
-        expect(await fs.exists(path.resolve(dir, 'package.json')), 'the package.json file should exist').to.equal(true);
+        expect(await fs.pathExists(dir), 'the target dir should have been created').to.equal(true);
+        expect(await fs.pathExists(path.resolve(dir, 'package.json')), 'the package.json file should exist').to.equal(true);
       });
 
       it('should have initialized a git repository', async () => {
-        expect(await fs.exists(path.resolve(dir, '.git')), 'the .git folder should exist').to.equal(true);
+        expect(await fs.pathExists(path.resolve(dir, '.git')), 'the .git folder should exist').to.equal(true);
       });
 
       it('should have installed the initial node_modules', async () => {
-        expect(await fs.exists(path.resolve(dir, 'node_modules')), 'node_modules folder should exist').to.equal(true);
-        expect(await fs.exists(path.resolve(dir, 'node_modules/electron-prebuilt-compile')), 'electron-prebuilt-compile should exist').to.equal(true);
-        expect(await fs.exists(path.resolve(dir, 'node_modules/babel-core')), 'babel-core should exist').to.equal(true);
+        expect(await fs.pathExists(path.resolve(dir, 'node_modules')), 'node_modules folder should exist').to.equal(true);
+        expect(await fs.pathExists(path.resolve(dir, 'node_modules/electron-prebuilt-compile')), 'electron-prebuilt-compile should exist').to.equal(true);
+        expect(await fs.pathExists(path.resolve(dir, 'node_modules/babel-core')), 'babel-core should exist').to.equal(true);
       });
 
       it('should have set the .compilerc electron version to be a float', async () => {
@@ -77,12 +77,12 @@ describe(`electron-forge API (with installer=${installer.substr(12)})`, () => {
     });
 
     it('should create dot files correctly', async () => {
-      expect(await fs.exists(dir), 'the target dir should have been created').to.equal(true);
-      expect(await fs.exists(path.resolve(dir, '.bar')), 'the .bar file should exist').to.equal(true);
+      expect(await fs.pathExists(dir), 'the target dir should have been created').to.equal(true);
+      expect(await fs.pathExists(path.resolve(dir, '.bar')), 'the .bar file should exist').to.equal(true);
     });
 
     it('should create deep files correctly', async () => {
-      expect(await fs.exists(path.resolve(dir, 'src/foo.js')), 'the src/foo.js file should exist').to.equal(true);
+      expect(await fs.pathExists(path.resolve(dir, 'src/foo.js')), 'the src/foo.js file should exist').to.equal(true);
     });
 
     describe('lint', () => {
@@ -171,11 +171,11 @@ describe(`electron-forge API (with installer=${installer.substr(12)})`, () => {
     it('can package to outDir without errors', async () => {
       const outDir = `${dir}/foo`;
 
-      expect(await fs.exists(outDir)).to.equal(false);
+      expect(await fs.pathExists(outDir)).to.equal(false);
 
       await forge.package({ dir, outDir });
 
-      expect(await fs.exists(outDir)).to.equal(true);
+      expect(await fs.pathExists(outDir)).to.equal(true);
     });
 
     it('can make from custom outDir without errors', async () => {

--- a/test/slow/rebuild_spec_slow.js
+++ b/test/slow/rebuild_spec_slow.js
@@ -1,4 +1,4 @@
-import fs from 'fs-promise';
+import fs from 'fs-extra';
 import path from 'path';
 import os from 'os';
 import { spawn as yarnOrNPMSpawn, hasYarn } from 'yarn-or-npm';
@@ -32,27 +32,27 @@ describe('rebuilder', () => {
 
   it('should have rebuilt top level prod dependencies', async () => {
     const forgeMeta = path.resolve(testModulePath, 'node_modules', 'ref', 'build', 'Release', '.forge-meta');
-    expect(await fs.exists(forgeMeta), 'ref build meta should exist').to.equal(true);
+    expect(await fs.pathExists(forgeMeta), 'ref build meta should exist').to.equal(true);
   });
 
   it('should have rebuilt children of top level prod dependencies', async () => {
     const forgeMeta = path.resolve(testModulePath, 'node_modules', 'microtime', 'build', 'Release', '.forge-meta');
-    expect(await fs.exists(forgeMeta), 'microtime build meta should exist').to.equal(true);
+    expect(await fs.pathExists(forgeMeta), 'microtime build meta should exist').to.equal(true);
   });
 
   it('should have rebuilt children of scoped top level prod dependencies', async () => {
     const forgeMeta = path.resolve(testModulePath, 'node_modules', '@newrelic/native-metrics', 'build', 'Release', '.forge-meta');
-    expect(await fs.exists(forgeMeta), '@newrelic/native-metrics build meta should exist').to.equal(true);
+    expect(await fs.pathExists(forgeMeta), '@newrelic/native-metrics build meta should exist').to.equal(true);
   });
 
   it('should have rebuilt top level optional dependencies', async () => {
     const forgeMeta = path.resolve(testModulePath, 'node_modules', 'zipfile', 'build', 'Release', '.forge-meta');
-    expect(await fs.exists(forgeMeta), 'zipfile build meta should exist').to.equal(true);
+    expect(await fs.pathExists(forgeMeta), 'zipfile build meta should exist').to.equal(true);
   });
 
   it('should not have rebuilt top level devDependencies', async () => {
     const forgeMeta = path.resolve(testModulePath, 'node_modules', 'ffi', 'build', 'Release', '.forge-meta');
-    expect(await fs.exists(forgeMeta), 'ffi build meta should not exist').to.equal(false);
+    expect(await fs.pathExists(forgeMeta), 'ffi build meta should not exist').to.equal(false);
   });
 
   after(async () => {


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* ~~The changes are appropriately documented~~ (not applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

As of `fs-extra` 3.0.0, it comes with builtin Promise support, so a wrapper module is no longer necessary.

Also comes with a non-deprecated `fs.exists` method.

This was pretty much a search/replace, so it wouldn't surprise me if I screwed up somewhere.