### PR TITLE
[BREAKING CHANGE] feat(publisher): add dir to publisher args & convert args from positional to keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,15 +280,16 @@ Your promise must resolve with an array of the artifacts you generated.
 
 ### API for `publish` targets
 
-You must export a Function that returns a Promise.  Your function will be called with the following parameters.
+You must export a `Function` that returns a `Promise`.  Your function will be called with the following keyword parameters:
 
-* artifactPaths - An array of absolute paths to artifacts to publish
-* packageJSON - An object representing the users package.json file
-* forgeConfig - An object representing the users forgeConfig
-* authToken - The value of `--auth-token`
-* tag - The value of `--tag`
-* platform - The platform you are publishing for
-* arch - The arch you are publishing for
+* `dir` - The application directory
+* `artifactPaths` - An array of absolute paths to artifacts to publish
+* `packageJSON` - An object representing the user's `package.json` file
+* `forgeConfig` - An object representing the user's [`forgeConfig`](#config)
+* `authToken` - The value of `--auth-token`
+* `tag` - The value of `--tag`
+* `platform` - The platform you are publishing for
+* `arch` - The arch you are publishing for
 
 You should use `ora` to indicate your publish progress.
 

--- a/src/api/publish.js
+++ b/src/api/publish.js
@@ -139,7 +139,16 @@ const publish = async (providedOptions = {}) => {
       }
     });
 
-    await publisher(artifacts, packageJSON, forgeConfig, authToken, tag, makeOptions.platform || process.platform, makeOptions.arch || process.arch);
+    await publisher({
+      dir,
+      artifacts,
+      packageJSON,
+      forgeConfig,
+      authToken,
+      tag,
+      platform: makeOptions.platform || process.platform,
+      arch: makeOptions.arch || process.arch,
+    });
   }
 };
 

--- a/src/publishers/electron-release-server.js
+++ b/src/publishers/electron-release-server.js
@@ -21,7 +21,7 @@ const ersPlatform = (platform, arch) => {
   }
 };
 
-export default async (artifacts, packageJSON, forgeConfig, authToken, tag, platform, arch) => {
+export default async ({ artifacts, packageJSON, forgeConfig, platform, arch }) => {
   const ersConfig = forgeConfig.electronReleaseServer;
   if (!(ersConfig.baseUrl && ersConfig.username && ersConfig.password)) {
     throw 'In order to publish to ERS you must set the "electronReleaseServer.baseUrl", "electronReleaseServer.username" and "electronReleaseServer.password" properties in your forge config. See the docs for more info'; // eslint-disable-line

--- a/src/publishers/github.js
+++ b/src/publishers/github.js
@@ -5,7 +5,7 @@ import path from 'path';
 import asyncOra from '../util/ora-handler';
 import GitHub from '../util/github';
 
-export default async (artifacts, packageJSON, forgeConfig, authToken, tag) => {
+export default async ({ artifacts, packageJSON, forgeConfig, authToken, tag }) => {
   if (!(forgeConfig.github_repository && typeof forgeConfig.github_repository === 'object' &&
     forgeConfig.github_repository.owner && forgeConfig.github_repository.name)) {
     throw 'In order to publish to github you must set the "github_repository.owner" and "github_repository.name" properties in your forge config. See the docs for more info'; // eslint-disable-line

--- a/src/publishers/s3.js
+++ b/src/publishers/s3.js
@@ -13,7 +13,7 @@ AWS.util.update(AWS.S3.prototype, {
   },
 });
 
-export default async (artifacts, packageJSON, forgeConfig, authToken, tag) => {
+export default async ({ artifacts, packageJSON, forgeConfig, authToken, tag }) => {
   const s3Config = forgeConfig.s3;
 
   s3Config.secretAccessKey = s3Config.secretAccessKey || authToken;


### PR DESCRIPTION



* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

I added `dir` in preparation for the `snapcraft` publisher, and realized that there are way too many args for publisher modules. It makes more sense to have it be keyword args instead of positional.

BREAKING CHANGE:
Arguments for publisher modules have changed from positional to keyword.