### PR TITLE
Throw error/warn when no app version exists in start/import

### DIFF
--- a/src/api/import.js
+++ b/src/api/import.js
@@ -184,6 +184,10 @@ export default async (providedOptions = {}) => {
 
   packageJSON = await readPackageJSON(dir);
 
+  if (!packageJSON.version) {
+    warn(interactive, "Please set the 'version' in your application's package.json".yellow);
+  }
+
   packageJSON.config = packageJSON.config || {};
   const templatePackageJSON = await readPackageJSON(path.resolve(__dirname, '../../tmpl'));
   packageJSON.config.forge = templatePackageJSON.config.forge;

--- a/src/api/package.js
+++ b/src/api/package.js
@@ -9,6 +9,7 @@ import { hostArch } from 'electron-packager/targets';
 
 import getForgeConfig from '../util/forge-config';
 import runHook from '../util/hook';
+import { warn } from '../util/messages';
 import realOra, { fakeOra } from '../util/ora';
 import packagerCompileHook from '../util/compile-hook';
 import readPackageJSON from '../util/read-package-json';
@@ -109,6 +110,11 @@ export default async (providedOptions = {}) => {
   if (typeof packageOpts.asar === 'object' && packageOpts.asar.unpack) {
     packagerSpinner.fail();
     throw new Error('electron-compile does not support asar.unpack yet.  Please use asar.unpackDir');
+  }
+
+  if (!packageJSON.version && !packageOpts.appVersion) {
+    // eslint-disable-next-line max-len
+    warn(interactive, "Please set 'version' or 'config.forge.electronPackagerConfig.appVersion' in your application's package.json so auto-updates work properly".yellow);
   }
 
   await runHook(forgeConfig, 'generateAssets');

--- a/src/api/start.js
+++ b/src/api/start.js
@@ -46,6 +46,10 @@ export default async (providedOptions = {}) => {
 
   const packageJSON = await readPackageJSON(dir);
 
+  if (!packageJSON.version) {
+    throw `Please set your application's 'version' in '${dir}/package.json'.`;
+  }
+
   await rebuild(dir, packageJSON.devDependencies['electron-prebuilt-compile'], process.platform, process.arch);
 
   const spawnOpts = {


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

* In `start`, throws an error when no app version exists.
* In `import`, warns when no app version exists.

Fixes #351.