### PR TITLE
feat(publisher): adds dryRun and resumeDryRun to the API

### DIFF
--- a/src/api/make.js
+++ b/src/api/make.js
@@ -146,14 +146,21 @@ export default async (providedOptions = {}) => {
       // eslint-disable-next-line no-loop-func
       await asyncOra(`Making for target: ${target.cyan} - On platform: ${platform.cyan} - For arch: ${targetArch.cyan}`, async () => {
         try {
-          outputs.push(await maker({
+          const output = await maker({
             dir: packageDir,
             appName,
             targetPlatform: platform,
             targetArch,
             forgeConfig,
             packageJSON,
-          }));
+          });
+
+          output.platform = platform;
+          output.arch = targetArch;
+          output.packageJSON = packageJSON;
+          output.forgeConfig = forgeConfig;
+
+          outputs.push(output);
         } catch (err) {
           if (err) {
             throw {

--- a/src/api/make.js
+++ b/src/api/make.js
@@ -25,10 +25,18 @@ import packager from './package';
  */
 
 /**
+ * @typedef {Object} MakeResult
+ * @property {Array<string>} artifacts An array of paths to artifacts generated for this make run
+ * @property {Object} packageJSON The state of the package.json file when the make happened
+ * @property {string} platform The platform this make run was for
+ * @property {string} arch The arch this make run was for
+ */
+
+/**
  * Make distributables for an Electron application.
  *
  * @param {MakeOptions} providedOptions - Options for the make method
- * @return {Promise} Will resolve when the make process is complete
+ * @return {Promise<Array<MakeResult>>} Will resolve when the make process is complete
  */
 export default async (providedOptions = {}) => {
   // eslint-disable-next-line prefer-const, no-unused-vars

--- a/src/api/make.js
+++ b/src/api/make.js
@@ -146,7 +146,7 @@ export default async (providedOptions = {}) => {
       // eslint-disable-next-line no-loop-func
       await asyncOra(`Making for target: ${target.cyan} - On platform: ${platform.cyan} - For arch: ${targetArch.cyan}`, async () => {
         try {
-          const output = await maker({
+          const artifacts = await maker({
             dir: packageDir,
             appName,
             targetPlatform: platform,
@@ -155,12 +155,12 @@ export default async (providedOptions = {}) => {
             packageJSON,
           });
 
-          output.platform = platform;
-          output.arch = targetArch;
-          output.packageJSON = packageJSON;
-          output.forgeConfig = forgeConfig;
-
-          outputs.push(output);
+          outputs.push({
+            artifacts,
+            packageJSON,
+            platform,
+            arch: targetArch,
+          });
         } catch (err) {
           if (err) {
             throw {

--- a/src/api/publish.js
+++ b/src/api/publish.js
@@ -23,9 +23,9 @@ const d = debug('electron-forge:publish');
  * @property {Array<string>} [publishTargets=[github]] The publish targets
  * @property {MakeOptions} [makeOptions] Options object to passed through to make()
  * @property {string} [outDir=`${dir}/out`] The path to the directory containing generated distributables
- * @property {boolean} [dryRun=false] Whether or not to generate dry run meta data and not actually publish
- * @property {boolean} [dryRunResume=false] Whether or not to attempt to resume a previously saved dryRun and publish
- * @property {Object} [makeResults=null] Provide results from make so that the publish step doesn't run make itself
+ * @property {boolean} [dryRun=false] Whether to generate dry run meta data but not actually publish
+ * @property {boolean} [dryRunResume=false] Whether or not to attempt to resume a previously saved `dryRun` and publish
+ * @property {MakeResult} [makeResults=null] Provide results from make so that the publish step doesn't run make itself
  */
 
 /**
@@ -72,7 +72,7 @@ const publish = async (providedOptions = {}) => {
         interactive,
         authToken,
         tag,
-        target,
+        publishTargets,
         makeOptions,
         dryRun: false,
         dryRunResume: false,

--- a/src/electron-forge-publish.js
+++ b/src/electron-forge-publish.js
@@ -14,6 +14,8 @@ import { getMakeOptions } from './electron-forge-make';
     .option('--auth-token', 'Authorization token for your publisher target (if required)')
     .option('--tag', 'The tag to publish to on GitHub')
     .option('--target [target[,target...]]', 'The comma-separated deployment targets, defaults to "github"')
+    .option('--dry-run', 'Triggers a publish dry run which saves state and doesn\'t upload anything')
+    .option('--from-dry-run', 'Attempts to publish artifacts from the last saved dry run')
     .allowUnknownOption(true)
     .action((cwd) => {
       if (!cwd) return;
@@ -30,6 +32,8 @@ import { getMakeOptions } from './electron-forge-make';
     interactive: true,
     authToken: program.authToken,
     tag: program.tag,
+    dryRun: program.dryRun,
+    dryRunResume: program.fromDryRun,
   };
   if (program.target) publishOpts.publishTargets = program.target.split(',');
 

--- a/src/publishers/github.js
+++ b/src/publishers/github.js
@@ -12,7 +12,7 @@ export default async (artifacts, packageJSON, forgeConfig, authToken, tag) => {
   const github = new GitHub(authToken, true);
 
   let release;
-  await asyncOra('Searching for target Release', async () => {
+  await asyncOra('Searching for target release', async () => {
     try {
       release = (await github.getGitHub().repos.getReleases({
         owner: forgeConfig.github_repository.owner,

--- a/src/util/publish-state.js
+++ b/src/util/publish-state.js
@@ -1,0 +1,76 @@
+import crypto from 'crypto';
+import fs from 'fs-extra';
+import path from 'path';
+
+const EXTENSION = '.forge.publish';
+
+export default class PublishState {
+  static async loadFromDirectory(directory) {
+    if (!await fs.exists(directory)) {
+      throw new Error(`Attempted to load publish state from a missing directory: ${directory}`);
+    }
+
+    const publishes = [];
+    for (const dirName of await fs.readdir(directory)) {
+      const subDir = path.resolve(directory, dirName);
+      const states = [];
+      if ((await fs.stat(subDir)).isDirectory()) {
+        const filePaths = (await fs.readdir(subDir))
+          .filter(fileName => fileName.endsWith(EXTENSION))
+          .map(fileName => path.resolve(subDir, fileName));
+
+        for (const filePath of filePaths) {
+          const state = new PublishState(filePath);
+          await state.load();
+          states.push(state);
+        }
+      }
+      publishes.push(states);
+    }
+    return publishes;
+  }
+
+  static async saveToDirectory(directory, artifacts) {
+    const id = crypto.createHash('md5').update(JSON.stringify(artifacts)).digest('hex');
+    for (const artifact of artifacts) {
+      const state = new PublishState(path.resolve(directory, id, 'null'), '', false);
+      state.setState({
+        paths: Array.from(artifact),
+        platform: artifact.platform,
+        arch: artifact.arch,
+        packageJSON: artifact.packageJSON,
+        forgeConfig: artifact.forgeConfig,
+      });
+      await state.saveToDisk();
+    }
+  }
+
+  constructor(filePath, hasHash = true) {
+    this.dir = path.dirname(filePath);
+    this.path = filePath;
+    this.hasHash = hasHash;
+  }
+
+  generateHash() {
+    const content = JSON.stringify(this.state || {});
+    return crypto.createHash('md5').update(content).digest('hex');
+  }
+
+  setState(state) {
+    this.state = state;
+  }
+
+  async load() {
+    this.state = await fs.readJson(this.path);
+  }
+
+  async saveToDisk() {
+    if (!this.hasHash) {
+      this.path = path.resolve(this.dir, `${this.generateHash()}${EXTENSION}`);
+      this.hasHash = true;
+    }
+
+    await fs.mkdirs(path.dirname(this.path));
+    await fs.writeJson(this.path, this.state);
+  }
+}

--- a/src/util/publish-state.js
+++ b/src/util/publish-state.js
@@ -34,13 +34,7 @@ export default class PublishState {
     const id = crypto.createHash('md5').update(JSON.stringify(artifacts)).digest('hex');
     for (const artifact of artifacts) {
       const state = new PublishState(path.resolve(directory, id, 'null'), '', false);
-      state.setState({
-        paths: Array.from(artifact),
-        platform: artifact.platform,
-        arch: artifact.arch,
-        packageJSON: artifact.packageJSON,
-        forgeConfig: artifact.forgeConfig,
-      });
+      state.setState(artifact);
       await state.saveToDisk();
     }
   }

--- a/src/util/publish-state.js
+++ b/src/util/publish-state.js
@@ -31,7 +31,7 @@ export default class PublishState {
   }
 
   static async saveToDirectory(directory, artifacts) {
-    const id = crypto.createHash('md5').update(JSON.stringify(artifacts)).digest('hex');
+    const id = crypto.createHash('SHA256').update(JSON.stringify(artifacts)).digest('hex');
     for (const artifact of artifacts) {
       const state = new PublishState(path.resolve(directory, id, 'null'), '', false);
       state.setState(artifact);
@@ -47,7 +47,7 @@ export default class PublishState {
 
   generateHash() {
     const content = JSON.stringify(this.state || {});
-    return crypto.createHash('md5').update(content).digest('hex');
+    return crypto.createHash('SHA256').update(content).digest('hex');
   }
 
   setState(state) {

--- a/test/fast/publish_spec.js
+++ b/test/fast/publish_spec.js
@@ -1,5 +1,7 @@
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
+import fs from 'fs-extra';
+import os from 'os';
 import path from 'path';
 import proxyquire from 'proxyquire';
 import sinon from 'sinon';
@@ -23,6 +25,7 @@ describe('publish', () => {
       './make': async (...args) => makeStub(...args),
       '../util/resolve-dir': async dir => resolveStub(dir),
       '../util/read-package-json': () => Promise.resolve(require('../fixture/dummy_app/package.json')),
+      '../util/forge-config': () => require('../../src/util/forge-config').default(path.resolve(__dirname, '../fixture/dummy_app')),
       '../util/require-search': requireSearchStub,
     }).default;
 
@@ -87,5 +90,144 @@ describe('publish', () => {
     expect(requireSearchStub.getCall(1).args[1][0]).to.equal('../publishers/nowhere.js');
     expect(requireSearchStub.getCall(2).args[1][0]).to.equal('../publishers/black_hole.js');
     expect(requireSearchStub.getCall(3).args[1][0]).to.equal('../publishers/everywhere.js');
+  });
+
+  describe('dry run', () => {
+    let dir;
+
+    const fakeMake = (platform) => {
+      const ret = [
+        [
+          path.resolve(dir, `artifact1-${platform}`),
+          path.resolve(dir, `artifact2-${platform}`),
+        ], [
+          path.resolve(dir, `artifact3-${platform}`),
+        ],
+        [
+          path.resolve(dir, `artifact4-${platform}`),
+        ],
+      ];
+      const state = {
+        platform,
+        arch: 'x64',
+        packageJSON: { state: 0 },
+        forgeConfig: { config: 0 },
+      };
+      Object.assign(ret[0], state);
+      Object.assign(ret[1], state);
+      Object.assign(ret[2], state);
+      return ret;
+    };
+
+    before(async () => {
+      dir = await fs.mkdtemp(path.resolve(os.tmpdir(), 'electron-forge-test-'));
+    });
+
+    describe('when creating a dry run', () => {
+      beforeEach(async () => {
+        makeStub.returns(fakeMake('darwin'));
+        const dryPath = path.resolve(dir, 'out', 'publish-dry-run');
+        await fs.mkdirs(dryPath);
+        await fs.writeFile(path.resolve(dryPath, 'hash.json'), 'test');
+        await publish({
+          dir,
+          interactive: false,
+          target: [],
+          dryRun: true,
+        });
+        expect(await fs.exists(path.resolve(dryPath, 'hash.json'))).to.equal(false, 'previous hashes should be erased');
+        const backupDir = path.resolve(dir, 'out', 'backup');
+        await fs.move(dryPath, backupDir);
+        makeStub.returns(fakeMake('win32'));
+        await publish({
+          dir,
+          interactive: false,
+          target: [],
+          dryRun: true,
+        });
+        for (const backedUp of await fs.readdir(backupDir)) {
+          await fs.copy(path.resolve(backupDir, backedUp), path.resolve(dryPath, backedUp));
+        }
+      });
+
+      it('should create dry run hash JSON files', async () => {
+        expect(makeStub.callCount).to.equal(2);
+        const dryRunFolder = path.resolve(dir, 'out', 'publish-dry-run');
+        expect(await fs.exists(dryRunFolder)).to.equal(true);
+
+        const hashFolders = await fs.readdir(dryRunFolder);
+        expect(hashFolders).to.have.length(2, 'Should contain two hashes (two publishes)');
+        for (const hashFolderName of hashFolders) {
+          const hashFolder = path.resolve(dryRunFolder, hashFolderName);
+          const makes = await fs.readdir(hashFolder);
+          expect(makes).to.have.length(3, 'Should contain the results of three makes');
+          for (const makeJson of makes) {
+            const jsonPath = path.resolve(hashFolder, makeJson);
+            const contents = await fs.readFile(jsonPath, 'utf8');
+            expect(() => JSON.parse(contents), 'Should be valid JSON').to.not.throw();
+            const data = JSON.parse(contents);
+            expect(data).to.have.property('paths');
+            expect(data).to.have.property('platform');
+            expect(data).to.have.property('arch');
+            expect(data).to.have.property('packageJSON');
+            expect(data).to.have.property('forgeConfig');
+
+            // Make the artifacts for later
+            for (const artifactPath of data.paths) {
+              await fs.writeFile(artifactPath, artifactPath);
+            }
+          }
+        }
+      });
+    });
+
+    describe('when resuming a dry run', () => {
+      let publisher;
+
+      beforeEach(async () => {
+        publisher = sinon.stub();
+        publisher.returns(Promise.resolve());
+        requireSearchStub.returns(publisher);
+        await publish({
+          dir,
+          interactive: false,
+          target: [__filename],
+          dryRunResume: true,
+        });
+      });
+
+      it('should successfully restore values and pass them to publisher', () => {
+        expect(makeStub.callCount).to.equal(0);
+        expect(publisher.callCount).to.equal(2, 'should call once for each platform (make run)');
+        const darwinIndex = publisher.firstCall.args[5] === 'darwin' ? 0 : 1;
+        const win32Index = darwinIndex === 0 ? 1 : 0;
+        expect(publisher.getCall(darwinIndex).args.slice(1)).to.deep.equal([
+          { state: 0 },
+          { config: 0 },
+          undefined,
+          null,
+          'darwin',
+          'x64',
+        ]);
+        expect(publisher.getCall(darwinIndex).args[0].sort()).to.deep.equal(
+          fakeMake('darwin').reduce((accum, val) => accum.concat(val), []).sort()
+        );
+        expect(publisher.getCall(win32Index).args.slice(1)).to.deep.equal([
+          { state: 0 },
+          { config: 0 },
+          undefined,
+          null,
+          'win32',
+          'x64',
+        ]);
+        expect(publisher.getCall(win32Index).args[0].sort()).to.deep.equal(
+          fakeMake('win32').reduce((accum, val) => accum.concat(val), []).sort()
+        );
+      });
+    });
+
+    after(async () => {
+      await fs.remove(dir);
+    });
   });
 });

--- a/test/slow/api_spec_slow.js
+++ b/test/slow/api_spec_slow.js
@@ -247,8 +247,8 @@ describe(`electron-forge API (with installer=${installer.substr(12)})`, () => {
             if (shouldPass) {
               it(`successfully makes for config: ${JSON.stringify(optionsFetcher(), 2)}`, async () => {
                 const outputs = await forge.make(optionsFetcher());
-                for (const outputArr of outputs.artifacts) {
-                  for (const output of outputArr) {
+                for (const outputResult of outputs) {
+                  for (const output of outputResult.artifacts) {
                     expect(await fs.exists(output)).to.equal(true);
                   }
                 }

--- a/test/slow/api_spec_slow.js
+++ b/test/slow/api_spec_slow.js
@@ -247,7 +247,7 @@ describe(`electron-forge API (with installer=${installer.substr(12)})`, () => {
             if (shouldPass) {
               it(`successfully makes for config: ${JSON.stringify(optionsFetcher(), 2)}`, async () => {
                 const outputs = await forge.make(optionsFetcher());
-                for (const outputArr of outputs) {
+                for (const outputArr of outputs.artifacts) {
                   for (const output of outputArr) {
                     expect(await fs.exists(output)).to.equal(true);
                   }


### PR DESCRIPTION
to allow post-make publishes

Fixes #230

<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Looking at the tests best explains what this does, basically you can run `publish --dry-run` and it will make distributables **but not actually upload them**.  It will instead serialize into JSON the information required to upload them including platform, arch, configs and such and save those in a standard location relative to the out directory.

Then when you resume a dry run forge will scan for all saved dry runs and restore them skipping the make step completely and relying on the saved serialized information.

This allows you to make on all three platforms and then at a later point download those artifacts to one deployment machine and deploy everything in one go.

It actually looks kinda similar to a cool thing @felixrieseberg did with slacks publish scripts https://twitter.com/felixrieseberg/status/876962403799281664
