### PR TITLE
refactor(maker): DRY up linux config transformations

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "github": "^12.0.3",
     "glob": "^7.1.1",
     "inquirer": "^4.0.0",
+    "lodash.merge": "^4.6.0",
     "lodash.template": "^4.4.0",
     "log-symbols": "^2.0.0",
     "node-fetch": "^1.6.3",

--- a/src/makers/linux/deb.js
+++ b/src/makers/linux/deb.js
@@ -2,12 +2,12 @@ import path from 'path';
 import pify from 'pify';
 
 import { ensureFile } from '../../util/ensure-output';
-import configFn from '../../util/config-fn';
 import isInstalled from '../../util/is-installed';
+import { linuxConfig, populateConfig } from '../../util/linux-config';
 
 export const isSupportedOnCurrentPlatform = async () => isInstalled('electron-installer-debian');
 
-function debianArch(nodeArch) {
+export function debianArch(nodeArch) {
   switch (nodeArch) {
     case 'ia32': return 'i386';
     case 'x64': return 'amd64';
@@ -21,18 +21,18 @@ export default async ({ dir, targetArch, forgeConfig, packageJSON }) => {
   const installer = require('electron-installer-debian');
 
   const arch = debianArch(targetArch);
-  const userConfig = configFn(forgeConfig.electronInstallerDebian, targetArch);
-  userConfig.options = userConfig.options || {};
-  const versionedName = `${userConfig.options.name || packageJSON.name}_${packageJSON.version}_${arch}`;
+  const config = populateConfig({ forgeConfig, configKey: 'electronInstallerDebian', targetArch });
+  const name = config.options.name || packageJSON.name;
+  const versionedName = `${name}_${packageJSON.version}_${arch}`;
   const outPath = path.resolve(dir, '../make', `${versionedName}.deb`);
 
   await ensureFile(outPath);
-  const debianDefaults = {
-    arch,
-    dest: path.dirname(outPath),
-    src: dir,
-  };
-  const debianConfig = Object.assign({}, userConfig, debianDefaults);
+  const debianConfig = linuxConfig({
+    config,
+    pkgArch: arch,
+    dir,
+    outPath,
+  });
 
   await pify(installer)(debianConfig);
   return [outPath];

--- a/src/makers/linux/rpm.js
+++ b/src/makers/linux/rpm.js
@@ -2,12 +2,12 @@ import path from 'path';
 import pify from 'pify';
 
 import { ensureFile } from '../../util/ensure-output';
-import configFn from '../../util/config-fn';
 import isInstalled from '../../util/is-installed';
+import { linuxConfig, populateConfig } from '../../util/linux-config';
 
 export const isSupportedOnCurrentPlatform = async () => isInstalled('electron-installer-redhat');
 
-function rpmArch(nodeArch) {
+export function rpmArch(nodeArch) {
   switch (nodeArch) {
     case 'ia32': return 'i386';
     case 'x64': return 'x86_64';
@@ -21,18 +21,18 @@ export default async ({ dir, targetArch, forgeConfig, packageJSON }) => {
   const installer = require('electron-installer-redhat');
 
   const arch = rpmArch(targetArch);
-  const userConfig = configFn(forgeConfig.electronInstallerRedhat, targetArch);
-  userConfig.options = userConfig.options || {};
-  const versionedName = `${userConfig.options.name || packageJSON.name}-${packageJSON.version}.${arch}`;
+  const config = populateConfig({ forgeConfig, configKey: 'electronInstallerRedhat', targetArch });
+  const name = config.options.name || packageJSON.name;
+  const versionedName = `${name}-${packageJSON.version}.${arch}`;
   const outPath = path.resolve(dir, '../make', `${versionedName}.rpm`);
 
   await ensureFile(outPath);
-  const rpmDefaults = {
-    arch,
-    dest: path.dirname(outPath),
-    src: dir,
-  };
-  const rpmConfig = Object.assign({}, userConfig, rpmDefaults);
+  const rpmConfig = linuxConfig({
+    config,
+    pkgArch: arch,
+    dir,
+    outPath,
+  });
 
   await pify(installer)(rpmConfig);
   return [outPath];

--- a/src/util/linux-config.js
+++ b/src/util/linux-config.js
@@ -1,0 +1,19 @@
+import merge from 'lodash.merge';
+import path from 'path';
+
+import configFn from './config-fn';
+
+export function populateConfig({ forgeConfig, configKey, targetArch }) {
+  const config = configFn(forgeConfig[configKey] || {}, targetArch);
+  config.options = config.options || {};
+
+  return config;
+}
+
+export function linuxConfig({ config, pkgArch, dir, outPath }) {
+  return merge({}, config, {
+    arch: pkgArch,
+    dest: path.dirname(outPath),
+    src: dir,
+  });
+}

--- a/test/fast/makers/deb_spec.js
+++ b/test/fast/makers/deb_spec.js
@@ -1,0 +1,64 @@
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import path from 'path';
+import proxyquire from 'proxyquire';
+import { stub } from 'sinon';
+
+chai.use(chaiAsPromised);
+
+describe('deb maker', () => {
+  let debModule;
+  let debMaker;
+  let eidStub;
+  let ensureFileStub;
+  let forgeConfig;
+
+  const dir = '/my/test/dir/out';
+  const appName = 'My Test App';
+  const targetArch = process.arch;
+  const packageJSON = { version: '1.2.3' };
+
+  beforeEach(() => {
+    ensureFileStub = stub().returns(Promise.resolve());
+    eidStub = stub().callsArg(1);
+    forgeConfig = { electronInstallerDebian: {} };
+
+    debModule = proxyquire.noPreserveCache().noCallThru().load('../../../src/makers/linux/deb', {
+      './config-fn': config => config,
+      '../../util/ensure-output': { ensureFile: ensureFileStub },
+      'electron-installer-debian': eidStub,
+    });
+    debMaker = debModule.default;
+  });
+
+  it('should pass through correct defaults', async () => {
+    await debMaker({ dir, appName, targetArch, forgeConfig, packageJSON });
+    const opts = eidStub.firstCall.args[0];
+    expect(opts).to.deep.equal({
+      arch: debModule.debianArch(process.arch),
+      options: {},
+      src: dir,
+      dest: path.resolve(dir, '..', 'make'),
+    });
+  });
+
+  it('should have config cascade correctly', async () => {
+    forgeConfig.electronInstallerDebian = {
+      arch: 'overridden',
+      options: {
+        productName: 'Debian',
+      },
+    };
+
+    await debMaker({ dir, appName, targetArch, forgeConfig, packageJSON });
+    const opts = eidStub.firstCall.args[0];
+    expect(opts).to.deep.equal({
+      arch: debModule.debianArch(process.arch),
+      options: {
+        productName: 'Debian',
+      },
+      src: dir,
+      dest: path.resolve(dir, '..', 'make'),
+    });
+  });
+});

--- a/test/fast/makers/dmg_spec.js
+++ b/test/fast/makers/dmg_spec.js
@@ -37,7 +37,8 @@ describe('dmg maker', () => {
   it('should pass through correct defaults', async () => {
     await dmgMaker({ dir, appName, targetArch, forgeConfig, packageJSON });
     const opts = eidStub.firstCall.args[0];
-    expect(opts).to.deep.equal({ overwrite: true,
+    expect(opts).to.deep.equal({
+      overwrite: true,
       name: appName,
       appPath: path.resolve(`${dir}/My Test App.app`),
       out: path.resolve(`${dir.substr(0, dir.length - 4)}/make`),

--- a/test/fast/makers/flatpak_spec.js
+++ b/test/fast/makers/flatpak_spec.js
@@ -1,0 +1,64 @@
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import path from 'path';
+import proxyquire from 'proxyquire';
+import { stub } from 'sinon';
+
+chai.use(chaiAsPromised);
+
+describe('flatpak maker', () => {
+  let flatpakModule;
+  let flatpakMaker;
+  let eidStub;
+  let ensureFileStub;
+  let forgeConfig;
+
+  const dir = '/my/test/dir/out';
+  const appName = 'My Test App';
+  const targetArch = process.arch;
+  const packageJSON = { version: '1.2.3' };
+
+  beforeEach(() => {
+    ensureFileStub = stub().returns(Promise.resolve());
+    eidStub = stub().callsArg(1);
+    forgeConfig = { electronInstallerFlatpak: {} };
+
+    flatpakModule = proxyquire.noPreserveCache().noCallThru().load('../../../src/makers/linux/flatpak', {
+      './config-fn': config => config,
+      '../../util/ensure-output': { ensureFile: ensureFileStub },
+      'electron-installer-flatpak': eidStub,
+    });
+    flatpakMaker = flatpakModule.default;
+  });
+
+  it('should pass through correct defaults', async () => {
+    await flatpakMaker({ dir, appName, targetArch, forgeConfig, packageJSON });
+    const opts = eidStub.firstCall.args[0];
+    expect(opts).to.deep.equal({
+      arch: flatpakModule.flatpakArch(process.arch),
+      options: {},
+      src: dir,
+      dest: path.resolve(dir, '..', 'make'),
+    });
+  });
+
+  it('should have config cascade correctly', async () => {
+    forgeConfig.electronInstallerFlatpak = {
+      arch: 'overridden',
+      options: {
+        productName: 'Flatpak',
+      },
+    };
+
+    await flatpakMaker({ dir, appName, targetArch, forgeConfig, packageJSON });
+    const opts = eidStub.firstCall.args[0];
+    expect(opts).to.deep.equal({
+      arch: flatpakModule.flatpakArch(process.arch),
+      options: {
+        productName: 'Flatpak',
+      },
+      src: dir,
+      dest: path.resolve(dir, '..', 'make'),
+    });
+  });
+});

--- a/test/fast/makers/rpm_spec.js
+++ b/test/fast/makers/rpm_spec.js
@@ -1,0 +1,64 @@
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import path from 'path';
+import proxyquire from 'proxyquire';
+import { stub } from 'sinon';
+
+chai.use(chaiAsPromised);
+
+describe('rpm maker', () => {
+  let rpmModule;
+  let rpmMaker;
+  let eidStub;
+  let ensureFileStub;
+  let forgeConfig;
+
+  const dir = '/my/test/dir/out';
+  const appName = 'My Test App';
+  const targetArch = process.arch;
+  const packageJSON = { version: '1.2.3' };
+
+  beforeEach(() => {
+    ensureFileStub = stub().returns(Promise.resolve());
+    eidStub = stub().callsArg(1);
+    forgeConfig = { electronInstallerRedhat: {} };
+
+    rpmModule = proxyquire.noPreserveCache().noCallThru().load('../../../src/makers/linux/rpm', {
+      './config-fn': config => config,
+      '../../util/ensure-output': { ensureFile: ensureFileStub },
+      'electron-installer-redhat': eidStub,
+    });
+    rpmMaker = rpmModule.default;
+  });
+
+  it('should pass through correct defaults', async () => {
+    await rpmMaker({ dir, appName, targetArch, forgeConfig, packageJSON });
+    const opts = eidStub.firstCall.args[0];
+    expect(opts).to.deep.equal({
+      arch: rpmModule.rpmArch(process.arch),
+      options: {},
+      src: dir,
+      dest: path.resolve(dir, '..', 'make'),
+    });
+  });
+
+  it('should have config cascade correctly', async () => {
+    forgeConfig.electronInstallerRedhat = {
+      arch: 'overridden',
+      options: {
+        productName: 'Redhat',
+      },
+    };
+
+    await rpmMaker({ dir, appName, targetArch, forgeConfig, packageJSON });
+    const opts = eidStub.firstCall.args[0];
+    expect(opts).to.deep.equal({
+      arch: rpmModule.rpmArch(process.arch),
+      options: {
+        productName: 'Redhat',
+      },
+      src: dir,
+      dest: path.resolve(dir, '..', 'make'),
+    });
+  });
+});


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This adds a new dependency, `lodash.merge`. Also adds fast tests for Linux maker config.