### PR TITLE
fix(packager): only call succeed on packagerSpinner if it exists (5.x)

### DIFF
--- a/src/api/package.js
+++ b/src/api/package.js
@@ -169,5 +169,7 @@ export default async (providedOptions = {}) => {
 
   await runHook(forgeConfig, 'postPackage');
 
-  packagerSpinner.succeed();
+  if (packagerSpinner) {
+    packagerSpinner.succeed();
+  }
 };


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Fixes #331. I'm not sure why the rebuild hook isn't being called to instantiate `packagerSpinner` , but :man_shrugging: 

Also need to forward-port.
