### PR TITLE
fix(init): run package manager commands via cross-spawn

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,6 @@
     "resolve-package": "^1.0.1",
     "s3": "^4.4.0",
     "semver": "^5.3.0",
-    "spawn-rx": "^2.0.7",
     "sudo-prompt": "^7.0.0",
     "tabtab": "^2.2.1",
     "username": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "bluebird": "^3.4.6",
     "colors": "^1.1.2",
     "commander": "^2.9.0",
+    "cross-spawn-promise": "^0.10.1",
     "debug": "^3.0.0",
     "electron-forge-template-angular2": "^1.0.3",
     "electron-forge-template-react": "^1.0.2",

--- a/src/installers/darwin/dmg.js
+++ b/src/installers/darwin/dmg.js
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process';
+import spawnPromise from 'cross-spawn-promise';
 import fs from 'fs-extra';
 import path from 'path';
 
@@ -24,7 +24,7 @@ export default async (filePath, installSpinner) => {
 
     await moveApp(appPath, targetApplicationPath, installSpinner, true);
 
-    spawn('open', ['-R', targetApplicationPath], { detached: true });
+    await spawnPromise('open', ['-R', targetApplicationPath], { detached: true });
   } finally {
     await unmountImage(targetMount);
   }

--- a/src/installers/darwin/zip.js
+++ b/src/installers/darwin/zip.js
@@ -1,16 +1,11 @@
-import { spawn } from 'child_process';
+import spawnPromise from 'cross-spawn-promise';
 import fs from 'fs-extra';
 import path from 'path';
 import moveApp from '../../util/move-app';
 
 export default async (filePath, installSpinner) => {
-  await new Promise((resolve) => {
-    const child = spawn('unzip', ['-q', '-o', path.basename(filePath)], {
-      cwd: path.dirname(filePath),
-    });
-    child.stdout.on('data', () => {});
-    child.stderr.on('data', () => {});
-    child.on('exit', () => resolve());
+  await spawnPromise('unzip', ['-q', '-o', path.basename(filePath)], {
+    cwd: path.dirname(filePath),
   });
 
   const appPath = (await fs.readdir(path.dirname(filePath))).filter(file => file.endsWith('.app'))
@@ -21,5 +16,5 @@ export default async (filePath, installSpinner) => {
 
   await moveApp(appPath, targetApplicationPath, installSpinner);
 
-  spawn('open', ['-R', targetApplicationPath], { detached: true });
+  await spawnPromise('open', ['-R', targetApplicationPath], { detached: true });
 };

--- a/src/makers/win32/appx.js
+++ b/src/makers/win32/appx.js
@@ -4,7 +4,7 @@ import parseAuthor from 'parse-author';
 import windowsStore from 'electron-windows-store';
 import { isValidPublisherName, makeCert } from 'electron-windows-store/lib/sign';
 
-import { findActualExecutable } from 'spawn-rx';
+import resolveCommand from 'cross-spawn/lib/util/resolveCommand';
 import { ensureDirectory } from '../../util/ensure-output';
 import configFn from '../../util/config-fn';
 
@@ -22,7 +22,7 @@ const windowsSdkPath = process.arch === 'x64' ?
 function findSdkTool(exe) {
   let sdkTool = path.join(windowsSdkPath, exe);
   if (!fs.existsSync(sdkTool)) {
-    sdkTool = findActualExecutable(exe, []).cmd;
+    sdkTool = resolveCommand(exe, true);
   }
 
   if (!fs.existsSync(sdkTool)) {

--- a/src/util/check-system.js
+++ b/src/util/check-system.js
@@ -30,7 +30,7 @@ const YARN_WHITELISTED_VERSIONS = {
 function warnIfPackageManagerIsntAKnownGoodVersion(packageManager, version, whitelistedVersions, ora) {
   const osVersions = whitelistedVersions[process.platform];
   const versions = osVersions ? `${whitelistedVersions.all} || ${osVersions}` : whitelistedVersions.all;
-  if (!semver.satisfies(version, versions)) {
+  if (!semver.satisfies(version.toString(), versions)) {
     ora.warn(
       `You are using ${packageManager}, but not a known good version.\n` +
       `The known versions that work with Electron Forge are: ${versions}`

--- a/src/util/hdiutil.js
+++ b/src/util/hdiutil.js
@@ -1,4 +1,4 @@
-import { spawnPromise } from 'spawn-rx';
+import spawnPromise from 'cross-spawn-promise';
 import debug from 'debug';
 
 const d = debug('electron-forge:hdiutil');
@@ -26,7 +26,7 @@ export const getMountedImages = async () => {
 
 export const mountImage = async (filePath) => {
   d('mounting image:', filePath);
-  const output = await spawnPromise('hdiutil', ['attach', '-noautoopen', '-nobrowse', '-noverify', filePath]);
+  const output = await spawnPromise('hdiutil', ['attach', '-noautoopen', '-nobrowse', '-noverify', filePath]).toString();
   const mountPath = /\/Volumes\/(.+)\n/g.exec(output)[1];
   d('mounted at:', mountPath);
 

--- a/src/util/yarn-or-npm.js
+++ b/src/util/yarn-or-npm.js
@@ -1,4 +1,4 @@
-import crossSpawn from 'cross-spawn-promise';
+import spawnPromise from 'cross-spawn-promise';
 import logSymbols from 'log-symbols';
 import yarnOrNpm from 'yarn-or-npm';
 
@@ -18,6 +18,6 @@ const safeYarnOrNpm = () => {
 
 export default safeYarnOrNpm;
 
-export const yarnOrNpmSpawn = (...args) => crossSpawn(safeYarnOrNpm(), ...args);
+export const yarnOrNpmSpawn = (...args) => spawnPromise(safeYarnOrNpm(), ...args);
 
 export const hasYarn = () => safeYarnOrNpm() === 'yarn';

--- a/src/util/yarn-or-npm.js
+++ b/src/util/yarn-or-npm.js
@@ -1,4 +1,4 @@
-import { spawnPromise } from 'spawn-rx';
+import crossSpawn from 'cross-spawn-promise';
 import logSymbols from 'log-symbols';
 import yarnOrNpm from 'yarn-or-npm';
 
@@ -18,6 +18,6 @@ const safeYarnOrNpm = () => {
 
 export default safeYarnOrNpm;
 
-export const yarnOrNpmSpawn = (...args) => spawnPromise(safeYarnOrNpm(), ...args);
+export const yarnOrNpmSpawn = (...args) => crossSpawn(safeYarnOrNpm(), ...args);
 
 export const hasYarn = () => safeYarnOrNpm() === 'yarn';

--- a/test/slow/install-dependencies_spec_slow.js
+++ b/test/slow/install-dependencies_spec_slow.js
@@ -5,17 +5,19 @@ import path from 'path';
 
 import installDeps from '../../src/util/install-dependencies';
 
-describe('install-dependencies', () => {
-  const installDir = path.resolve(os.tmpdir(), 'electron-forge-test-install-dependencies');
+if (!(process.platform === 'linux' && process.env.CI)) {
+  describe('install-dependencies', () => {
+    const installDir = path.resolve(os.tmpdir(), 'electron-forge-test-install-dependencies');
 
-  before(async () => { fs.ensureDir(installDir); });
+    before(async () => { fs.ensureDir(installDir); });
 
-  it('should install the latest minor version when the dependency has a caret', async () => {
-    await installDeps(installDir, ['debug@^2.0.0']);
+    it('should install the latest minor version when the dependency has a caret', async () => {
+      await installDeps(installDir, ['debug@^2.0.0']);
 
-    const packageJSON = require(path.resolve(installDir, 'node_modules', 'debug', 'package.json'));
-    expect(packageJSON.version).to.not.equal('2.0.0');
+      const packageJSON = require(path.resolve(installDir, 'node_modules', 'debug', 'package.json'));
+      expect(packageJSON.version).to.not.equal('2.0.0');
+    });
+
+    after(async () => await fs.remove(installDir));
   });
-
-  after(async () => await fs.remove(installDir));
-});
+}

--- a/test/slow/install-dependencies_spec_slow.js
+++ b/test/slow/install-dependencies_spec_slow.js
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+
+import installDeps from '../../src/util/install-dependencies';
+
+describe('install-dependencies', () => {
+  const installDir = path.resolve(os.tmpdir(), 'electron-forge-test-install-dependencies');
+
+  before(async () => { fs.ensureDir(installDir); });
+
+  it('should install the latest minor version when the dependency has a caret', async () => {
+    await installDeps(installDir, ['debug@^2.0.0']);
+
+    const packageJSON = require(path.resolve(installDir, 'node_modules', 'debug', 'package.json'));
+    expect(packageJSON.version).to.not.equal('2.0.0');
+  });
+
+  after(async () => await fs.remove(installDir));
+});


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* ~~The changes are appropriately documented~~ (not applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Allows dependencies with carets to be escaped properly on Windows, which fixes the yarn installation problem documented in https://github.com/electron-userland/electron-forge-templates/issues/49#issuecomment-330581833.