### PR TITLE
Improve CI runtimes

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,14 +13,12 @@ branches:
 
 install:
 - ps: Install-Product node $env:nodejs_version $env:platform
-- npm install -g npm@4
 - set PATH=%APPDATA%\npm;%PATH%
-- npm install
-- npm update
+- yarn
 
 test_script:
 - node --version
-- npm --version
-- npm test -- --installer=%node_installer%
+- yarn --version
+- yarn test --installer=%node_installer%
 
 build: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,7 @@ environment:
   matrix:
   - node_installer: yarn
 cache:
-- '%APPDATA%\npm-cache'
+- 'node_modules'
 - '%USERPROFILE%\.electron'
 branches:
   only:
@@ -16,6 +16,7 @@ install:
 - npm install -g npm@4
 - set PATH=%APPDATA%\npm;%PATH%
 - npm install
+- npm update
 
 test_script:
 - node --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ os:
 dist: trusty
 osx_image: xcode8.3
 sudo: required
+cache:
+  directories:
+  - node_modules
 services:
 - docker
 env:
@@ -18,6 +21,9 @@ branches:
   - master
   - /^v\d+\.\d+\.\d+/
 before_install: if [[ "$NODE_INSTALLER" = "yarn" ]]; then npm install -g yarn@0.23.3; fi
+install:
+- npm install
+- npm update
 script: ci/script.sh
 after_success: ci/coverage.sh
 notifications:

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,7 +1,0 @@
-FROM malept/electron-forge-container:latest
-
-ENV CI=true
-
-RUN mkdir /code
-WORKDIR /code
-ADD . /code/

--- a/ci/docker.sh
+++ b/ci/docker.sh
@@ -3,4 +3,7 @@
 NODE_INSTALLER="$1"
 
 if [[ "$NODE_INSTALLER" = "yarn" ]]; then npm i -g yarn; fi
-npm run test -- --installer=$NODE_INSTALLER
+
+cd /code
+
+CI=true npm run test -- --installer=$NODE_INSTALLER

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then
-    sudo docker build -f ci/Dockerfile . -t electron-forge-ci
-    sudo docker run -it electron-forge-ci ci/docker.sh $NODE_INSTALLER
+    sudo docker run --interactive --tty --volume $(pwd):/code malept/electron-forge-container:latest /code/ci/docker.sh $NODE_INSTALLER
 else
     npm run test-coverage -- --installer=$NODE_INSTALLER
 fi


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* ~~The changes are appropriately documented~~ (not applicable).
* [x] The changes have sufficient test coverage (if applicable).
* ~~The testsuite passes successfully on my local machine~~ (not applicable).

**Summarize your changes:**

The addition of `import` tests make the macOS tests run dangerously close to the max execution time, so I did some general optimizations to the test environments.

* Cache `node_modules` in both CI environments
* Consolidate a bunch of the Docker-related CI scripts - for example, the intermediate Docker container wasn't necessary.
* Exclusively use Yarn in AppVeyor, since that's the only node installer that's being used in that CI environment anyway.