### PR TITLE
refactor(initializer): use fs.copy and for...of

### DIFF
--- a/src/init/init-starter-files.js
+++ b/src/init/init-starter-files.js
@@ -6,23 +6,10 @@ import asyncOra from '../util/ora-handler';
 
 const d = debug('electron-forge:init:starter-files');
 
-export const copy = (source, target) =>
-  new Promise((resolve, reject) => {
-    d(`copying "${source}" --> "${target}"`);
-    let rd;
-    let wr;
-    const rejectCleanup = (err) => {
-      rd.destroy();
-      wr.end();
-      reject(err);
-    };
-    rd = fs.createReadStream(source);
-    rd.on('error', rejectCleanup);
-    wr = fs.createWriteStream(target);
-    wr.on('error', rejectCleanup);
-    wr.on('finish', resolve);
-    rd.pipe(wr);
-  });
+export const copy = (source, target) => {
+  d(`copying "${source}" --> "${target}"`);
+  fs.copy(source, target);
+};
 
 export default async (dir, lintStyle) => {
   await asyncOra('Copying Starter Files', async () => {
@@ -34,11 +21,11 @@ export default async (dir, lintStyle) => {
     if (lintStyle === 'airbnb') rootFiles.push('_eslintrc');
     const srcFiles = ['index.js', 'index.html'];
 
-    rootFiles.forEach(async (file) => {
+    for (const file of rootFiles) {
       await copy(path.resolve(tmplPath, file), path.resolve(dir, file.replace(/^_/, '.')));
-    });
-    srcFiles.forEach(async (file) => {
+    }
+    for (const file of srcFiles) {
       await copy(path.resolve(tmplPath, file), path.resolve(dir, 'src', file));
-    });
+    }
   });
 };

--- a/src/init/init-starter-files.js
+++ b/src/init/init-starter-files.js
@@ -6,9 +6,9 @@ import asyncOra from '../util/ora-handler';
 
 const d = debug('electron-forge:init:starter-files');
 
-export const copy = (source, target) => {
+export const copy = async (source, target) => {
   d(`copying "${source}" --> "${target}"`);
-  fs.copy(source, target);
+  await fs.copy(source, target);
 };
 
 export default async (dir, lintStyle) => {


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* ~~The changes are appropriately documented~~ (not applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

We use the excellent fs-extra module now :smile:

Also, I try to avoid `forEach` unless there's a good reason to use it. Especially given that Node 6 is required.