### PR TITLE
fix(core): show the package manager stderr when installing deps fails

### DIFF
--- a/packages/api/core/src/util/install-dependencies.ts
+++ b/packages/api/core/src/util/install-dependencies.ts
@@ -41,6 +41,6 @@ export default async (
       stdio: 'pipe',
     });
   } catch (err) {
-    throw new Error(`Failed to install modules: ${JSON.stringify(deps)}\n\nWith output: ${err.message}`);
+    throw new Error(`Failed to install modules: ${JSON.stringify(deps)}\n\nWith output: ${err.message}\n${err.stderr.toString()}`);
   }
 };


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* <del>The changes are appropriately documented</del> (not applicable).
* <del>The changes have sufficient test coverage</del> (not applicable).
* <del>The testsuite passes successfully on my local machine</del> (not applicable).

**Summarize your changes:**

We used to have this when `--verbose` was set, but this should avoid some unnecessary GitHub issues
when it's always part of the exception.

The code change itself is based on looking at the [`cross-spawn-promise` usage](https://github.com/zentrick/cross-spawn-promise#usage).