### PR TITLE
chore(generic): don't nonzero-exit when trying to install tabtab completions

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "commit": "git-cz",
     "docs": "esdoc",
     "install": "node tabtab-install.js",
-    "lint": "eslint src test gulpfile.babel.js",
+    "lint": "eslint src test gulpfile.babel.js tabtab-install.js",
     "prepublish": "gulp build",
     "pretest": "gulp build",
     "test": "npm run lint && npm run test-all",

--- a/tabtab-install.js
+++ b/tabtab-install.js
@@ -1,7 +1,16 @@
-process.argv.push('install');
-process.argv.push('--auto');
-try {
-  require('tabtab/src/cli');
-} catch (e) {
-  console.warn(`Failed to install tab completion: ${e}`);
+const Complete = require('tabtab/src/complete');
+const Installer = require('tabtab/src/installer');
+
+const options = { auto: true, name: 'electron-forge' };
+const complete = new Complete(options);
+const installer = new Installer(options, complete);
+
+let shell = process.env.SHELL;
+if (shell) shell = shell.split((process.platform !== 'win32') ? '/' : '\\').slice(-1)[0];
+
+if (installer[shell]) {
+  installer.handle(options.name, options)
+    .catch(e => console.warn(`Failed to install tab completion: ${e}`));
+} else {
+  console.warn(`User shell ${shell} not supported, skipping completion install`);
 }


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* <del>The changes are appropriately documented</del> (not applicable).
* <del>The changes have sufficient test coverage</del> (not applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Copies the installation code from tabtab, except it only warns instead of nonzero exits when an error occurs.

ISSUES CLOSED: #321