### PR TITLE
BREAKING CHANGE: Replace deprecated publish option

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,9 @@ electron-forge lint
 electron-forge publish
 ```
 
-This will `make` your project and publish any generated artifacts.  By default it will publish to GitHub but you can change the publish target with `--target=YourTarget`.
+This will `make` your project and publish any generated artifacts.  By default it will publish to
+GitHub, but you can change the publish target(s) with `--target=YourTarget,YourTarget2`, where the
+value is a comma-separated list of targets.
 
 # Config
 

--- a/src/api/publish.js
+++ b/src/api/publish.js
@@ -2,7 +2,6 @@ import 'colors';
 import path from 'path';
 
 import asyncOra from '../util/ora-handler';
-import deprecate from '../util/deprecate';
 import getForgeConfig from '../util/forge-config';
 import readPackageJSON from '../util/read-package-json';
 import requireSearch from '../util/require-search';
@@ -16,7 +15,7 @@ import make from './make';
  * @property {boolean} [interactive=false] Whether to use sensible defaults or prompt the user visually
  * @property {string} [authToken] An authentication token to use when publishing
  * @property {string} [tag=packageJSON.version] The string to tag this release with
- * @property {string} [target=github] The publish target
+ * @property {Array<string>} [publishTargets=[github]] The publish targets
  * @property {MakeOptions} [makeOptions] Options object to passed through to make()
  */
 
@@ -28,16 +27,14 @@ import make from './make';
  */
 export default async (providedOptions = {}) => {
   // eslint-disable-next-line prefer-const, no-unused-vars
-  let { dir, interactive, authToken, tag, target, makeOptions } = Object.assign({
+  let { dir, interactive, authToken, tag, publishTargets, makeOptions } = Object.assign({
     dir: process.cwd(),
     interactive: false,
     tag: null,
     makeOptions: {},
-    target: null,
+    publishTargets: null,
   }, providedOptions);
   asyncOra.interactive = interactive;
-  // FIXME(MarshallOfSound): Change the method param to publishTargets in the next major bump
-  let publishTargets = target;
 
   const makeResults = await make(Object.assign({
     dir,
@@ -60,10 +57,6 @@ export default async (providedOptions = {}) => {
 
   if (publishTargets === null) {
     publishTargets = forgeConfig.publish_targets[makeOptions.platform || process.platform];
-  } else if (typeof publishTargets === 'string') {
-    // FIXME(MarshallOfSound): Remove this fallback string typeof check in the next major bump
-    deprecate('publish target as a string').replaceWith('an array of publish targets');
-    publishTargets = [publishTargets];
   }
 
   for (const publishTarget of publishTargets) {

--- a/src/electron-forge-publish.js
+++ b/src/electron-forge-publish.js
@@ -13,7 +13,7 @@ import { getMakeOptions } from './electron-forge-make';
     .arguments('[cwd]')
     .option('--auth-token', 'Authorization token for your publisher target (if required)')
     .option('--tag', 'The tag to publish to on GitHub')
-    .option('--target [target]', 'The deployment target, defaults to "github"')
+    .option('--target [target[,target...]]', 'The comma-separated deployment targets, defaults to "github"')
     .allowUnknownOption(true)
     .action((cwd) => {
       if (!cwd) return;
@@ -31,7 +31,7 @@ import { getMakeOptions } from './electron-forge-make';
     authToken: program.authToken,
     tag: program.tag,
   };
-  if (program.target) publishOpts.target = program.target.split(',');
+  if (program.target) publishOpts.publishTargets = program.target.split(',');
 
   publishOpts.makeOptions = getMakeOptions();
 

--- a/test/fast/publish_spec.js
+++ b/test/fast/publish_spec.js
@@ -72,7 +72,7 @@ describe('publish', () => {
     await publish({
       dir: __dirname,
       interactive: false,
-      target: 'void',
+      publishTargets: ['void'],
     });
     expect(requireSearchStub.firstCall.args[1][0]).to.equal('../publishers/void.js');
   });
@@ -81,7 +81,7 @@ describe('publish', () => {
     await publish({
       dir: __dirname,
       interactive: false,
-      target: ['void', 'nowhere', 'black_hole', 'everywhere'],
+      publishTargets: ['void', 'nowhere', 'black_hole', 'everywhere'],
     });
     expect(requireSearchStub.getCall(0).args[1][0]).to.equal('../publishers/void.js');
     expect(requireSearchStub.getCall(1).args[1][0]).to.equal('../publishers/nowhere.js');


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Rename `target` option in the publish API to `publishTargets`, and only allow the param to be an Array of Strings, per the FIXMEs.

Also updated the docs to mention that multiple targets are allowed.