### PR TITLE
docs(publisher): fix publisher api doc in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Your promise must resolve with an array of the artifacts you generated.
 You must export a `Function` that returns a `Promise`.  Your function will be called with the following keyword parameters:
 
 * `dir` - The application directory
-* `artifactPaths` - An array of absolute paths to artifacts to publish
+* `artifacts` - An array of absolute paths to artifacts to publish
 * `packageJSON` - An object representing the user's `package.json` file
 * `forgeConfig` - An object representing the user's [`forgeConfig`](#config)
 * `authToken` - The value of `--auth-token`


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x ] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x ] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x ] The changes are appropriately documented (if applicable).
* [x ] The changes have sufficient test coverage (if applicable).
* [x ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

The documentation of the publish API doesn't match the actual API as implemented in [/src/api/publish.js#L144](https://github.com/electron-userland/electron-forge/blob/master/src/api/publish.js#L144). This fixes the documentation in README.md.