### PR TITLE
I think when you say "mas" you mean "mac"?

### DIFF
--- a/src/api/make.js
+++ b/src/api/make.js
@@ -65,9 +65,9 @@ export default async (providedOptions = {}) => {
   const outDir = providedOptions.outDir || getCurrentOutDir(dir, forgeConfig);
 
   const actualTargetPlatform = platform;
-  platform = platform === 'mas' ? 'darwin' : platform;
-  if (!['darwin', 'win32', 'linux', 'mas'].includes(actualTargetPlatform)) {
-    throw new Error(`'${actualTargetPlatform}' is an invalid platform. Choices are 'darwin', 'mas', 'win32' or 'linux'`);
+  platform = platform === 'mac' ? 'darwin' : platform;
+  if (!['darwin', 'win32', 'linux', 'mac'].includes(actualTargetPlatform)) {
+    throw new Error(`'${actualTargetPlatform}' is an invalid platform. Choices are 'darwin', 'mac', 'win32' or 'linux'`);
   }
 
   const makers = {};


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Fix what appears to be a typo in the platform option.
