### PR TITLE
docs(packager): clarify why arch/dir/platform can't be set in Packager config

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,12 +180,12 @@ config object:
 You can set `electronPackagerConfig` with any of the options from
 [Electron Packager](https://github.com/electron-userland/electron-packager/blob/master/docs/api.md), except:
 
-* `arch` (use `--arch=...` command-line parameter so that it is available to each generator)
+* `arch` (use the `--arch` Forge command line argument instead, so it's available to all of Forge)
 * `asar.unpack` (use `asar.unpackDir` instead)
-* `dir`
+* `dir` (use the `cwd` Forge command line argument instead, so it's available to all of Forge)
 * `electronVersion` (uses the exact version specified for `electron-prebuilt-compile` in your `devDependencies`)
 * `out`
-* `platform`
+* `platform` (use the `--platform` Forge command line argument instead, so it's available to all of Forge)
 * `quiet`
 
 **NOTE:** You can also set your `forge` config property of your package.json to point to a JS file that exports the config object:

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ config object:
 You can set `electronPackagerConfig` with any of the options from
 [Electron Packager](https://github.com/electron-userland/electron-packager/blob/master/docs/api.md), except:
 
-* `arch`
+* `arch` (use `--arch=...` command-line parameter so that it is available to each generator)
 * `asar.unpack` (use `asar.unpackDir` instead)
 * `dir`
 * `electronVersion` (uses the exact version specified for `electron-prebuilt-compile` in your `devDependencies`)


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
I didn't understand why setting the `arch` property in `electronPackagerConfig` was not supported, so I chatted briefly with @malept and came to understand that doing so creates complications regarding making that information available to each generator whereas specifying it on the command line makes it globally available. I added a short note to the `README.md` file to summarize this since I think it might be helpful to other developers who might want to understand why this is the case. 

