### PR TITLE
fix(core): stops breaking regexps in the config parser

### DIFF
--- a/packages/api/core/src/util/forge-config.ts
+++ b/packages/api/core/src/util/forge-config.ts
@@ -16,7 +16,8 @@ const proxify = <T extends object>(buildIdentifier: string | (() => string), obj
   }
 
   Object.keys(object).forEach((key) => {
-    if (typeof (object as any)[key] === 'object' && key !== 'pluginInterface') {
+    const val = (object as any)[key];
+    if (typeof val === 'object' && key !== 'pluginInterface' && !(val instanceof RegExp)) {
       (newObject as any)[key] = proxify(buildIdentifier, (object as any)[key], `${envPrefix}_${underscoreCase(key)}`);
     } else {
       (newObject as any)[key] = (object as any)[key];

--- a/packages/api/core/test/fast/forge-config_spec.ts
+++ b/packages/api/core/test/fast/forge-config_spec.ts
@@ -57,6 +57,7 @@ describe('forge-config', () => {
     delete config.sub;
     delete config.topLevelProp;
     delete config.topLevelUndef;
+    delete config.regexp;
     expect(config).to.be.deep.equal(Object.assign({}, defaults, {
       buildIdentifier: 'beta',
       packagerConfig: { foo: 'bar', baz: {} },

--- a/packages/api/core/test/fast/forge-config_spec.ts
+++ b/packages/api/core/test/fast/forge-config_spec.ts
@@ -109,4 +109,11 @@ describe('forge-config', () => {
     const conf: any = await findConfig(path.resolve(__dirname, '../fixture/dummy_js_conf'));
     expect(Array.isArray(conf.sub.prop.inArray)).to.equal(true, 'original array should be recognized as array');
   });
+
+  it('should leave regexps intact', async () => {
+    const conf: any = await findConfig(path.resolve(__dirname, '../fixture/dummy_js_conf'));
+    expect(conf.regexp).to.be.instanceOf(RegExp);
+    expect(conf.regexp.test('foo')).to.equal(true, 'regexp should match foo');
+    expect(conf.regexp.test('bar')).to.equal(false, 'regexp should not match bar');
+  });
 });

--- a/packages/api/core/test/fixture/dummy_js_conf/forge.config.js
+++ b/packages/api/core/test/fixture/dummy_js_conf/forge.config.js
@@ -10,6 +10,7 @@ module.exports = {
   magicFn: () => 'magic result',
   topLevelProp: fromBuildIdentifier({ beta: 'foo' }),
   topLevelUndef: fromBuildIdentifier({ stable: 'heya' }),
+  regexp: /foo/,
   sub: {
     prop: {
       inArray: [


### PR DESCRIPTION
Fixes #557 

Basically `typeof /foo/ === 'object'`