### PR TITLE
Allow AWS credentials to be picked up from the environment or .aws/credentials file

### DIFF
--- a/src/publishers/s3.js
+++ b/src/publishers/s3.js
@@ -15,18 +15,22 @@ AWS.util.update(AWS.S3.prototype, {
 
 export default async (artifacts, packageJSON, forgeConfig, authToken, tag) => {
   const s3Config = forgeConfig.s3;
+
   s3Config.secretAccessKey = s3Config.secretAccessKey || authToken;
-  if (!(s3Config.accessKeyId && s3Config.secretAccessKey && s3Config.bucket)) {
+
+  const s3Client = new AWS.S3({
+    accessKeyId: s3Config.accessKeyId,
+    secretAccessKey: s3Config.secretAccessKey,
+  });
+
+  if (!s3Client.config.credentials || !s3Config.bucket) {
     throw 'In order to publish to s3 you must set the "s3.accessKeyId", "process.env.ELECTRON_FORGE_S3_SECRET_ACCESS_KEY" and "s3.bucket" properties in your forge config. See the docs for more info'; // eslint-disable-line
   }
 
   d('creating s3 client with options:', s3Config);
 
   const client = s3.createClient({
-    s3Client: new AWS.S3({
-      accessKeyId: s3Config.accessKeyId || process.env.AWS_ACCESS_KEY_ID,
-      secretAccessKey: s3Config.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY,
-    }),
+    s3Client,
   });
   client.s3.addExpect100Continue = () => {};
 


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

S3 publisher was failing to up the standard `.aws/credentials` file nor the standard `AWS_` env-vars. Instead it'd fail out early if you did not explicitly use the `package.json.config.s3` properties, which are preferred to env-vars/`credentials`.

May fix https://github.com/electron-userland/electron-forge/issues/259
