### PR TITLE
refactor(importer): use pruner from Electron Packager

### DIFF
--- a/src/api/import.js
+++ b/src/api/import.js
@@ -2,6 +2,8 @@ import debug from 'debug';
 import fs from 'fs-extra';
 import inquirer from 'inquirer';
 import path from 'path';
+import pify from 'pify';
+import { pruneModules } from 'electron-packager/prune';
 
 import initGit from '../init/init-git';
 import { deps, devDeps, exactDevDeps } from '../init/init-npm';
@@ -11,7 +13,7 @@ import { info, warn } from '../util/messages';
 import installDepList from '../util/install-dependencies';
 import readPackageJSON from '../util/read-package-json';
 import confirmIfInteractive from '../util/confirm-if-interactive';
-import { yarnOrNpmSpawn, hasYarn } from '../util/yarn-or-npm';
+import { yarnOrNpm } from '../util/yarn-or-npm';
 
 const d = debug('electron-forge:import');
 
@@ -150,10 +152,7 @@ export default async (providedOptions = {}) => {
   if (electronName) {
     await asyncOra('Pruning deleted modules', async () => {
       d('attempting to prune node_modules in:', dir);
-      await yarnOrNpmSpawn(hasYarn() ? [] : ['prune'], {
-        cwd: dir,
-        stdio: 'ignore',
-      });
+      await pify(pruneModules)({ packageManager: yarnOrNpm() }, dir);
     });
   }
 


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Delegate pruning to Packager. Sets up the possibility of just using the `pruner` module here, when Packager 9 is released.