### PR TITLE
fix(publisher): call resolve() when electron-release-server publisher succeeds

### DIFF
--- a/packages/publisher/electron-release-server/src/PublisherERS.js
+++ b/packages/publisher/electron-release-server/src/PublisherERS.js
@@ -116,6 +116,7 @@ export default class PublisherERS extends PublisherBase {
             d('upload successful for asset:', artifactPath);
             uploaded += 1;
             updateSpinner();
+            resolve();
           } catch (err) {
             reject(err);
           }


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This should probably be backported to 5.x too.

ISSUES CLOSED: #460