### PR TITLE
fix(core): install @electron-forge/cli to new projects

### DIFF
--- a/packages/api/core/src/api/init-scripts/init-npm.js
+++ b/packages/api/core/src/api/init-scripts/init-npm.js
@@ -11,7 +11,7 @@ import readPackageJSON from '../../util/read-package-json';
 const d = debug('electron-forge:init:npm');
 
 export const deps = ['electron-squirrel-startup'];
-export const devDeps = ['electron-forge'];
+export const devDeps = ['@electron-forge/cli'];
 export const exactDevDeps = ['electron'];
 
 export default async (dir) => {

--- a/packages/api/core/test/slow/api_spec_slow.js
+++ b/packages/api/core/test/slow/api_spec_slow.js
@@ -60,8 +60,8 @@ describe(`electron-forge API (with installer=${nodeInstaller})`, () => {
     it('should have installed the initial node_modules', async () => {
       expectProjectPathExists('node_modules', 'folder');
       expect(await fs.pathExists(path.resolve(dir, 'node_modules/electron')), 'electron should exist').to.equal(true);
-      expect(await fs.pathExists(path.resolve(dir, 'node_modules/babel-core')), 'babel-core should exist').to.equal(true);
-      expect(await fs.pathExists(path.resolve(dir, 'node_modules/electron-forge')), 'electron-forge should exist').to.equal(true);
+      expect(await fs.pathExists(path.resolve(dir, 'node_modules/electron-squirrel-startup')), 'electron-squirrel-startup should exist').to.equal(true);
+      expect(await fs.pathExists(path.resolve(dir, 'node_modules/@electron-forge/cli')), '@electron-forge/cli should exist').to.equal(true);
     });
 
     describe('lint', () => {


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Otherwise it points to `electron-forge@5`.