### PR TITLE
fix(generic): fix installing tab completion when installing Forge locally

### DIFF
--- a/tabtab-install.js
+++ b/tabtab-install.js
@@ -1,11 +1,7 @@
-const fs = require('fs');
-const path = require('path');
-const { findActualExecutable, spawnPromise } = require('spawn-rx');
-
-const tabtabPath = path.resolve(__dirname, './node_modules/.bin/tabtab');
-
-if (!fs.existsSync(path.resolve(__dirname, 'src'))) {
-  spawnPromise(findActualExecutable(tabtabPath).cmd, ['install', '--auto'], {
-    stdio: 'inherit',
-  }).catch(err => console.error('Failed to install tab completion:', err));
+process.argv.push('install');
+process.argv.push('--auto');
+try {
+  require('tabtab/src/cli');
+} catch (e) {
+  console.warning(`Failed to install tab completion: ${e}`);
 }


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* ~~The changes are appropriately documented~~ (not applicable).
* ~~The changes have sufficient test coverage~~ (not applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

When you install Forge via something like `npm install electron-forge --save-dev` (i.e., not globally), this warning shows up:

https://travis-ci.org/malept/electron-forge-demo123/jobs/265829065#L524-L535

This is because tabtab is a peer dependency when Forge is installed locally. To fix this, I just called the CLI as a `require()` instead of via `spawn-rx`.