### PR TITLE
fix(maker-wix): correct path to distributable

### DIFF
--- a/packages/api/core/test/slow/api_spec_slow.ts
+++ b/packages/api/core/test/slow/api_spec_slow.ts
@@ -329,6 +329,7 @@ describe(`electron-forge API (with installer=${nodeInstaller})`, () => {
                 for (const outputResult of outputs) {
                   for (const output of outputResult.artifacts) {
                     expect(await fs.pathExists(output)).to.equal(true);
+                    expect(output.startsWith(path.resolve(dir, 'out', 'make'))).to.equal(true);
                   }
                 }
               });

--- a/packages/maker/wix/src/MakerWix.ts
+++ b/packages/maker/wix/src/MakerWix.ts
@@ -24,7 +24,7 @@ export default class MakerWix extends MakerBase<MakerWixConfig> {
     packageJSON,
     appName,
   }: MakerOptions) {
-    const outPath = path.resolve(makeDir, `/wix/${targetArch}`);
+    const outPath = path.resolve(makeDir, `wix/${targetArch}`);
     await this.ensureDirectory(outPath);
 
     const creator = new MSICreator(Object.assign({


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Fixes #608.

