### PR TITLE
Move rebuild to post prune

### DIFF
--- a/src/api/package.js
+++ b/src/api/package.js
@@ -107,6 +107,7 @@ export default async (providedOptions = {}) => {
       done();
     }].concat(resolveHooks(forgeConfig.electronPackagerConfig.afterCopy, dir)),
     afterExtract: resolveHooks(forgeConfig.electronPackagerConfig.afterExtract, dir),
+    afterPrune: resolveHooks(forgeConfig.electronPackagerConfig.afterPrune, dir),
     dir,
     arch,
     platform,

--- a/src/api/package.js
+++ b/src/api/package.js
@@ -95,10 +95,6 @@ export default async (providedOptions = {}) => {
       prepareSpinner.succeed();
       await packagerCompileHook(dir, ...args);
     }, async (buildPath, electronVersion, pPlatform, pArch, done) => {
-      await rebuildHook(buildPath, electronVersion, pPlatform, pArch);
-      packagerSpinner = ora('Packaging Application').start();
-      done();
-    }, async (buildPath, electronVersion, pPlatform, pArch, done) => {
       const copiedPackageJSON = await readPackageJSON(buildPath);
       if (copiedPackageJSON.config && copiedPackageJSON.config.forge) {
         delete copiedPackageJSON.config.forge;
@@ -107,7 +103,11 @@ export default async (providedOptions = {}) => {
       done();
     }].concat(resolveHooks(forgeConfig.electronPackagerConfig.afterCopy, dir)),
     afterExtract: resolveHooks(forgeConfig.electronPackagerConfig.afterExtract, dir),
-    afterPrune: resolveHooks(forgeConfig.electronPackagerConfig.afterPrune, dir),
+    afterPrune: [async (buildPath, electronVersion, pPlatform, pArch, done) => {
+      await rebuildHook(buildPath, electronVersion, pPlatform, pArch);
+      packagerSpinner = ora('Packaging Application').start();
+      done();
+    }].concat(resolveHooks(forgeConfig.electronPackagerConfig.afterPrune, dir)),
     dir,
     arch,
     platform,

--- a/src/api/package.js
+++ b/src/api/package.js
@@ -29,6 +29,17 @@ const d = debug('electron-forge:packager');
  */
 
 /**
+ * Resolves hooks if they are a path to a file (instead of a `Function`).
+ */
+function resolveHooks(hooks, dir) {
+  if (hooks) {
+    return hooks.map(hook => (typeof hook === 'string' ? requireSearch(dir, [hook]) : hook));
+  }
+
+  return [];
+}
+
+/**
  * Package an Electron application into an platform dependent format.
  *
  * @param {PackageOptions} providedOptions - Options for the Package method
@@ -94,12 +105,8 @@ export default async (providedOptions = {}) => {
       }
       await fs.writeFile(path.resolve(buildPath, 'package.json'), JSON.stringify(copiedPackageJSON, null, 2));
       done();
-    }].concat(forgeConfig.electronPackagerConfig.afterCopy ? forgeConfig.electronPackagerConfig.afterCopy.map(item =>
-      (typeof item === 'string' ? requireSearch(dir, [item]) : item)
-    ) : []),
-    afterExtract: forgeConfig.electronPackagerConfig.afterExtract ? forgeConfig.electronPackagerConfig.afterExtract.map(item =>
-      (typeof item === 'string' ? requireSearch(dir, [item]) : item)
-    ) : [],
+    }].concat(resolveHooks(forgeConfig.electronPackagerConfig.afterCopy, dir)),
+    afterExtract: resolveHooks(forgeConfig.electronPackagerConfig.afterExtract, dir),
     dir,
     arch,
     platform,


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Per https://github.com/electron-userland/electron-forge/issues/330#issuecomment-331743953

Also adds the feature of resolving `afterPrune` file hooks, to be consistent with the others.

In the `sqlite3` testcase in that issue that I have repro steps for, you still need to add `node-pre-gyp` to `devDependencies` in order to get it to finish running `npm run package` when `packageManager: 'yarn'`.