### PR TITLE
feat(core): allow mutating packageJSON on load

### DIFF
--- a/packages/api/core/src/api/import.ts
+++ b/packages/api/core/src/api/import.ts
@@ -9,7 +9,7 @@ import { deps, devDeps, exactDevDeps } from './init-scripts/init-npm';
 import { setInitialForgeConfig } from '../util/forge-config';
 import { info, warn } from '../util/messages';
 import installDepList from '../util/install-dependencies';
-import readPackageJSON from '../util/read-package-json';
+import { readRawPackageJson } from '../util/read-package-json';
 
 const d = debug('electron-forge:import');
 
@@ -72,7 +72,7 @@ export default async ({
 
   await initGit(dir);
 
-  let packageJSON = await readPackageJSON(dir);
+  let packageJSON = await readRawPackageJson(dir);
   if (packageJSON.config && packageJSON.config.forge) {
     warn(interactive, 'It looks like this project is already configured for "electron-forge"'.green);
     if (typeof shouldContinueOnExisting === 'function') {
@@ -161,14 +161,14 @@ export default async ({
     await installDepList(dir, exactDevDeps, true, true);
   });
 
-  packageJSON = await readPackageJSON(dir);
+  packageJSON = await readRawPackageJson(dir);
 
   if (!packageJSON.version) {
     warn(interactive, 'Please set the "version" in your application\'s package.json'.yellow);
   }
 
   packageJSON.config = packageJSON.config || {};
-  const templatePackageJSON = await readPackageJSON(path.resolve(__dirname, '../../tmpl'));
+  const templatePackageJSON = await readRawPackageJson(path.resolve(__dirname, '../../tmpl'));
   packageJSON.config.forge = templatePackageJSON.config.forge;
   setInitialForgeConfig(packageJSON);
 

--- a/packages/api/core/src/api/init-scripts/init-npm.ts
+++ b/packages/api/core/src/api/init-scripts/init-npm.ts
@@ -6,7 +6,7 @@ import username from 'username';
 
 import { setInitialForgeConfig } from '../../util/forge-config';
 import installDepList from '../../util/install-dependencies';
-import readPackageJSON from '../../util/read-package-json';
+import { readRawPackageJson } from '../../util/read-package-json';
 
 const d = debug('electron-forge:init:npm');
 
@@ -22,7 +22,7 @@ export const exactDevDeps = ['electron'];
 
 export default async (dir: string) => {
   await asyncOra('Initializing NPM Module', async () => {
-    const packageJSON = await readPackageJSON(path.resolve(__dirname, '../../../tmpl'));
+    const packageJSON = await readRawPackageJson(path.resolve(__dirname, '../../../tmpl'));
     packageJSON.productName = packageJSON.name = path.basename(dir).toLowerCase();
     packageJSON.author = await username();
     setInitialForgeConfig(packageJSON);

--- a/packages/api/core/src/api/package.ts
+++ b/packages/api/core/src/api/package.ts
@@ -9,9 +9,9 @@ import pify from 'pify';
 import packager from 'electron-packager';
 
 import getForgeConfig from '../util/forge-config';
-import runHook from '../util/hook';
+import { runHook } from '../util/hook';
 import { warn } from '../util/messages';
-import readPackageJSON from '../util/read-package-json';
+import { readMutatedPackageJson } from '../util/read-package-json';
 import rebuildHook from '../util/rebuild';
 import requireSearch from '../util/require-search';
 import resolveDir from '../util/resolve-dir';
@@ -96,13 +96,13 @@ export default async ({
   }
   dir = resolvedDir;
 
-  const packageJSON = await readPackageJSON(dir);
+  const forgeConfig = await getForgeConfig(dir);
+  const packageJSON = await readMutatedPackageJson(dir, forgeConfig);
 
   if (!packageJSON.main) {
     throw 'packageJSON.main must be set to a valid entry point for your Electron app';
   }
 
-  const forgeConfig = await getForgeConfig(dir);
   const calculatedOutDir = outDir || getCurrentOutDir(dir, forgeConfig);
   let packagerSpinner: OraImpl | null = null;
 
@@ -133,7 +133,7 @@ export default async ({
   ];
 
   afterCopyHooks.push(async (buildPath, electronVersion, pPlatform, pArch, done) => {
-    const copiedPackageJSON = await readPackageJSON(buildPath);
+    const copiedPackageJSON = await readMutatedPackageJson(buildPath, forgeConfig);
     if (copiedPackageJSON.config && copiedPackageJSON.config.forge) {
       delete copiedPackageJSON.config.forge;
     }

--- a/packages/api/core/src/api/publish.ts
+++ b/packages/api/core/src/api/publish.ts
@@ -7,7 +7,7 @@ import fs from 'fs-extra';
 import path from 'path';
 
 import getForgeConfig from '../util/forge-config';
-import readPackageJSON from '../util/read-package-json';
+import { readMutatedPackageJson } from '../util/read-package-json';
 import resolveDir from '../util/resolve-dir';
 import PublishState from '../util/publish-state';
 import getCurrentOutDir from '../util/out-dir';
@@ -73,9 +73,9 @@ const publish = async ({
     throw 'Can\'t resume a dry run and use the provided makeResults at the same time';
   }
 
-  let packageJSON = await readPackageJSON(dir);
-
   const forgeConfig = await getForgeConfig(dir);
+  let packageJSON = await readMutatedPackageJson(dir, forgeConfig);
+
   const calculatedOutDir = outDir || getCurrentOutDir(dir, forgeConfig);
   const dryRunDir = path.resolve(calculatedOutDir, 'publish-dry-run');
 

--- a/packages/api/core/src/api/start.ts
+++ b/packages/api/core/src/api/start.ts
@@ -4,11 +4,11 @@ import { StartOptions, ForgePlatform, ForgeArch } from '@electron-forge/shared-t
 import { spawn, ChildProcess } from 'child_process';
 import path from 'path';
 
-import readPackageJSON from '../util/read-package-json';
+import { readMutatedPackageJson } from '../util/read-package-json';
 import rebuild from '../util/rebuild';
 import resolveDir from '../util/resolve-dir';
 import getForgeConfig from '../util/forge-config';
-import runHook from '../util/hook';
+import { runHook } from '../util/hook';
 import getElectronVersion from '../util/electron-version';
 
 export { StartOptions };
@@ -32,13 +32,12 @@ export default async ({
     dir = resolvedDir;
   });
 
-  const packageJSON = await readPackageJSON(dir);
+  const forgeConfig = await getForgeConfig(dir);
+  const packageJSON = await readMutatedPackageJson(dir, forgeConfig);
 
   if (!packageJSON.version) {
     throw `Please set your application's 'version' in '${dir}/package.json'.`;
   }
-
-  const forgeConfig = await getForgeConfig(dir);
 
   await rebuild(
     dir,

--- a/packages/api/core/src/util/forge-config.ts
+++ b/packages/api/core/src/util/forge-config.ts
@@ -3,9 +3,9 @@ import fs from 'fs-extra';
 import path from 'path';
 import _template from 'lodash.template';
 
-import readPackageJSON from './read-package-json';
+import { readRawPackageJson } from './read-package-json';
 import PluginInterface from './plugin-interface';
-import runHook from './hook';
+import { runMutatingHook } from './hook';
 
 const underscoreCase = (str: string) => str.replace(/(.)([A-Z][a-z]+)/g, '$1_$2').replace(/([a-z0-9])([A-Z])/g, '$1_$2').toUpperCase();
 
@@ -70,7 +70,7 @@ export function fromBuildIdentifier<T>(map: { [key: string]: T | undefined }) {
 }
 
 export default async (dir: string) => {
-  const packageJSON = await readPackageJSON(dir);
+  const packageJSON = await readRawPackageJson(dir);
   let forgeConfig: ForgeConfig | string = packageJSON.config.forge;
 
   if (typeof forgeConfig === 'string' && (await fs.pathExists(path.resolve(dir, forgeConfig)) || await fs.pathExists(path.resolve(dir, `${forgeConfig}.js`)))) {
@@ -109,7 +109,7 @@ export default async (dir: string) => {
 
   forgeConfig.pluginInterface = new PluginInterface(dir, forgeConfig);
 
-  await runHook(forgeConfig, 'resolveForgeConfig', forgeConfig);
+  forgeConfig = await runMutatingHook(forgeConfig, 'resolveForgeConfig', forgeConfig);
 
   return proxify<ForgeConfig>(forgeConfig.buildIdentifier || '', forgeConfig, 'ELECTRON_FORGE');
 };

--- a/packages/api/core/src/util/hook.ts
+++ b/packages/api/core/src/util/hook.ts
@@ -3,7 +3,7 @@ import debug from 'debug';
 
 const d = debug('electron-forge:hook');
 
-export default async (forgeConfig: ForgeConfig, hookName: string, ...hookArgs: any[]) => {
+export const runHook = async (forgeConfig: ForgeConfig, hookName: string, ...hookArgs: any[]) => {
   const hooks = forgeConfig.hooks;
   if (hooks) {
     d(`hook triggered: ${hookName}`);
@@ -13,4 +13,19 @@ export default async (forgeConfig: ForgeConfig, hookName: string, ...hookArgs: a
     }
   }
   await forgeConfig.pluginInterface.triggerHook(hookName, hookArgs);
+};
+
+export const runMutatingHook = async <T>(forgeConfig: ForgeConfig, hookName: string, item: T): Promise<T> => {
+  const hooks = forgeConfig.hooks;
+  if (hooks) {
+    d(`hook triggered: ${hookName}`);
+    if (typeof hooks[hookName] === 'function') {
+      d('calling mutating hook:', hookName, 'with item:', item);
+      const result = await hooks[hookName](forgeConfig, item);
+      if (typeof result !== 'undefined') {
+        item = result;
+      }
+    }
+  }
+  return await forgeConfig.pluginInterface.triggerMutatingHook(hookName, item);
 };

--- a/packages/api/core/src/util/plugin-interface.ts
+++ b/packages/api/core/src/util/plugin-interface.ts
@@ -54,6 +54,18 @@ export default class PluginInterface implements IForgePluginInterface {
     }
   }
 
+  async triggerMutatingHook<T>(hookName: string, item: T) {
+    for (const plugin of this.plugins) {
+      if (typeof plugin.getHook === 'function') {
+        const hook = plugin.getHook(hookName);
+        if (hook) {
+          item = await hook(this.config, item);
+        }
+      }
+    }
+    return item;
+  }
+
   async overrideStartLogic(opts: StartOptions) {
     let newStartFn;
     const claimed = [];

--- a/packages/api/core/src/util/read-package-json.ts
+++ b/packages/api/core/src/util/read-package-json.ts
@@ -1,5 +1,11 @@
+import { ForgeConfig } from '@electron-forge/shared-types';
 import fs from 'fs-extra';
 import path from 'path';
 
-export default async (dir: string) =>
+import { runMutatingHook } from './hook';
+
+export const readRawPackageJson =  async (dir: string) =>
   await fs.readJson(path.resolve(dir, 'package.json'));
+
+export const readMutatedPackageJson = async (dir: string, forgeConfig: ForgeConfig) => 
+  runMutatingHook(forgeConfig, 'readPackageJson', await readRawPackageJson(dir));

--- a/packages/api/core/src/util/resolve-dir.ts
+++ b/packages/api/core/src/util/resolve-dir.ts
@@ -1,11 +1,14 @@
 import debug from 'debug';
 import fs from 'fs-extra';
 import path from 'path';
-import readPackageJSON from './read-package-json';
+import { readRawPackageJson } from './read-package-json';
 import getElectronVersion from './electron-version';
 
 const d = debug('electron-forge:project-resolver');
 
+// FIXME: If we want getElectronVersion to be overridable by plugins
+//        and / or forge config then we need to be able to resolve
+//        the dir without calling getElectronVersion
 export default async (dir: string) => {
   let mDir = dir;
   let prevDir;
@@ -14,8 +17,10 @@ export default async (dir: string) => {
     const testPath = path.resolve(mDir, 'package.json');
     d('searching for project in:', mDir);
     if (await fs.pathExists(testPath)) {
-      const packageJSON = await readPackageJSON(mDir);
+      const packageJSON = await readRawPackageJson(mDir);
 
+      // TODO: Move this check to inside the forge config resolver and use
+      //       mutatedPackageJson reader
       const electronVersion = getElectronVersion(packageJSON);
       if (electronVersion) {
         if (!/[0-9]/.test(electronVersion[0])) {

--- a/packages/api/core/test/fast/hook_spec.ts
+++ b/packages/api/core/test/fast/hook_spec.ts
@@ -1,28 +1,46 @@
 import { ForgeConfig } from '@electron-forge/shared-types';
 import { expect } from 'chai';
-import { stub } from 'sinon';
+import { stub, SinonStub } from 'sinon';
 
-import runHook from '../../src/util/hook';
+import { runHook, runMutatingHook } from '../../src/util/hook';
 
 const fakeConfig = {
   pluginInterface: {
     triggerHook: async () => false,
+    triggerMutatingHook: async (_: any, item: any) => item,
   },
 } as any as ForgeConfig;
 
-describe('runHook', () => {
-  it('should not error when running non existent hooks', async () => {
-    await runHook(Object.assign({}, fakeConfig), 'magic');
+describe('hooks', () => {
+  describe('runHook', () => {
+    it('should not error when running non existent hooks', async () => {
+      await runHook(Object.assign({}, fakeConfig), 'magic');
+    });
+  
+    it('should not error when running a hook that is not a function', async () => {
+      await runHook(Object.assign({ hooks: { myHook: 'abc' } }, fakeConfig), 'abc');
+    });
+  
+    it('should run the hook if it is provided as a function', async () => {
+      const myStub = stub();
+      myStub.returns(Promise.resolve());
+      await runHook(Object.assign({ hooks: { myHook: myStub } }, fakeConfig), 'myHook');
+      expect(myStub.callCount).to.equal(1);
+    });
   });
 
-  it('should not error when running a hook that is not a function', async () => {
-    await runHook(Object.assign({ hooks: { myHook: 'abc' } }, fakeConfig), 'abc');
-  });
+  describe('runMutatingHook', () => {
+    it('should return the input when running non existent hooks', async () => {
+      expect(await runMutatingHook(Object.assign({}, fakeConfig), 'magic', 'input')).to.equal('input');
+    });
 
-  it('should run the hook if it is provided as a function', async () => {
-    const myStub = stub();
-    myStub.returns(Promise.resolve());
-    await runHook(Object.assign({ hooks: { myHook: myStub } }, fakeConfig), 'myHook');
-    expect(myStub.callCount).to.equal(1);
+    it('should return the mutated input when returned from a hook', async () => {
+      fakeConfig.pluginInterface.triggerMutatingHook = stub().returnsArg(1);
+      const myStub = stub();
+      myStub.returns(Promise.resolve('magneto'));
+      const output = await runMutatingHook(Object.assign({ hooks: { myHook: myStub } }, fakeConfig), 'myHook', 'input');
+      expect(output).to.equal('magneto');
+      expect((fakeConfig.pluginInterface.triggerMutatingHook as SinonStub).firstCall.args[1]).to.equal('magneto');
+    });
   });
 });

--- a/packages/api/core/test/fast/publish_spec.ts
+++ b/packages/api/core/test/fast/publish_spec.ts
@@ -33,7 +33,9 @@ describe('publish', () => {
     publish = proxyquire.noCallThru().load('../../src/api/publish', {
       './make': async (...args: any[]) => makeStub(...args),
       '../util/resolve-dir': async (dir: string) => resolveStub(dir),
-      '../util/read-package-json': () => Promise.resolve(require('../fixture/dummy_app/package.json')),
+      '../util/read-package-json': {
+        readMutatedPackageJson: () => Promise.resolve(require('../fixture/dummy_app/package.json')),
+      },
       '../util/forge-config': async () => {
         const config = await (require('../../src/util/forge-config').default(path.resolve(__dirname, '../fixture/dummy_app')));
 

--- a/packages/api/core/test/fast/read-package-json_spec.ts
+++ b/packages/api/core/test/fast/read-package-json_spec.ts
@@ -1,10 +1,34 @@
 import path from 'path';
 import { expect } from 'chai';
 
-import readPackageJSON from '../../src/util/read-package-json';
+import { readRawPackageJson, readMutatedPackageJson } from '../../src/util/read-package-json';
 
 describe('read-package-json', () => {
-  it('should find a package.json file from the given directory', async () => {
-    expect(await readPackageJSON(path.resolve(__dirname, '../..'))).to.deep.equal(require('../../package.json'));
+  describe('readRawPackageJson', () => {
+    it('should find a package.json file from the given directory', async () => {
+      expect(await readRawPackageJson(path.resolve(__dirname, '../..'))).to.deep.equal(require('../../package.json'));
+    });
+  });
+
+  describe('readMutatedPackageJson', () => {
+    it('should find a package.json file from the given directory', async () => {
+      expect(await readMutatedPackageJson(
+        path.resolve(__dirname, '../..'), {
+          pluginInterface: {
+            triggerMutatingHook: (_: any, pj: any) => Promise.resolve(pj),
+          },
+        } as any,
+      )).to.deep.equal(require('../../package.json'));
+    });
+
+    it('should allow mutations from hooks', async () => {
+      expect(await readMutatedPackageJson(
+        path.resolve(__dirname, '../..'), {
+          pluginInterface: {
+            triggerMutatingHook: () => Promise.resolve('test_mut'),
+          },
+        } as any,
+      )).to.deep.equal('test_mut');
+    });
   });
 });

--- a/packages/api/core/test/fast/start_spec.ts
+++ b/packages/api/core/test/fast/start_spec.ts
@@ -29,7 +29,9 @@ describe('start', () => {
       }),
       [path.resolve(__dirname, 'node_modules/electron')]: 'fake_electron_path',
       '../util/resolve-dir': async (dir: string) => resolveStub(dir),
-      '../util/read-package-json': () => Promise.resolve(packageJSON),
+      '../util/read-package-json': {
+        readMutatedPackageJson: () => Promise.resolve(packageJSON),
+      },
       '../util/rebuild': () => Promise.resolve(),
       child_process: {
         spawn: spawnStub,

--- a/packages/api/core/test/slow/api_spec_slow.ts
+++ b/packages/api/core/test/slow/api_spec_slow.ts
@@ -8,7 +8,7 @@ import proxyquire from 'proxyquire';
 
 import { createDefaultCertificate } from '@electron-forge/maker-appx';
 import installDeps from '../../src/util/install-dependencies';
-import readPackageJSON from '../../src/util/read-package-json';
+import { readRawPackageJson } from '../../src/util/read-package-json';
 import yarnOrNpm from '../../src/util/yarn-or-npm';
 import { InitOptions } from '../../src/api';
 
@@ -155,7 +155,7 @@ describe(`electron-forge API (with installer=${nodeInstaller})`, () => {
     });
 
     it('creates a forge config', async () => {
-      const packageJSON = await readPackageJSON(dir);
+      const packageJSON = await readRawPackageJson(dir);
       packageJSON.name = 'Name';
       packageJSON.productName = 'Product Name';
       packageJSON.customProp = 'propVal';
@@ -176,7 +176,7 @@ describe(`electron-forge API (with installer=${nodeInstaller})`, () => {
           },
         },
         customProp,
-      } = await readPackageJSON(dir);
+      } = await readRawPackageJson(dir);
 
       expect(winstallerName).to.equal('Name');
       expect(customProp).to.equal('propVal');
@@ -195,7 +195,7 @@ describe(`electron-forge API (with installer=${nodeInstaller})`, () => {
       dirID += 1;
       await forge.init({ dir });
 
-      const packageJSON = await readPackageJSON(dir);
+      const packageJSON = await readRawPackageJson(dir);
       packageJSON.name = 'testapp';
       packageJSON.productName = 'Test App';
       packageJSON.config.forge.packagerConfig.asar = false;
@@ -215,11 +215,11 @@ describe(`electron-forge API (with installer=${nodeInstaller})`, () => {
     });
 
     it('throws an error when all is set', async () => {
-      let packageJSON = await readPackageJSON(dir);
+      let packageJSON = await readRawPackageJson(dir);
       packageJSON.config.forge.packagerConfig.all = true;
       await fs.writeJson(path.join(dir, 'package.json'), packageJSON);
       await expect(forge.package({ dir })).to.eventually.be.rejectedWith(/packagerConfig\.all is not supported by Electron Forge/);
-      packageJSON = await readPackageJSON(dir);
+      packageJSON = await readRawPackageJson(dir);
       delete packageJSON.config.forge.packagerConfig.all;
       await fs.writeJson(path.join(dir, 'package.json'), packageJSON);
     });
@@ -235,7 +235,7 @@ describe(`electron-forge API (with installer=${nodeInstaller})`, () => {
     });
 
     it('can make from custom outDir without errors', async () => {
-      const packageJSON = await readPackageJSON(dir);
+      const packageJSON = await readRawPackageJson(dir);
       packageJSON.config.forge.makers = [{ name: require.resolve('@electron-forge/maker-zip') }];
       await fs.writeJson(path.resolve(dir, 'package.json'), packageJSON);
 
@@ -253,7 +253,7 @@ describe(`electron-forge API (with installer=${nodeInstaller})`, () => {
     });
 
     it('can package without errors', async () => {
-      const packageJSON = await readPackageJSON(dir);
+      const packageJSON = await readRawPackageJson(dir);
       delete packageJSON.dependencies.ref;
       packageJSON.config.forge.packagerConfig.asar = true;
       await fs.writeJson(path.resolve(dir, 'package.json'), packageJSON);
@@ -276,7 +276,7 @@ describe(`electron-forge API (with installer=${nodeInstaller})`, () => {
       });
 
       it('should not affect the actual forge config', async () => {
-        const normalPackageJSON = await readPackageJSON(dir);
+        const normalPackageJSON = await readRawPackageJson(dir);
         expect(normalPackageJSON).to.have.nested.property('config.forge');
       });
 
@@ -316,7 +316,7 @@ describe(`electron-forge API (with installer=${nodeInstaller})`, () => {
       const testMakeTarget = function testMakeTarget(target: () => { name: string }, shouldPass: boolean, ...options: any[]) {
         describe(`make (with target=${path.basename(target().name)})`, async () => {
           before(async () => {
-            const packageJSON = await readPackageJSON(dir);
+            const packageJSON = await readRawPackageJson(dir);
             packageJSON.config.forge.makers = [target()];
             await fs.writeFile(path.resolve(dir, 'package.json'), JSON.stringify(packageJSON));
           });

--- a/packages/plugin/auto-unpack-natives/src/AutoUnpackNativesPlugin.ts
+++ b/packages/plugin/auto-unpack-natives/src/AutoUnpackNativesPlugin.ts
@@ -36,5 +36,6 @@ export default class AutoUnpackNativesPlugin extends PluginBase<AutoUnpackNative
     } else {
       forgeConfig.packagerConfig.asar.unpack = newUnpack;
     }
+    return forgeConfig;
   }
 }

--- a/packages/utils/types/src/index.ts
+++ b/packages/utils/types/src/index.ts
@@ -7,9 +7,10 @@ import { RebuildOptions } from 'electron-rebuild/lib/src/rebuild';
 // declare module '@electron-forge/shared-types' {
   export type ForgePlatform = 'darwin' | 'mas' | 'win32' | 'linux';
   export type ForgeArch = 'ia32' | 'x64' | 'armv7l' | 'arm'; 
-  export type ForgeHookFn = (forgeConfig: ForgeConfig, ...args: any[]) => Promise<void>;
+  export type ForgeHookFn = (forgeConfig: ForgeConfig, ...args: any[]) => Promise<any>;
   export interface IForgePluginInterface {
     triggerHook(hookName: string, hookArgs: any[]): Promise<void>;
+    triggerMutatingHook<T>(hookName: string, item: T): Promise<any>;
     overrideStartLogic(opts: any): Promise<ChildProcess | false>;
   }
   export interface ForgeConfig {


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

In order to override fields like "version" at build time. This provides the ability
to intercept forge loading your package.json file and modify the JS object we read in

Docs: https://v6.electronforge.io/configuration#readpackagejson
