### PR TITLE
feat(initializer): add electron-squirrel-startup to the default template

### DIFF
--- a/src/init/init-npm.js
+++ b/src/init/init-npm.js
@@ -10,7 +10,7 @@ import yarnOrNpm from '../util/yarn-or-npm';
 
 const d = debug('electron-forge:init:npm');
 
-export const deps = ['electron-compile'];
+export const deps = ['electron-compile', 'electron-squirrel-startup'];
 export const devDeps = ['babel-preset-env', 'babel-preset-react', 'babel-plugin-transform-async-to-generator', 'electron-forge'];
 export const exactDevDeps = ['electron-prebuilt-compile'];
 export const standardDeps = ['standard'];

--- a/tmpl/index.js
+++ b/tmpl/index.js
@@ -1,7 +1,7 @@
 import { app, BrowserWindow } from 'electron';
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
-if (require('electron-squirrel-startup')) {
+if (require('electron-squirrel-startup')) { // eslint-disable-line global-require
   app.quit();
 }
 

--- a/tmpl/index.js
+++ b/tmpl/index.js
@@ -1,5 +1,10 @@
 import { app, BrowserWindow } from 'electron';
 
+// Handle creating/removing shortcuts on Windows when installing/uninstalling.
+if (require('electron-squirrel-startup')) {
+  app.quit();
+}
+
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 let mainWindow;


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This is something I suggested in the Slack channel a while ago and only recently remembered it.
