### PR TITLE
refactor(generic): Use readJson and writeJson from fs-extra

### DIFF
--- a/src/api/import.js
+++ b/src/api/import.js
@@ -135,7 +135,7 @@ export default async (providedOptions = {}) => {
 
   const writeChanges = async () => {
     await asyncOra('Writing modified package.json file', async () => {
-      await fs.writeFile(path.resolve(dir, 'package.json'), `${JSON.stringify(packageJSON, null, 2)}\n`);
+      await fs.writeJson(path.resolve(dir, 'package.json'), packageJSON, { spaces: 2 });
     });
   };
 
@@ -208,7 +208,7 @@ export default async (providedOptions = {}) => {
   let babelConfig = packageJSON.babel;
   const babelPath = path.resolve(dir, '.babelrc');
   if (!babelConfig && await fs.pathExists(babelPath)) {
-    babelConfig = JSON.parse(await fs.readFile(babelPath, 'utf8'));
+    babelConfig = await fs.readJson(babelPath, 'utf8');
   }
 
   if (babelConfig) {
@@ -216,12 +216,12 @@ export default async (providedOptions = {}) => {
       let compileConfig = {};
       const compilePath = path.resolve(dir, '.compilerc');
       if (await fs.pathExists(compilePath)) {
-        compileConfig = JSON.parse(await fs.readFile(compilePath, 'utf8'));
+        compileConfig = await fs.readJson(compilePath, 'utf8');
       }
 
-      await fs.writeFile(compilePath, JSON.stringify(Object.assign(compileConfig, {
+      await fs.writeJson(compilePath, Object.assign(compileConfig, {
         'application/javascript': babelConfig,
-      }), null, 2));
+      }), { spaces: 2 });
     });
 
     info(interactive, 'NOTE: You might be able to remove your `.compilerc` file completely if you are only using the `es2016` and `react` presets'.yellow);

--- a/src/api/package.js
+++ b/src/api/package.js
@@ -111,7 +111,7 @@ export default async (providedOptions = {}) => {
     if (copiedPackageJSON.config && copiedPackageJSON.config.forge) {
       delete copiedPackageJSON.config.forge;
     }
-    await fs.writeFile(path.resolve(buildPath, 'package.json'), JSON.stringify(copiedPackageJSON, null, 2));
+    await fs.writeJson(path.resolve(buildPath, 'package.json'), copiedPackageJSON, { spaces: 2 });
     done();
   });
 

--- a/src/init/init-npm.js
+++ b/src/init/init-npm.js
@@ -36,7 +36,7 @@ export default async (dir, lintStyle) => {
         break;
     }
     d('writing package.json to:', dir);
-    await fs.writeFile(path.resolve(dir, 'package.json'), JSON.stringify(packageJSON, null, 4));
+    await fs.writeJson(path.resolve(dir, 'package.json'), packageJSON, { spaces: 2 });
   });
 
   await asyncOra('Installing NPM Dependencies', async () => {
@@ -67,7 +67,7 @@ export default async (dir, lintStyle) => {
 
     // NB: For babel-preset-env to work correctly, it needs to know the
     // actual version of Electron that we installed
-    const content = JSON.parse(await fs.readFile(path.join(dir, '.compilerc'), 'utf8'));
+    const content = await fs.readJson(path.join(dir, '.compilerc'), 'utf8');
     const electronPrebuilt = require(
       path.join(dir, 'node_modules', 'electron-prebuilt-compile', 'package.json'));
 
@@ -78,6 +78,6 @@ export default async (dir, lintStyle) => {
       envTarget[1].targets.electron = parseFloat(electronPrebuilt.version).toString();
     }
 
-    await fs.writeFile(path.join(dir, '.compilerc'), JSON.stringify(content, null, 2), 'utf8');
+    await fs.writeJson(path.join(dir, '.compilerc'), content, { spaces: 2 });
   });
 };

