### PR TITLE
Update MakerWix.ts

### DIFF
--- a/packages/maker/wix/src/MakerWix.ts
+++ b/packages/maker/wix/src/MakerWix.ts
@@ -24,7 +24,7 @@ export default class MakerWix extends MakerBase<MakerWixConfig> {
     packageJSON,
     appName,
   }: MakerOptions) {
-    const outPath = path.resolve(makeDir, `/wix/${targetArch}`);
+    const outPath = path.resolve(makeDir, `./wix/${targetArch}`);
     await this.ensureDirectory(outPath);
 
     const creator = new MSICreator(Object.assign({


### PR DESCRIPTION
path.resolve with an absolute path always resolves to that path

<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [ ] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [ ] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [ ] The changes are appropriately documented (if applicable).
* [ ] The changes have sufficient test coverage (if applicable).
* [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**


