### PR TITLE
 fix(importer): handle the case where productName doesn't exist

### DIFF
--- a/src/util/forge-config.js
+++ b/src/util/forge-config.js
@@ -42,9 +42,11 @@ const proxify = (object, envPrefix) => {
  * Sets sensible defaults for the `config.forge` object.
  */
 export function setInitialForgeConfig(packageJSON) {
+  const { name = '', productName = '' } = packageJSON;
+
   /* eslint-disable no-param-reassign */
-  packageJSON.config.forge.electronWinstallerConfig.name = packageJSON.name.replace(/-/g, '_');
-  packageJSON.config.forge.windowsStoreConfig.name = packageJSON.productName.replace(/-/g, '');
+  packageJSON.config.forge.electronWinstallerConfig.name = name.replace(/-/g, '_');
+  packageJSON.config.forge.windowsStoreConfig.name = productName.replace(/-/g, '');
   packageJSON.config.forge.electronPackagerConfig.packageManager = yarnOrNpm();
   /* eslint-enable no-param-reassign */
 }

--- a/src/util/forge-config.js
+++ b/src/util/forge-config.js
@@ -42,7 +42,7 @@ const proxify = (object, envPrefix) => {
  * Sets sensible defaults for the `config.forge` object.
  */
 export function setInitialForgeConfig(packageJSON) {
-  const { name = '', productName = '' } = packageJSON;
+  const { name = '', productName = name } = packageJSON;
 
   /* eslint-disable no-param-reassign */
   packageJSON.config.forge.electronWinstallerConfig.name = name.replace(/-/g, '_');

--- a/test/slow/api_spec_slow.js
+++ b/test/slow/api_spec_slow.js
@@ -12,12 +12,13 @@ import installDeps from '../../src/util/install-dependencies';
 import readPackageJSON from '../../src/util/read-package-json';
 import yarnOrNpm from '../../src/util/yarn-or-npm';
 
-const installer = process.argv.find(arg => arg.startsWith('--installer=')) || `--installer=${yarnOrNpm()}`;
+const installerArg = process.argv.find(arg => arg.startsWith('--installer=')) || `--installer=${yarnOrNpm()}`;
+const installer = installerArg.substr(12);
 const forge = proxyquire.noCallThru().load('../../src/api', {
   './install': async () => {},
 });
 
-describe(`electron-forge API (with installer=${installer.substr(12)})`, () => {
+describe(`electron-forge API (with installer=${installer})`, () => {
   let dir;
   let dirID = Date.now();
 
@@ -153,6 +154,20 @@ describe(`electron-forge API (with installer=${installer.substr(12)})`, () => {
 
     after(async () => {
       await fs.remove(dir);
+    });
+  });
+
+  describe('import', () => {
+    before(async () => {
+      await ensureTestDirIsNonexistent();
+      await fs.mkdir(dir);
+      execSync(`${installer} init -y`, {
+        cwd: dir,
+      });
+    });
+
+    it('works', async () => {
+      await forge.import({ dir });
     });
   });
 

--- a/test/slow/api_spec_slow.js
+++ b/test/slow/api_spec_slow.js
@@ -75,6 +75,7 @@ describe(`electron-forge API (with nodeInstaller=${nodeInstaller})`, () => {
       after(() => fs.remove(dir));
     });
   };
+
   forLintingMethod('airbnb');
   forLintingMethod('standard');
 
@@ -167,7 +168,31 @@ describe(`electron-forge API (with nodeInstaller=${nodeInstaller})`, () => {
     });
 
     it('works', async () => {
+      const packageJSON = await readPackageJSON(dir);
+      packageJSON.name = 'Name';
+      packageJSON.productName = 'Product Name';
+      packageJSON.customProp = 'propVal';
+      await fs.writeFile(path.resolve(dir, 'package.json'), JSON.stringify(packageJSON, null, 2));
+
       await forge.import({ dir });
+
+      const {
+        config: {
+          forge: {
+            electronWinstallerConfig: { name: winstallerName },
+            windowsStoreConfig: { name: windowsStoreName },
+          },
+        },
+        customProp,
+      } = await readPackageJSON(dir);
+
+      expect(winstallerName).to.equal('Name');
+      expect(windowsStoreName).to.equal('Product Name');
+      expect(customProp).to.equal('propVal');
+    });
+
+    after(async () => {
+      await fs.remove(dir);
     });
   });
 

--- a/test/slow/api_spec_slow.js
+++ b/test/slow/api_spec_slow.js
@@ -12,13 +12,13 @@ import installDeps from '../../src/util/install-dependencies';
 import readPackageJSON from '../../src/util/read-package-json';
 import yarnOrNpm from '../../src/util/yarn-or-npm';
 
-const installerArg = process.argv.find(arg => arg.startsWith('--installer=')) || `--installer=${yarnOrNpm()}`;
-const installer = installerArg.substr(12);
+const nodeInstallerArg = process.argv.find(arg => arg.startsWith('--installer=')) || `--installer=${yarnOrNpm()}`;
+const nodeInstaller = nodeInstallerArg.substr(12);
 const forge = proxyquire.noCallThru().load('../../src/api', {
   './install': async () => {},
 });
 
-describe(`electron-forge API (with installer=${installer})`, () => {
+describe(`electron-forge API (with nodeInstaller=${nodeInstaller})`, () => {
   let dir;
   let dirID = Date.now();
 
@@ -161,7 +161,7 @@ describe(`electron-forge API (with installer=${installer})`, () => {
     before(async () => {
       await ensureTestDirIsNonexistent();
       await fs.mkdir(dir);
-      execSync(`${installer} init -y`, {
+      execSync(`${nodeInstaller} init -y`, {
         cwd: dir,
       });
     });

--- a/test/slow/api_spec_slow.js
+++ b/test/slow/api_spec_slow.js
@@ -18,7 +18,7 @@ const forge = proxyquire.noCallThru().load('../../src/api', {
   './install': async () => {},
 });
 
-describe(`electron-forge API (with nodeInstaller=${nodeInstaller})`, () => {
+describe(`electron-forge API (with installer=${nodeInstaller})`, () => {
   let dir;
   let dirID = Date.now();
 
@@ -172,7 +172,7 @@ describe(`electron-forge API (with nodeInstaller=${nodeInstaller})`, () => {
       packageJSON.name = 'Name';
       packageJSON.productName = 'Product Name';
       packageJSON.customProp = 'propVal';
-      await fs.writeFile(path.resolve(dir, 'package.json'), JSON.stringify(packageJSON, null, 2));
+      await fs.writeJson(path.resolve(dir, 'package.json'), packageJSON);
 
       await forge.import({ dir });
 
@@ -189,6 +189,27 @@ describe(`electron-forge API (with nodeInstaller=${nodeInstaller})`, () => {
       expect(winstallerName).to.equal('Name');
       expect(windowsStoreName).to.equal('Product Name');
       expect(customProp).to.equal('propVal');
+    });
+
+    it('defaults windowsStoreConfig.name to packageJSON.name', async () => {
+      const packageJSON = await readPackageJSON(dir);
+      packageJSON.name = 'Name';
+      delete packageJSON.productName;
+      await fs.writeJson(path.resolve(dir, 'package.json'), packageJSON);
+
+      await forge.import({ dir });
+
+      const {
+        config: {
+          forge: {
+            electronWinstallerConfig: { name: winstallerName },
+            windowsStoreConfig: { name: windowsStoreName },
+          },
+        },
+      } = await readPackageJSON(dir);
+
+      expect(winstallerName).to.equal('Name');
+      expect(windowsStoreName).to.equal('Name');
     });
 
     after(async () => {

--- a/test/slow/api_spec_slow.js
+++ b/test/slow/api_spec_slow.js
@@ -167,7 +167,7 @@ describe(`electron-forge API (with nodeInstaller=${nodeInstaller})`, () => {
       });
     });
 
-    it('works', async () => {
+    it('creates a forge config', async () => {
       const packageJSON = await readPackageJSON(dir);
       packageJSON.name = 'Name';
       packageJSON.productName = 'Product Name';


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

`yarn init` and `npm init` don't add a `productName` to `package.json`, and when running import on a project without a `productName`, the config setup would throw an exception, so guard against that. This also implements a very basic import unit test -- maybe we want more, but this at least covers this bug fix and other sanity-check-level issues.