### PR TITLE
fix(generic): assume invalid semver package manager versions are incompatible

### DIFF
--- a/test/fast/system_spec.js
+++ b/test/fast/system_spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import checkSystem, { isNightlyYarnVersion } from '../../src/util/check-system';
+import checkSystem, { validPackageManagerVersion } from '../../src/util/check-system';
 import { fakeOra } from '../../src/util/ora';
 
 describe('check-system', () => {
@@ -8,17 +8,17 @@ describe('check-system', () => {
     expect(await checkSystem(fakeOra())).to.be.equal(true);
   });
 
-  describe('isNightlyYarnVersion', () => {
-    it('should not match release versions', () => {
-      expect(isNightlyYarnVersion('0.10.0')).to.be.equal(false);
+  describe('validPackageManagerVersion', () => {
+    it('should consider whitelisted versions to be valid', () => {
+      expect(validPackageManagerVersion('NPM', '3.10.1', '^3.0.0', fakeOra())).to.be.equal(true);
     });
 
-    it('should not match rc/beta/alpha versions', () => {
-      expect(isNightlyYarnVersion('0.10.0-beta.1')).to.be.equal(false);
+    it('should consider Yarn nightly versions to be invalid', () => {
+      expect(validPackageManagerVersion('Yarn', '0.23.0-20170311.0515', '0.23.0', fakeOra())).to.be.equal(false);
     });
 
-    it('should match nightly versions', () => {
-      expect(isNightlyYarnVersion('0.23.0-20170311.0515')).to.be.equal(true);
+    it('should consider invalid semver versions to be invalid', () => {
+      expect(validPackageManagerVersion('Yarn', '0.22', '0.22.0', fakeOra())).to.be.equal(false);
     });
   });
 });


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

I replaced `isNightlyYarnVersion`, but I'm not sure if we need to emit a warning in that case.

ISSUES CLOSED: #376