### PR TITLE
Allow config for Electron Release Server to be read from envars

### DIFF
--- a/src/util/forge-config.js
+++ b/src/util/forge-config.js
@@ -50,6 +50,7 @@ export default async (dir) => {
     electronInstallerRedhat: {},
     s3: {},
     github_repository: {},
+    electronReleaseServer: {},
   }, forgeConfig);
   forgeConfig.make_targets = Object.assign({
     win32: ['squirrel'],

--- a/test/fast/forge-config_spec.js
+++ b/test/fast/forge-config_spec.js
@@ -23,6 +23,7 @@ const defaults = {
   },
   github_repository: {},
   s3: {},
+  electronReleaseServer: {},
 };
 
 describe('forge-config', () => {
@@ -54,7 +55,10 @@ describe('forge-config', () => {
     expect(conf.s3.secretAccessKey).to.equal(undefined);
 
     process.env.ELECTRON_FORGE_S3_SECRET_ACCESS_KEY = 'SecretyThing';
+    process.env.ELECTRON_FORGE_ELECTRON_RELEASE_SERVER_BASE_URL = 'http://example.com';
     expect(conf.s3.secretAccessKey).to.equal('SecretyThing');
+    expect(conf.electronReleaseServer.baseUrl).to.equal('http://example.com');
     delete process.env.ELECTRON_FORGE_S3_SECRET_ACCESS_KEY;
+    delete process.env.ELECTRON_FORGE_ELECTRON_RELEASE_SERVER_BASE_URL;
   });
 });


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* ~~[ ] The changes are appropriately documented (if applicable).~~
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

Adds electronReleaseServer to the Forge Config template so configuration can be read from environment variables.