### PR TITLE
fix(starter): start electron-prebuilt-compile binary from its module folder

### DIFF
--- a/src/api/start.js
+++ b/src/api/start.js
@@ -73,12 +73,7 @@ export default async (providedOptions = {}) => {
   await runHook(forgeConfig, 'generateAssets');
 
   await asyncOra('Launching Application', async () => {
-    /* istanbul ignore if  */
-    if (process.platform === 'win32') {
-      spawned = spawn(path.resolve(dir, 'node_modules/.bin/electron.cmd'), [appPath].concat(args), spawnOpts);
-    } else {
-      spawned = spawn(path.resolve(dir, 'node_modules/.bin/electron'), [appPath].concat(args), spawnOpts);
-    }
+    spawned = spawn(process.execPath, [path.resolve(dir, 'node_modules/electron-prebuilt-compile/lib/cli'), appPath].concat(args), spawnOpts);
   });
 
   return spawned;

--- a/test/fast/start_spec.js
+++ b/test/fast/start_spec.js
@@ -1,5 +1,6 @@
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
+import path from 'path';
 import proxyquire from 'proxyquire';
 import sinon from 'sinon';
 
@@ -31,7 +32,8 @@ describe('start', () => {
       interactive: false,
     });
     expect(spawnStub.callCount).to.equal(1);
-    expect(spawnStub.firstCall.args[0]).to.contain('electron');
+    expect(spawnStub.firstCall.args[0]).to.equal(process.execPath);
+    expect(spawnStub.firstCall.args[1][0]).to.contain(`electron-prebuilt-compile${path.sep}lib${path.sep}cli`);
     expect(spawnStub.firstCall.args[2]).to.have.property('cwd', __dirname);
     expect(spawnStub.firstCall.args[2].env).to.not.have.property('ELECTRON_ENABLE_LOGGING');
   });
@@ -42,8 +44,9 @@ describe('start', () => {
       dir: __dirname,
     });
     expect(spawnStub.callCount).to.equal(1);
-    expect(spawnStub.firstCall.args[0]).to.contain('electron');
-    expect(spawnStub.firstCall.args[1][0]).to.equal('.');
+    expect(spawnStub.firstCall.args[0]).to.equal(process.execPath);
+    expect(spawnStub.firstCall.args[1][0]).to.contain(`electron-prebuilt-compile${path.sep}lib${path.sep}cli`);
+    expect(spawnStub.firstCall.args[1][1]).to.equal('.');
   });
 
   it('should pass electron the app path if specified', async () => {
@@ -53,8 +56,9 @@ describe('start', () => {
       appPath: '/path/to/app.js',
     });
     expect(spawnStub.callCount).to.equal(1);
-    expect(spawnStub.firstCall.args[0]).to.contain('electron');
-    expect(spawnStub.firstCall.args[1][0]).to.equal('/path/to/app.js');
+    expect(spawnStub.firstCall.args[0]).to.equal(process.execPath);
+    expect(spawnStub.firstCall.args[1][0]).to.contain(`electron-prebuilt-compile${path.sep}lib${path.sep}cli`);
+    expect(spawnStub.firstCall.args[1][1]).to.equal('/path/to/app.js');
   });
 
   it('should enable electron logging if enableLogging=true', async () => {
@@ -65,7 +69,8 @@ describe('start', () => {
       enableLogging: true,
     });
     expect(spawnStub.callCount).to.equal(1);
-    expect(spawnStub.firstCall.args[0]).to.contain('electron');
+    expect(spawnStub.firstCall.args[0]).to.equal(process.execPath);
+    expect(spawnStub.firstCall.args[1][0]).to.contain(`electron-prebuilt-compile${path.sep}lib${path.sep}cli`);
     expect(spawnStub.firstCall.args[2].env).to.have.property('ELECTRON_ENABLE_LOGGING', true);
   });
 
@@ -109,8 +114,8 @@ describe('start', () => {
       args,
     });
     expect(spawnStub.callCount).to.equal(1);
-    expect(spawnStub.firstCall.args[0]).to.contain('electron');
-    expect(spawnStub.firstCall.args[1].slice(1)).to.deep.equal(args);
+    expect(spawnStub.firstCall.args[0]).to.equal(process.execPath);
+    expect(spawnStub.firstCall.args[1].slice(2)).to.deep.equal(args);
   });
 
   it('should pass --inspect at the start of the args if inspect is set', async () => {
@@ -124,8 +129,8 @@ describe('start', () => {
       inspect: true,
     });
     expect(spawnStub.callCount).to.equal(1);
-    expect(spawnStub.firstCall.args[0]).to.contain('electron');
-    expect(spawnStub.firstCall.args[1].slice(1)).to.deep.equal(['--inspect'].concat(args));
+    expect(spawnStub.firstCall.args[0]).to.equal(process.execPath);
+    expect(spawnStub.firstCall.args[1].slice(2)).to.deep.equal(['--inspect'].concat(args));
   });
 
   it('should resolve with a handle to the spawned instance', async () => {


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Start the `electron-prebuilt-compile` binary from the module folder so we don't have to rely on npm/yarn to install into the .bin folder correctly

Helps #269