### PR TITLE
fix(generic): correct the getOwnPropertyDescriptor proxy hook to resp…

### DIFF
--- a/src/util/forge-config.js
+++ b/src/util/forge-config.js
@@ -28,8 +28,10 @@ const proxify = (object, envPrefix) => {
     getOwnPropertyDescriptor(target, name) {
       const envValue = process.env[`${envPrefix}_${underscoreCase(name)}`];
       // eslint-disable-next-line no-prototype-builtins
-      if (target.hasOwnProperty(name) || envValue) {
-        return { configurable: true, enumerable: true };
+      if (target.hasOwnProperty(name)) {
+        return Object.getOwnPropertyDescriptor(target, name);
+      } else if (envValue) {
+        return { writable: true, enumerable: true, configurable: true, value: envValue };
       }
     },
   });

--- a/test/fast/forge-config_spec.js
+++ b/test/fast/forge-config_spec.js
@@ -37,12 +37,26 @@ describe('forge-config', () => {
       },
     }));
   });
+
   it('should allow access to built-ins of proxied objects', async () => {
     const conf = await findConfig(path.resolve(__dirname, '../fixture/dummy_js_conf'));
     expect(conf.electronPackagerConfig.baz.hasOwnProperty).to.be.a('function');
     process.env.ELECTRON_FORGE_S3_SECRET_ACCESS_KEY = 'SecretyThing';
     // eslint-disable-next-line no-prototype-builtins
     expect(conf.s3.hasOwnProperty('secretAccessKey')).to.equal(true);
+    delete process.env.ELECTRON_FORGE_S3_SECRET_ACCESS_KEY;
+  });
+
+  it('should allow overwrite of properties in proxied objects', async () => {
+    const conf = await findConfig(path.resolve(__dirname, '../fixture/dummy_js_conf'));
+    expect(conf.electronPackagerConfig.baz.hasOwnProperty).to.be.a('function');
+    expect(() => { conf.electronPackagerConfig.baz = 'bar'; }).to.not.throw();
+    process.env.ELECTRON_FORGE_S3_SECRET_ACCESS_KEY = 'SecretyThing';
+
+    const descriptor = { writable: true, enumerable: true, configurable: true, value: 'SecretyThing' };
+    expect(Object.getOwnPropertyDescriptor(conf.s3, 'secretAccessKey')).to.be.deep.equal(descriptor);
+    expect(() => { conf.s3.secretAccessKey = 'bar'; }).to.not.throw();
+    expect(conf.s3.secretAccessKey).to.equal('bar');
     delete process.env.ELECTRON_FORGE_S3_SECRET_ACCESS_KEY;
   });
 


### PR DESCRIPTION
…ect current properties writabil

ISSUES CLOSED: #340 

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).
