### PR TITLE
feat(starter): add easy way to inspect electron main process from forge

### DIFF
--- a/src/api/start.js
+++ b/src/api/start.js
@@ -26,13 +26,14 @@ import runHook from '../util/hook';
  */
 export default async (providedOptions = {}) => {
   // eslint-disable-next-line prefer-const, no-unused-vars
-  let { dir, interactive, enableLogging, appPath, args, runAsNode } = Object.assign({
+  let { dir, interactive, enableLogging, appPath, args, runAsNode, inspect } = Object.assign({
     dir: process.cwd(),
     appPath: '.',
     interactive: false,
     enableLogging: false,
     args: [],
     runAsNode: false,
+    inspect: false,
   }, providedOptions);
   asyncOra.interactive = interactive;
 
@@ -60,6 +61,10 @@ export default async (providedOptions = {}) => {
     spawnOpts.env.ELECTRON_RUN_AS_NODE = true;
   } else {
     delete spawnOpts.env.ELECTRON_RUN_AS_NODE;
+  }
+
+  if (inspect) {
+    args = ['--inspect'].concat(args);
   }
 
   let spawned;

--- a/src/electron-forge-start.js
+++ b/src/electron-forge-start.js
@@ -23,6 +23,7 @@ import { start } from './api';
     .option('-l, --enable-logging', 'Enable advanced logging.  This will log internal Electron things')
     .option('-n, --run-as-node', 'Run the Electron app as a Node.JS script')
     .option('--vscode', 'Used to enable arg transformation for debugging Electron through VSCode.  Do not use yourself.')
+    .option('-i, --inspect-electron', 'Triggers inspect mode on Electron to allow debugging the main process.  Electron >1.7 only')
     .action((cwd) => {
       if (!cwd) return;
       if (path.isAbsolute(cwd) && fs.existsSync(cwd)) {
@@ -46,6 +47,7 @@ import { start } from './api';
     interactive: true,
     enableLogging: !!program.enableLogging,
     runAsNode: !!program.runAsNode,
+    inspect: !!program.inspectElectron,
   };
 
   if (program.vscode && appArgs) {

--- a/test/fast/electron_forge_start_spec.js
+++ b/test/fast/electron_forge_start_spec.js
@@ -44,6 +44,7 @@ describe('electron-forge start', () => {
       interactive: true,
       enableLogging: false,
       runAsNode: false,
+      inspect: false,
     });
   });
 
@@ -55,6 +56,7 @@ describe('electron-forge start', () => {
       interactive: true,
       enableLogging: false,
       runAsNode: false,
+      inspect: false,
     });
   });
 
@@ -66,6 +68,7 @@ describe('electron-forge start', () => {
       interactive: true,
       enableLogging: false,
       runAsNode: false,
+      inspect: false,
     });
   });
 
@@ -78,6 +81,7 @@ describe('electron-forge start', () => {
       interactive: true,
       enableLogging: false,
       runAsNode: false,
+      inspect: false,
     });
   });
 
@@ -89,6 +93,7 @@ describe('electron-forge start', () => {
       enableLogging: true,
       interactive: true,
       runAsNode: false,
+      inspect: false,
     });
   });
 
@@ -101,6 +106,7 @@ describe('electron-forge start', () => {
       interactive: true,
       args: ['-a', 'foo', '-l'],
       runAsNode: false,
+      inspect: false,
     });
   });
 
@@ -112,6 +118,19 @@ describe('electron-forge start', () => {
       enableLogging: false,
       interactive: true,
       runAsNode: true,
+      inspect: false,
+    });
+  });
+
+  it('should handle inspect-electron', async () => {
+    await runCommand(['--inspect-electron']);
+    expect(startStub.callCount).to.equal(1);
+    expect(startStub.firstCall.args[0]).to.deep.equal({
+      dir: process.cwd(),
+      enableLogging: false,
+      interactive: true,
+      runAsNode: false,
+      inspect: true,
     });
   });
 

--- a/test/fast/start_spec.js
+++ b/test/fast/start_spec.js
@@ -113,6 +113,21 @@ describe('start', () => {
     expect(spawnStub.firstCall.args[1].slice(1)).to.deep.equal(args);
   });
 
+  it('should pass --inspect at the start of the args if inspect is set', async () => {
+    const args = ['magic'];
+    resolveStub.returnsArg(0);
+    spawnStub.returns(0);
+    await start({
+      dir: __dirname,
+      interactive: false,
+      args,
+      inspect: true,
+    });
+    expect(spawnStub.callCount).to.equal(1);
+    expect(spawnStub.firstCall.args[0]).to.contain('electron');
+    expect(spawnStub.firstCall.args[1].slice(1)).to.deep.equal(['--inspect'].concat(args));
+  });
+
   it('should resolve with a handle to the spawned instance', async () => {
     resolveStub.returnsArg(0);
     spawnStub.returns('child');


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Adds a new `--inspect-electron` arg to start to launch electron in inspect mode 😄 