### PR TITLE
[5.x] fix(maker): return the correct outPath for a deb prerelease version

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     }
   },
   "optionalDependencies": {
-    "electron-installer-debian": "^0.8.0",
+    "electron-installer-debian": "^1.0.0",
     "electron-installer-dmg": "^0.2.0",
     "electron-installer-flatpak": "^0.8.0",
     "electron-installer-redhat": "^0.5.0",

--- a/src/makers/linux/deb.js
+++ b/src/makers/linux/deb.js
@@ -22,7 +22,7 @@ export default async ({ dir, targetArch, forgeConfig, packageJSON }) => {
   const arch = debianArch(targetArch);
   const config = populateConfig({ forgeConfig, configKey: 'electronInstallerDebian', targetArch });
   const name = config.options.name || packageJSON.name;
-  const versionedName = `${name}_${packageJSON.version}_${arch}`;
+  const versionedName = `${name}_${installer.transformVersion(packageJSON.version)}_${arch}`;
   const outPath = path.resolve(dir, '../make', `${versionedName}.deb`);
 
   await ensureFile(outPath);

--- a/test/fast/makers/deb_spec.js
+++ b/test/fast/makers/deb_spec.js
@@ -21,6 +21,7 @@ describe('deb maker', () => {
   beforeEach(() => {
     ensureFileStub = stub().returns(Promise.resolve());
     eidStub = stub().resolves();
+    eidStub.transformVersion = version => version;
     forgeConfig = { electronInstallerDebian: {} };
 
     debModule = proxyquire.noPreserveCache().noCallThru().load('../../../src/makers/linux/deb', {
@@ -61,4 +62,14 @@ describe('deb maker', () => {
       dest: path.resolve(dir, '..', 'make'),
     });
   });
+
+  if (process.platform === 'linux') {
+    it('should return the proper pre-release version in the outPath', async () => {
+      eidStub.transformVersion = require('electron-installer-debian').transformVersion;
+
+      packageJSON.version = '1.2.3-beta.4';
+      const outPath = await debMaker({ dir, appName, targetArch, forgeConfig, packageJSON });
+      expect(outPath).to.match(/1\.2\.3~beta\.4/);
+    });
+  }
 });


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This is a backport of #584.

ISSUES CLOSED: #583