### PR TITLE
refactor(installer): replace electron-sudo with sudo-prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "electron-forge-template-vue": "^1.0.2",
     "electron-packager": "^8.5.2",
     "electron-rebuild": "^1.5.7",
-    "electron-sudo": "malept/electron-sudo#fix-linux-sudo-detection",
     "form-data": "^2.1.4",
     "fs-extra": "^3.0.0",
     "github": "^9.0.0",

--- a/src/util/linux-installer.js
+++ b/src/util/linux-installer.js
@@ -1,5 +1,6 @@
 import { spawnSync } from 'child_process';
-import Sudoer from 'electron-sudo';
+import pify from 'pify';
+import sudoPrompt from 'sudo-prompt';
 
 const which = async (type, prog, promise) => {
   if (spawnSync('which', [prog]).status === 0) {
@@ -10,20 +11,6 @@ const which = async (type, prog, promise) => {
 };
 
 export const sudo = (type, prog, args) =>
-  new Promise((resolve, reject) => {
-    const sudoer = new Sudoer({ name: 'Electron Forge' });
-
-    which(type, prog, sudoer.spawn(`${prog} ${args}`)
-      .then((child) => {
-        child.on('exit', async (code) => {
-          if (code !== 0) {
-            console.error(child.output.stdout.toString('utf8').red);
-            console.error(child.output.stderr.toString('utf8').red);
-            return reject(new Error(`${prog} failed with status code ${code}`));
-          }
-          resolve();
-        });
-      }));
-  });
+  which(type, prog, pify(sudoPrompt.exec)(`${prog} ${args}`, { name: 'Electron Forge' }));
 
 export default which;


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* ~~The changes are appropriately documented~~ (not applicable).
* ~~The changes have sufficient test coverage~~ (not applicable).
* ~~The testsuite passes successfully on my local machine~~ (not applicable).

**Summarize your changes:**

Not worth using a branch of a Node module just for Promise support for one platform.

I manually tested the "sudo succeeds" path and the "sudo fails" path via `electron-forge install MarshallOfSound/electron-forge-demo123` and selecting the Debian package.

Closes #58.