### PR TITLE
Finding right path to `electron-forge-start.js` for VSCode Debugger (fixing #535)

### DIFF
--- a/packages/api/cli/script/vscode.cmd
+++ b/packages/api/cli/script/vscode.cmd
@@ -4,6 +4,6 @@ SETLOCAL
 SET FORGE_ARGS=%*
 
 SET FORGE_ARGS=%FORGE_ARGS: =~ ~%
-node "%~dp0/../../@electron-forge/cli/dist/electron-forge-start.js" --vscode -- ~%FORGE_ARGS%~
+node "%~dp0/../../../@electron-forge/cli/dist/electron-forge-start.js" --vscode -- ~%FORGE_ARGS%~
 
 ENDLOCAL

--- a/packages/api/cli/script/vscode.sh
+++ b/packages/api/cli/script/vscode.sh
@@ -4,4 +4,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ARGS=$@
 ARGS=${ARGS// /\~ \~}
 
-node $DIR/../@electron-forge/cli/dist/electron-forge-start --vscode -- \~$ARGS\~
+node $DIR/../../../@electron-forge/cli/dist/electron-forge-start --vscode -- \~$ARGS\~


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [ ] The changes have sufficient test coverage (if applicable).
* [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

It must fix #535 because of the missed parent directory in vscode debugger scripts.

Please test it in Unix shell, because `*.sh` script double misses upper directory or it's intended behavior.