### PR TITLE
fix(initializer): electron versions for babel-preset-env should be strings

### DIFF
--- a/src/init/init-npm.js
+++ b/src/init/init-npm.js
@@ -75,7 +75,7 @@ export default async (dir, lintStyle) => {
       const envTarget = content.env[profile]['application/javascript'].presets.find(x => x[0] === 'env');
       // parseFloat strips the patch version
       // parseFloat('1.3.2') === 1.3
-      envTarget[1].targets.electron = parseFloat(electronPrebuilt.version);
+      envTarget[1].targets.electron = parseFloat(electronPrebuilt.version).toString();
     }
 
     await fs.writeFile(path.join(dir, '.compilerc'), JSON.stringify(content, null, 2), 'utf8');

--- a/test/slow/api_spec_slow.js
+++ b/test/slow/api_spec_slow.js
@@ -62,10 +62,12 @@ describe(`electron-forge API (with installer=${nodeInstaller})`, () => {
         expect(await fs.pathExists(path.resolve(dir, 'node_modules/electron-forge')), 'electron-forge should exist').to.equal(true);
       });
 
-      it('should have set the .compilerc electron version to be a float', async () => {
+      it('should have set the .compilerc electron version to be a string', async () => {
         expectProjectPathExists('.compilerc', 'file');
         const compilerc = JSON.parse(await fs.readFile(path.resolve(dir, '.compilerc')));
-        expect(compilerc.env.development['application/javascript'].presets[0][1].targets.electron).to.be.a('number');
+        const electronVersion = compilerc.env.development['application/javascript'].presets[0][1].targets.electron;
+        expect(electronVersion).to.be.a('string');
+        expect(electronVersion.split('.').length).to.equal(2);
       });
 
       describe('lint', () => {

--- a/tmpl/_compilerc
+++ b/tmpl/_compilerc
@@ -3,7 +3,7 @@
     "development": {
       "application/javascript": {
         "presets": [
-          ["env", { "targets": { "electron": 1.4 } }],
+          ["env", { "targets": { "electron": "1.4" } }],
           "react"
         ],
         "plugins": ["transform-async-to-generator"],
@@ -13,7 +13,7 @@
     "production": {
       "application/javascript": {
         "presets": [
-          ["env", { "targets": { "electron": 1.4 } }],
+          ["env", { "targets": { "electron": "1.4" } }],
           "react"
         ],
         "plugins": ["transform-async-to-generator"],


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* ~~The changes are appropriately documented~~ (not applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Forge changed to floats in #187 due to a break in `babel-preset-env`. The Babel folks added proper support for strings as versions in [v1.5.0](https://github.com/babel/babel-preset-env/blob/8d09fa52975e46e6244032abdb641ce5294474af/CHANGELOG.md#v150-2017-05-19) via https://github.com/babel/babel-preset-env/pull/321, about 1.5 months later (we require `^1.6.0` already).

Removes the following warning when running `electron-forge start`:

> Warning, the following targets are using a decimal version:
>
>   electron: 1.7
>
> We recommend using a string for minor/patch versions to avoid numbers like 6.10
> getting parsed as 6.1, which can lead to unexpected behavior.