### PR TITLE
fix(core): keep track of application restarts and close stdin pipe correctly

### DIFF
--- a/packages/api/core/test/fast/start_spec.ts
+++ b/packages/api/core/test/fast/start_spec.ts
@@ -11,7 +11,7 @@ describe('start', () => {
   let packageJSON: any;
   let resolveStub: SinonStub;
   let spawnStub: SinonStub;
-  let shouldOverride: boolean;
+  let shouldOverride: any;
   let processOn: SinonStub;
 
   beforeEach(() => {
@@ -58,7 +58,7 @@ describe('start', () => {
 
   it('should not spawn if a plugin overrides the start command', async () => {
     resolveStub.returnsArg(0);
-    shouldOverride = true;
+    shouldOverride = { on: () => {} };
     await start({
       dir: __dirname,
       interactive: false,
@@ -172,12 +172,13 @@ describe('start', () => {
 
   it('should resolve with a handle to the spawned instance', async () => {
     resolveStub.returnsArg(0);
-    spawnStub.returns('child');
+    const fakeChild = { on: () => {} };
+    spawnStub.returns(fakeChild);
 
     await expect(start({
       dir: __dirname,
       interactive: false,
       enableLogging: true,
-    })).to.eventually.equal('child');
+    })).to.eventually.equal(fakeChild);
   });
 });


### PR DESCRIPTION
Previously we weren't tracking application restarts in the CLI module or closing our stdin pipe once
the child app had quit

ISSUES CLOSED: #545 

