### PR TITLE
[5.x] fix(generic): throw an error when there's no node_modules folder in the project

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "electron-installer-dmg": "^0.2.0",
     "electron-installer-flatpak": "^0.8.0",
     "electron-installer-redhat": "^0.5.0",
-    "electron-installer-snap": "^2.0.0",
+    "electron-installer-snap": "^3.0.1",
     "electron-windows-store": "^0.12.0",
     "electron-winstaller": "^2.5.0",
     "electron-wix-msi": "^2.1.1"

--- a/src/util/rebuild.js
+++ b/src/util/rebuild.js
@@ -3,6 +3,10 @@ import rebuild from 'electron-rebuild';
 import asyncOra from '../util/ora-handler';
 
 export default async (buildPath, electronVersion, platform, arch, config = {}) => {
+  if (!electronVersion) {
+    throw new Error("Could not determine Electron version. Make sure that 'npm install' (or 'yarn') has been run before invoking electron-forge.");
+  }
+
   await asyncOra('Preparing native dependencies', async (rebuildSpinner) => {
     const rebuilder = rebuild(Object.assign({}, config, {
       buildPath,


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

Addresses #615.

6.x uses a different method of retrieving the Electron version and so should not be affected by this bug.