### PR TITLE
fix(starter): fix double dash arg pass through

### DIFF
--- a/src/electron-forge.js
+++ b/src/electron-forge.js
@@ -8,6 +8,15 @@ import asyncOra from './util/ora-handler';
 import checkSystem from './util/check-system';
 import config from './util/config';
 
+const originalSC = program.executeSubCommand.bind(program);
+program.executeSubCommand = (argv, args, unknown) => {
+  let newArgs = [].concat(args[0]).concat(unknown);
+  if (args.length > 1) {
+    newArgs = args.concat('--').concat(args.slice(1));
+  }
+  return originalSC(argv, newArgs, []);
+};
+
 program
   .version(require('../package.json').version)
   .option('--verbose', 'Enables verbose mode')


### PR DESCRIPTION
ISSUES CLOSED: #215

<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This fixes the `--` not working issue by overriding the `executeSubCommand` function on our commander instance to map any args found (anything after `--`) to be after `--` again when spawning the sub command.