### PR TITLE
fix(packager): package spinner isn't defined when asar.unpack is checked

### DIFF
--- a/src/api/package.js
+++ b/src/api/package.js
@@ -139,7 +139,6 @@ export default async (providedOptions = {}) => {
   });
   packageOpts.quiet = true;
   if (typeof packageOpts.asar === 'object' && packageOpts.asar.unpack) {
-    packagerSpinner.fail();
     throw new Error('electron-compile does not support asar.unpack yet.  Please use asar.unpackDir');
   }
 

--- a/test/slow/api_spec_slow.js
+++ b/test/slow/api_spec_slow.js
@@ -267,6 +267,16 @@ describe(`electron-forge API (with installer=${nodeInstaller})`, () => {
       await fs.remove(path.resolve(dir, 'out'));
     });
 
+    it('throws an error when asar.unpack is set', async () => {
+      let packageJSON = await readPackageJSON(dir);
+      packageJSON.config.forge.electronPackagerConfig.asar = { unpack: 'somedir/**' };
+      await fs.writeJson(path.join(dir, 'package.json'), packageJSON);
+      await expect(forge.package({ dir })).to.eventually.be.rejectedWith(/electron-compile does not support asar\.unpack/);
+      packageJSON = await readPackageJSON(dir);
+      delete packageJSON.config.forge.electronPackagerConfig.asar;
+      await fs.writeJson(path.join(dir, 'package.json'), packageJSON);
+    });
+
     it('can package without errors with native pre-gyp deps installed', async () => {
       await installDeps(dir, ['ref']);
       await forge.package({ dir });


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

ISSUES CLOSED: #396