### PR TITLE
fix(importer): Fix typo in dependency check

### DIFF
--- a/src/api/import.js
+++ b/src/api/import.js
@@ -175,7 +175,7 @@ export default async (providedOptions = {}) => {
 
     d('installing exactDevDependencies');
     await installDepList(dir, exactDevDeps.map((dep) => {
-      if (dep === 'electron-prebuild-compile') {
+      if (dep === 'electron-prebuilt-compile') {
         return `${dep}@${electronVersion || 'latest'}`;
       }
 


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

I noticed this typo, not sure if it's actually been causing anybody any issues.