### PR TITLE
fix(packager): make packager respect the interactive flag and silence its oras

### DIFF
--- a/src/api/package.js
+++ b/src/api/package.js
@@ -9,7 +9,7 @@ import packager from 'electron-packager';
 import electronHostArch from '../util/electron-host-arch';
 import getForgeConfig from '../util/forge-config';
 import runHook from '../util/hook';
-import ora from '../util/ora';
+import realOra, { fakeOra } from '../util/ora';
 import packagerCompileHook from '../util/compile-hook';
 import readPackageJSON from '../util/read-package-json';
 import rebuildHook from '../util/rebuild';
@@ -41,6 +41,8 @@ export default async (providedOptions = {}) => {
     arch: electronHostArch(),
     platform: process.platform,
   }, providedOptions);
+
+  const ora = interactive ? realOra : fakeOra;
 
   const outDir = providedOptions.outDir || path.resolve(dir, 'out');
   let prepareSpinner = ora(`Preparing to Package Application for arch: ${(arch === 'all' ? 'ia32' : arch).cyan}`).start();

--- a/src/util/ora.js
+++ b/src/util/ora.js
@@ -9,7 +9,7 @@ if (useFakeOra) {
   console.warn('WARNING: DEBUG environment variable detected.  Progress indicators will be sent over electron-forge:lifecycle'.red);
 }
 
-export default useFakeOra ? (name) => {
+export const fakeOra = (name) => {
   const fake = {
     start: () => {
       d('Process Started:', name);
@@ -29,4 +29,6 @@ export default useFakeOra ? (name) => {
     },
   };
   return fake;
-} : realOra;
+};
+
+export default useFakeOra ? fakeOra : realOra;


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Packager oras still used to show up because we weren't (and can't) use `asyncOra`, instead we know just toggle between `fakeOra` and `ora` manually 👍 