### PR TITLE
fix(installer): hdiutil output should be a string

### DIFF
--- a/src/util/hdiutil.js
+++ b/src/util/hdiutil.js
@@ -5,7 +5,7 @@ const d = debug('electron-forge:hdiutil');
 
 export const getMountedImages = async () => {
   const output = await spawnPromise('hdiutil', ['info']);
-  const mounts = output.split(/====\n/g);
+  const mounts = output.toString().split(/====\n/g);
   mounts.shift();
 
   const mountObjects = [];
@@ -26,8 +26,8 @@ export const getMountedImages = async () => {
 
 export const mountImage = async (filePath) => {
   d('mounting image:', filePath);
-  const output = await spawnPromise('hdiutil', ['attach', '-noautoopen', '-nobrowse', '-noverify', filePath]).toString();
-  const mountPath = /\/Volumes\/(.+)\n/g.exec(output)[1];
+  const output = await spawnPromise('hdiutil', ['attach', '-noautoopen', '-nobrowse', '-noverify', filePath]);
+  const mountPath = /\/Volumes\/(.+)\n/g.exec(output.toString())[1];
   d('mounted at:', mountPath);
 
   return {


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

cross-spawn-promise returns stdout as a buffer.

@zeke could you see if this fixes your problem? I'm kind of flying blind since I don't have a Mac.

Fixes #410.