### PR TITLE
fix(linter): don't pass --color to linters that don't support it

### DIFF
--- a/src/api/lint.js
+++ b/src/api/lint.js
@@ -39,9 +39,9 @@ export default async (providedOptions = {}) => {
       throw 'Failed to locate lintable Electron application';
     }
 
-    d('executing "run lint -- --color" in dir:', dir);
+    d('executing "run lint" in dir:', dir);
     try {
-      await yarnOrNpmSpawn(['run', 'lint', '--', '--color'], {
+      await yarnOrNpmSpawn(['run', 'lint'], {
         stdio: process.platform === 'win32' ? 'inherit' : 'pipe',
         cwd: dir,
       });

--- a/src/init/init-npm.js
+++ b/src/init/init-npm.js
@@ -31,7 +31,7 @@ export default async (dir, lintStyle) => {
         packageJSON.scripts.lint = 'standard';
         break;
       case 'airbnb':
-        packageJSON.scripts.lint = 'eslint src';
+        packageJSON.scripts.lint = 'eslint src --color';
         break;
       default:
         packageJSON.scripts.lint = 'echo "No linting configured"';


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Add the flag directly to the NPM script call for the `airbnb` linter.

ISSUES CLOSED: electron-userland/electron-forge-templates#48