--- a/src/util/compile-hook.js
+++ b/src/util/compile-hook.js
@@ -31,9 +31,7 @@ export default async(originalDir, buildPath, electronVersion, pPlatform, pArch, 
       await fs.writeFile(path.join(appDir, 'es6-shim.js'),
         await fs.readFile(path.join(path.resolve(originalDir, 'node_modules/electron-compile/lib/es6-shim.js')), 'utf8'));
 
-      await fs.writeFile(
-        path.join(appDir, 'package.json'),
-        JSON.stringify(packageJSON, null, 2));
+      await fs.writeJson(path.join(appDir, 'package.json'), packageJSON, { spaces: 2 });
     }
 
     await compileAndShim(buildPath);

--- a/src/util/config.js
+++ b/src/util/config.js
@@ -31,18 +31,18 @@ class BasicConfigStore {
     this._load();
     this._store[key] = value;
     d('setting key:', key, 'to value:', value);
-    fs.writeFileSync(this._path, JSON.stringify(this._store));
+    fs.writeJsonSync(this._path, this._store);
   }
 
   _load() {
     if (fs.existsSync(this._path)) {
-      this._store = JSON.parse(fs.readFileSync(this._path, 'utf8'));
+      this._store = fs.readJsonSync(this._path);
     }
   }
 
   reset() {
     this._store = {};
-    fs.writeFileSync(this._path, JSON.stringify(this._store));
+    fs.writeJsonSync(this._path, this._store);
   }
 }
 

--- a/src/util/read-package-json.js
+++ b/src/util/read-package-json.js
@@ -1,7 +1,5 @@
 import fs from 'fs-extra';
 import path from 'path';
 
-export default async (dir) => {
-  const packageData = await fs.readFile(path.resolve(dir, 'package.json'), 'utf8');
-  return JSON.parse(packageData);
-};
+export default async dir =>
+  await fs.readJson(path.resolve(dir, 'package.json'));

--- a/test/slow/api_spec_slow.js
+++ b/test/slow/api_spec_slow.js
@@ -64,7 +64,7 @@ describe(`electron-forge API (with installer=${nodeInstaller})`, () => {
 
       it('should have set the .compilerc electron version to be a string', async () => {
         expectProjectPathExists('.compilerc', 'file');
-        const compilerc = JSON.parse(await fs.readFile(path.resolve(dir, '.compilerc')));
+        const compilerc = await fs.readJson(path.resolve(dir, '.compilerc'));
         const electronVersion = compilerc.env.development['application/javascript'].presets[0][1].targets.electron;
         expect(electronVersion).to.be.a('string');
         expect(electronVersion.split('.').length).to.equal(2);
@@ -242,7 +242,7 @@ describe(`electron-forge API (with installer=${nodeInstaller})`, () => {
       }
       packageJSON.homepage = 'http://www.example.com/';
       packageJSON.author = 'Test Author';
-      await fs.writeFile(path.resolve(dir, 'package.json'), JSON.stringify(packageJSON, null, 2));
+      await fs.writeJson(path.resolve(dir, 'package.json'), packageJSON);
     });
 
     it('can package to outDir without errors', async () => {
@@ -258,7 +258,7 @@ describe(`electron-forge API (with installer=${nodeInstaller})`, () => {
     it('can make from custom outDir without errors', async () => {
       const packageJSON = await readPackageJSON(dir);
       packageJSON.config.forge.make_targets[process.platform] = ['zip'];
-      await fs.writeFile(path.resolve(dir, 'package.json'), JSON.stringify(packageJSON));
+      await fs.writeJson(path.resolve(dir, 'package.json'), packageJSON);
 
       await forge.make({ dir, skipPackage: true, outDir: `${dir}/foo` });
 
@@ -276,7 +276,7 @@ describe(`electron-forge API (with installer=${nodeInstaller})`, () => {
     it('can package without errors', async () => {
       const packageJSON = await readPackageJSON(dir);
       packageJSON.config.forge.electronPackagerConfig.asar = true;
-      await fs.writeFile(path.resolve(dir, 'package.json'), JSON.stringify(packageJSON, null, 2));
+      await fs.writeJson(path.resolve(dir, 'package.json'), packageJSON);
 
       await forge.package({ dir });
     });


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Use `fs-extra`'s `readJson` and `writeJson` instead of rolling our own.