### PR TITLE
chore(tests): remove unnecessary chai-fetch-mock dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "babel-preset-es2015": "^6.16.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
-    "chai-fetch-mock": "^1.0.0",
     "commitizen": "^2.8.6",
     "coveralls": "^2.11.15",
     "cross-env": "^4.0.0",

--- a/test/slow/install_spec_slow.js
+++ b/test/slow/install_spec_slow.js
@@ -1,11 +1,9 @@
 import chai, { expect } from 'chai';
 import fetchMock from 'fetch-mock';
-import chaiFetchMock from 'chai-fetch-mock';
 import chaiAsPromised from 'chai-as-promised';
 import proxyquire from 'proxyquire';
 import sinon from 'sinon';
 
-chai.use(chaiFetchMock);
 chai.use(chaiAsPromised);
 
 describe('install', () => {


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* ~~The changes are appropriately documented~~ (not applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

I was looking at `chai-fetch-mock` because I was wondering what it did (since it's one of two dependencies preventing us from upgrading `chai`), and it doesn't look like we're using any of its features. `fetch-mock` is still required for tests. @MarshallOfSound let me know if we're going to be using any of its features (now or soon) and I'll close this PR.