### PR TITLE
Add warning about master/6.x while it's under construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ jump right in to Electron development.
 
 ----
 
+## :rotating_light: :construction: **WARNING** :construction: :rotating_light:
+
+:building_construction:
+
+The `master` branch is a rewrite of Electron Forge that will eventually be the 6.x series. If you
+are looking for the 5.x series (the version currently published to NPM), please view the [5.x branch](https://github.com/electron-userland/electron-forge/tree/5.x).
+
+----
+
 [Website](https://electronforge.io) |
 [Goals](#project-goals) |
 [Usage](#usage) |


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).

**Summarize your changes:**

Point users to the 5.x docs for stable versions.