### PR TITLE
feat(generic): allow specifying electron-prebuilt-compile via URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ docs
 .nyc_output
 coverage
 npm-debug.log
+package-lock.json
+yarn.lock
+yarn-error.log

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,4 @@ docs
 coverage
 npm-debug.log
 package-lock.json
-yarn.lock
 yarn-error.log

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "electron-forge-template-vue": "^1.0.2",
     "electron-packager": "^11.0.0",
     "electron-rebuild": "^1.6.0",
+    "exact-version": "^1.0.1",
     "form-data": "^2.1.4",
     "fs-extra": "^5.0.0",
     "glob": "^7.1.1",

--- a/src/api/make.js
+++ b/src/api/make.js
@@ -130,7 +130,7 @@ export default async (providedOptions = {}) => {
 
   await runHook(forgeConfig, 'preMake');
 
-  const electronVersion = getElectronVersion(packageJSON);
+  const electronVersion = await getElectronVersion(dir);
   for (const targetArch of parseArchs(platform, arch, electronVersion)) {
     const packageDir = path.resolve(outDir, `${appName}-${actualTargetPlatform}-${targetArch}`);
     if (!(await fs.pathExists(packageDir))) {

--- a/src/api/make.js
+++ b/src/api/make.js
@@ -4,6 +4,7 @@ import path from 'path';
 import { hostArch } from 'electron-packager/targets';
 
 import asyncOra from '../util/ora-handler';
+import getElectronVersion from '../util/get-electron-version';
 import getForgeConfig from '../util/forge-config';
 import runHook from '../util/hook';
 import { info, warn } from '../util/messages';
@@ -129,7 +130,8 @@ export default async (providedOptions = {}) => {
 
   await runHook(forgeConfig, 'preMake');
 
-  for (const targetArch of parseArchs(platform, arch, packageJSON.devDependencies['electron-prebuilt-compile'])) {
+  const electronVersion = getElectronVersion(packageJSON);
+  for (const targetArch of parseArchs(platform, arch, electronVersion)) {
     const packageDir = path.resolve(outDir, `${appName}-${actualTargetPlatform}-${targetArch}`);
     if (!(await fs.pathExists(packageDir))) {
       throw new Error(`Couldn't find packaged app at: ${packageDir}`);

--- a/src/api/package.js
+++ b/src/api/package.js
@@ -8,6 +8,7 @@ import packager from 'electron-packager';
 import { hostArch } from 'electron-packager/targets';
 
 import getForgeConfig from '../util/forge-config';
+import getElectronVersion from '../util/get-electron-version';
 import runHook from '../util/hook';
 import { warn } from '../util/messages';
 import realOra, { fakeOra } from '../util/ora';
@@ -136,6 +137,7 @@ export default async (providedOptions = {}) => {
     afterPruneHooks.push(...resolveHooks(forgeConfig.electronPackagerConfig.afterPrune, dir));
   }
 
+  const electronVersion = getElectronVersion(packageJSON);
   const packageOpts = Object.assign({
     asar: false,
     overwrite: true,
@@ -147,7 +149,7 @@ export default async (providedOptions = {}) => {
     arch,
     platform,
     out: outDir,
-    electronVersion: packageJSON.devDependencies['electron-prebuilt-compile'],
+    electronVersion,
   });
   packageOpts.quiet = true;
   if (typeof packageOpts.asar === 'object' && packageOpts.asar.unpack) {

--- a/src/api/package.js
+++ b/src/api/package.js
@@ -137,7 +137,6 @@ export default async (providedOptions = {}) => {
     afterPruneHooks.push(...resolveHooks(forgeConfig.electronPackagerConfig.afterPrune, dir));
   }
 
-  const electronVersion = getElectronVersion(packageJSON);
   const packageOpts = Object.assign({
     asar: false,
     overwrite: true,
@@ -149,7 +148,7 @@ export default async (providedOptions = {}) => {
     arch,
     platform,
     out: outDir,
-    electronVersion,
+    electronVersion: await getElectronVersion(dir),
   });
   packageOpts.quiet = true;
   if (typeof packageOpts.asar === 'object' && packageOpts.asar.unpack) {

--- a/src/api/start.js
+++ b/src/api/start.js
@@ -52,7 +52,7 @@ export default async (providedOptions = {}) => {
   }
 
   const forgeConfig = await getForgeConfig(dir);
-  const electronVersion = getElectronVersion(packageJSON);
+  const electronVersion = await getElectronVersion(dir);
 
   await rebuild(dir, electronVersion, process.platform, process.arch, forgeConfig.electronRebuildConfig);
 

--- a/src/api/start.js
+++ b/src/api/start.js
@@ -3,6 +3,7 @@ import { spawn } from 'child_process';
 import path from 'path';
 
 import asyncOra from '../util/ora-handler';
+import getElectronVersion from '../util/get-electron-version';
 import readPackageJSON from '../util/read-package-json';
 import rebuild from '../util/rebuild';
 import resolveDir from '../util/resolve-dir';
@@ -51,8 +52,9 @@ export default async (providedOptions = {}) => {
   }
 
   const forgeConfig = await getForgeConfig(dir);
+  const electronVersion = getElectronVersion(packageJSON);
 
-  await rebuild(dir, packageJSON.devDependencies['electron-prebuilt-compile'], process.platform, process.arch, forgeConfig.electronRebuildConfig);
+  await rebuild(dir, electronVersion, process.platform, process.arch, forgeConfig.electronRebuildConfig);
 
   const spawnOpts = {
     cwd: dir,

--- a/src/util/get-electron-version.js
+++ b/src/util/get-electron-version.js
@@ -7,21 +7,20 @@ const d = debug('electron-forge:util');
 export default async (projectDir) => {
   let result = null;
 
-  const modulesToExamine = ['electron-prebuilt-compile', 'electron-compile', 'electron'];
-  for (let i = 0; i < modulesToExamine.length; i += 1) {
-    const moduleName = modulesToExamine[i];
+  const modulesToExamine = ['electron-prebuilt-compile', 'electron', 'electron-prebuilt'];
+  for (const moduleName of modulesToExamine) {
     const moduleDir = path.join(projectDir, 'node_modules', moduleName);
     try {
       const packageJSON = await readPackageJSON(moduleDir);
       result = packageJSON.version;
       break;
     } catch (e) {
-      d(`Could not read package.json for moduleName=${moduleName}`);
+      d(`Could not read package.json for moduleName=${moduleName}`, e);
     }
   }
 
   if (!result) {
-    d(`getElectronVersion failed to determine electron version: projectDir=${projectDir}, result=${result}`);
+    d(`getElectronVersion failed to determine Electron version: projectDir=${projectDir}, result=${result}`);
   }
 
   return result;

--- a/src/util/get-electron-version.js
+++ b/src/util/get-electron-version.js
@@ -1,0 +1,6 @@
+const getElectronVersion = (packageJSON) => {
+  const electronVersion = packageJSON.devDependencies['electron-prebuilt-compile'];
+  return electronVersion;
+};
+
+export default getElectronVersion;

--- a/src/util/get-electron-version.js
+++ b/src/util/get-electron-version.js
@@ -1,6 +1,28 @@
-const getElectronVersion = (packageJSON) => {
-  const electronVersion = packageJSON.devDependencies['electron-prebuilt-compile'];
-  return electronVersion;
-};
+import debug from 'debug';
+import path from 'path';
+import readPackageJSON from './read-package-json';
 
-export default getElectronVersion;
+const d = debug('electron-forge:util');
+
+export default async (projectDir) => {
+  let result = null;
+
+  const modulesToExamine = ['electron-prebuilt-compile', 'electron-compile', 'electron'];
+  for (let i = 0; i < modulesToExamine.length; i += 1) {
+    const moduleName = modulesToExamine[i];
+    const moduleDir = path.join(projectDir, 'node_modules', moduleName);
+    try {
+      const packageJSON = await readPackageJSON(moduleDir);
+      result = packageJSON.version;
+      break;
+    } catch (e) {
+      d(`Could not read package.json for moduleName=${moduleName}`);
+    }
+  }
+
+  if (!result) {
+    d(`getElectronVersion failed to determine electron version: projectDir=${projectDir}, result=${result}`);
+  }
+
+  return result;
+};

--- a/src/util/resolve-dir.js
+++ b/src/util/resolve-dir.js
@@ -1,5 +1,6 @@
 import debug from 'debug';
 import fs from 'fs-extra';
+import isExactVersion from 'exact-version';
 import path from 'path';
 import readPackageJSON from './read-package-json';
 
@@ -16,8 +17,9 @@ export default async (dir) => {
       const packageJSON = await readPackageJSON(mDir);
 
       if (packageJSON.devDependencies && packageJSON.devDependencies['electron-prebuilt-compile']) {
-        if (!/[0-9]/.test(packageJSON.devDependencies['electron-prebuilt-compile'][0])) {
-          throw 'You must depend on an EXACT version of "electron-prebuilt-compile" not a range';
+        const version = packageJSON.devDependencies['electron-prebuilt-compile'];
+        if (!isExactVersion(version)) {
+          throw `You must depend on an EXACT version of "electron-prebuilt-compile" not a range (got "${version}")`;
         }
       } else {
         throw 'You must depend on "electron-prebuilt-compile" in your devDependencies';


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

* Replace [home-made RegEx](https://github.com/electron-userland/electron-forge/blob/012b152f94b04c4f4ba2aa27b23b572a846cd4b6/src/util/resolve-dir.js#L19) for testing whether or not the version string of `electron-prebuild-compile` with [`exact-version`](https://github.com/bendrucker/exact-version). 
  - Since this functionality is not closely related to electron / electron-forge, I think it makes sense to use and external library instead. Even though it is relatively small, there are [a lot of subtleties that should have test coverage](https://github.com/jacobq/exact-version/blob/feat/support-commitish/test.js).
  - The existing implementation does not correctly identify strings like `1.x`, `1.7.0 || 1.8.3`, or `1.0.0 - 1.5.0` as a range.

* Obtain electron version via new `getElectronVersion` util, which reads the `electron-prebuilt-compile`'s package.json (using the existing util `readPackageJSON`), which is guaranteed (by package.json / npm publish semantics) to be in a predictable format.

Why? One reason is that it should make it much easier to try the latest version of electron before a corresponding version of the official `electron-prebuilt-compile` module is published to NPM.