### PR TITLE
fix(publisher-github): remove deprecated option from @octokit/rest params (6.x)

### DIFF
--- a/packages/publisher/github/src/util/github.ts
+++ b/packages/publisher/github/src/util/github.ts
@@ -7,7 +7,6 @@ export default class GitHub {
 
   constructor(authToken: string | undefined = undefined, requireAuth: boolean = false, options: GitHubAPI.Options = {}) {
     this.options = merge(
-      { protocol: 'https' },
       options,
       { headers: { 'user-agent': 'Electron Forge' } },
     );

--- a/packages/publisher/github/test/github_spec.ts
+++ b/packages/publisher/github/test/github_spec.ts
@@ -50,17 +50,12 @@ describe('GitHub', () => {
 
     it('should be able to set the Enterprise URL settings', () => {
       const gh = new GitHub('1234', true, {
-        host: 'github.example.com',
-        port: 8443,
-        pathPrefix: '/enterprise',
+        baseUrl: 'https://github.example.com:8443/enterprise',
       });
       const api = gh.getGitHub();
 
       expect((api as any).options).to.deep.equal({
-        protocol: 'https',
-        host: 'github.example.com',
-        port: 8443,
-        pathPrefix: '/enterprise',
+        baseUrl: 'https://github.example.com:8443/enterprise',
         headers: {
           'user-agent': 'Electron Forge',
         },


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This broke with `@octokit/rest.js` 15.2.0.

Fixes #493.