### PR TITLE
docs(packager): list the Packager options that are not configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,16 @@ config object:
 
 ## Configuring `package`
 
-You can set `electronPackagerConfig` with **any** of the options from
-[Electron Packager](https://github.com/electron-userland/electron-packager/blob/master/docs/api.md).
+You can set `electronPackagerConfig` with any of the options from
+[Electron Packager](https://github.com/electron-userland/electron-packager/blob/master/docs/api.md), except:
+
+* `arch`
+* `asar.unpack` (use `asar.unpackDir` instead)
+* `dir`
+* `electronVersion` (uses the exact version specified for `electron-prebuilt-compile` in your `devDependencies`)
+* `out`
+* `platform`
+* `quiet`
 
 **NOTE:** You can also set your `forge` config property of your package.json to point to a JS file that exports the config object:
 


### PR DESCRIPTION
* [X] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* ~~The changes have sufficient test coverage~~ (not applicable).
* ~~The testsuite passes successfully on my local machine~~ (not applicable).

**Summarize your changes:**

Fixes #109.