### PR TITLE
Add simple Importer from Forge 5.x to 6.x

### DIFF
--- a/packages/api/core/src/api/import.ts
+++ b/packages/api/core/src/api/import.ts
@@ -7,6 +7,7 @@ import path from 'path';
 import initGit from './init-scripts/init-git';
 import { deps, devDeps, exactDevDeps } from './init-scripts/init-npm';
 
+import { updateElectronDependency } from '../util/electron-version';
 import { setInitialForgeConfig } from '../util/forge-config';
 import { info, warn } from '../util/messages';
 import installDepList, { DepType, DepVersionRestriction } from '../util/install-dependencies';
@@ -14,25 +15,6 @@ import { readRawPackageJson } from '../util/read-package-json';
 import upgradeForgeConfig, { updateUpgradedForgeDevDeps } from'../util/upgrade-forge-config';
 
 const d = debug('electron-forge:import');
-
-function findElectronDep(dep: string): boolean {
-  return ['electron', 'electron-prebuilt', 'electron-prebuilt-compile'].includes(dep);
-}
-
-function updateElectronDependency(packageJSON: any, dev: string[], exact: string[]): [string[], string[]] {
-  if (Object.keys(packageJSON.devDependencies).find(findElectronDep)) {
-    exact = exact.filter(dep => dep !== 'electron');
-  } else {
-    const electronKey = Object.keys(packageJSON.dependencies).find(findElectronDep);
-    if (electronKey) {
-      d(`Moving ${electronKey} from dependencies to devDependencies`);
-      dev.push(`${electronKey}@${packageJSON.dependencies[electronKey]}`);
-      delete packageJSON.dependencies[electronKey];
-    }
-  }
-
-  return [dev, exact];
-}
 
 export interface ImportOptions {
   /**

--- a/packages/api/core/src/api/init-scripts/init-npm.ts
+++ b/packages/api/core/src/api/init-scripts/init-npm.ts
@@ -11,7 +11,7 @@ import { readRawPackageJson } from '../../util/read-package-json';
 const d = debug('electron-forge:init:npm');
 const corePackage = fs.readJsonSync(path.resolve(__dirname, '../../../package.json'));
 
-function siblingDep(name: string) {
+export function siblingDep(name: string) {
   return `@electron-forge/${name}@${corePackage.version}`;
 }
 

--- a/packages/api/core/src/api/make.ts
+++ b/packages/api/core/src/api/make.ts
@@ -12,7 +12,7 @@ import parseArchs from '../util/parse-archs';
 import { readMutatedPackageJson } from '../util/read-package-json';
 import resolveDir from '../util/resolve-dir';
 import getCurrentOutDir from '../util/out-dir';
-import getElectronVersion from '../util/electron-version';
+import { getElectronVersion } from '../util/electron-version';
 import requireSearch from '../util/require-search';
 
 import packager from './package';

--- a/packages/api/core/src/api/package.ts
+++ b/packages/api/core/src/api/package.ts
@@ -16,7 +16,7 @@ import rebuildHook from '../util/rebuild';
 import requireSearch from '../util/require-search';
 import resolveDir from '../util/resolve-dir';
 import getCurrentOutDir from '../util/out-dir';
-import getElectronVersion from '../util/electron-version';
+import { getElectronVersion } from '../util/electron-version';
 
 const { host: hostArch }: { host: () => ForgeArch | 'all' } = require('electron-download/lib/arch');
 

--- a/packages/api/core/src/api/start.ts
+++ b/packages/api/core/src/api/start.ts
@@ -9,7 +9,7 @@ import rebuild from '../util/rebuild';
 import resolveDir from '../util/resolve-dir';
 import getForgeConfig from '../util/forge-config';
 import { runHook } from '../util/hook';
-import getElectronVersion from '../util/electron-version';
+import { getElectronVersion } from '../util/electron-version';
 
 export { StartOptions };
 

--- a/packages/api/core/src/util/electron-version.ts
+++ b/packages/api/core/src/util/electron-version.ts
@@ -1,6 +1,40 @@
-export default (packageJSON: any) => {
-  if (!packageJSON.devDependencies) return null;
-  return (packageJSON.devDependencies['electron-prebuilt-compile']
-      || packageJSON.devDependencies['electron-prebuilt']
-      || packageJSON.devDependencies.electron);
+import debug from 'debug';
+
+const d = debug('electron-forge:electron-version');
+
+const electronPackageNames = [
+  'electron-prebuilt-compile',
+  'electron-prebuilt',
+  'electron',
+];
+
+function findElectronDep(dep: string): boolean {
+  return electronPackageNames.includes(dep);
+}
+
+export function getElectronVersion (packageJSON: any) {
+  if (!packageJSON.devDependencies) {
+    throw new Error('package.json for app does not have any devDependencies'.red);
+  }
+  const packageName = electronPackageNames.find(pkg => packageJSON.devDependencies[pkg]);
+  if (packageName === undefined) {
+    throw new Error('Could not find any Electron packages in devDependencies');
+  }
+  return packageJSON.devDependencies[packageName];
 };
+
+export function updateElectronDependency(packageJSON: any, dev: string[], exact: string[]): [string[], string[]] {
+  if (Object.keys(packageJSON.devDependencies).find(findElectronDep)) {
+    exact = exact.filter(dep => dep !== 'electron');
+  } else {
+    const electronKey = Object.keys(packageJSON.dependencies).find(findElectronDep);
+    if (electronKey) {
+      exact = exact.filter(dep => dep !== 'electron');
+      d(`Moving ${electronKey} from dependencies to devDependencies`);
+      dev.push(`${electronKey}@${packageJSON.dependencies[electronKey]}`);
+      delete packageJSON.dependencies[electronKey];
+    }
+  }
+
+  return [dev, exact];
+}

--- a/packages/api/core/src/util/electron-version.ts
+++ b/packages/api/core/src/util/electron-version.ts
@@ -12,7 +12,7 @@ function findElectronDep(dep: string): boolean {
   return electronPackageNames.includes(dep);
 }
 
-export function getElectronVersion (packageJSON: any) {
+export function getElectronVersion(packageJSON: any) {
   if (!packageJSON.devDependencies) {
     throw new Error('package.json for app does not have any devDependencies'.red);
   }
@@ -21,7 +21,7 @@ export function getElectronVersion (packageJSON: any) {
     throw new Error('Could not find any Electron packages in devDependencies');
   }
   return packageJSON.devDependencies[packageName];
-};
+}
 
 export function updateElectronDependency(packageJSON: any, dev: string[], exact: string[]): [string[], string[]] {
   if (Object.keys(packageJSON.devDependencies).find(findElectronDep)) {

--- a/packages/api/core/src/util/electron-version.ts
+++ b/packages/api/core/src/util/electron-version.ts
@@ -25,17 +25,19 @@ export function getElectronVersion(packageJSON: any) {
 }
 
 export function updateElectronDependency(packageJSON: any, dev: string[], exact: string[]): [string[], string[]] {
+  const alteredDev = ([] as string[]).concat(dev);
+  let alteredExact = ([] as string[]).concat(exact);
   if (Object.keys(packageJSON.devDependencies).find(findElectronDep)) {
-    exact = exact.filter(dep => dep !== 'electron');
+    alteredExact = alteredExact.filter(dep => dep !== 'electron');
   } else {
     const electronKey = Object.keys(packageJSON.dependencies).find(findElectronDep);
     if (electronKey) {
-      exact = exact.filter(dep => dep !== 'electron');
+      alteredExact = alteredExact.filter(dep => dep !== 'electron');
       d(`Moving ${electronKey} from dependencies to devDependencies`);
-      dev.push(`${electronKey}@${packageJSON.dependencies[electronKey]}`);
+      alteredDev.push(`${electronKey}@${packageJSON.dependencies[electronKey]}`);
       delete packageJSON.dependencies[electronKey];
     }
   }
 
-  return [dev, exact];
+  return [alteredDev, alteredExact];
 }

--- a/packages/api/core/src/util/electron-version.ts
+++ b/packages/api/core/src/util/electron-version.ts
@@ -5,6 +5,7 @@ const d = debug('electron-forge:electron-version');
 const electronPackageNames = [
   'electron-prebuilt-compile',
   'electron-prebuilt',
+  'electron-nightly',
   'electron',
 ];
 

--- a/packages/api/core/src/util/resolve-dir.ts
+++ b/packages/api/core/src/util/resolve-dir.ts
@@ -2,7 +2,7 @@ import debug from 'debug';
 import fs from 'fs-extra';
 import path from 'path';
 import { readRawPackageJson } from './read-package-json';
-import getElectronVersion from './electron-version';
+import { getElectronVersion } from './electron-version';
 
 const d = debug('electron-forge:project-resolver');
 

--- a/packages/api/core/src/util/upgrade-forge-config.ts
+++ b/packages/api/core/src/util/upgrade-forge-config.ts
@@ -1,0 +1,142 @@
+import {
+  ForgeConfig,
+  ForgePlatform,
+  IForgeResolvableMaker,
+  IForgeResolvablePublisher,
+} from '@electron-forge/shared-types';
+import path from 'path';
+import { siblingDep } from '../api/init-scripts/init-npm';
+
+function mapMakeTargets(forge5Config: any): Map<string, ForgePlatform[]> {
+  const makeTargets = new Map<string, ForgePlatform[]>();
+  if (forge5Config.makeTargets) {
+    // TODO: Use object.entries when dropping Node 6
+    for (const platform in forge5Config.makeTargets) {
+      for (const target of forge5Config.makeTargets[platform]) {
+        let platforms = makeTargets.get(target);
+        if (platforms === undefined) {
+          platforms = [];
+          makeTargets.set(target, platforms);
+        }
+        platforms.push(platform as ForgePlatform);
+      }
+    }
+  }
+
+  return makeTargets;
+}
+
+const forge5MakerMappings = new Map<string, string>([
+  ['electronInstallerDebian', 'deb'],
+  ['electronInstallerDMG', 'dmg'],
+  ['electronInstallerFlatpak', 'flatpak'],
+  ['electronInstallerRedhat', 'rpm'],
+  ['electronInstallerSnap', 'snap'],
+  ['electronWinstallerConfig', 'squirrel'],
+  ['electronWixMSIConfig', 'wix'],
+  ['windowsStoreConfig', 'appx'],
+]);
+
+/**
+ * Converts Forge v5 maker config to v6.
+ */
+function generateForgeMakerConfig(forge5Config: any): IForgeResolvableMaker[] {
+  const makeTargets = mapMakeTargets(forge5Config);
+  const makers: IForgeResolvableMaker[] = [];
+
+  for (const [forge5Key, makerType] of forge5MakerMappings) {
+    const config = forge5Config[forge5Key];
+    if (config) {
+      makers.push({
+        name: `@electron-forge/maker-${makerType}`,
+        config: forge5Config[forge5Key],
+        platforms: makeTargets.get(makerType) || null,
+      } as IForgeResolvableMaker);
+    }
+  }
+
+  const zipPlatforms = makeTargets.get('zip');
+  if (zipPlatforms) {
+    makers.push({
+      name: '@electron-forge/maker-zip',
+      platforms: zipPlatforms,
+    } as IForgeResolvableMaker);
+  }
+
+  return makers;
+}
+
+const forge5PublisherMappings = new Map<string, string>([
+  ['github_repository', 'github'],
+  ['s3', 's3'],
+  ['electron-release-server', 'electron-release-server'],
+  ['snapStore', 'snapcraft'],
+]);
+
+/**
+ * Converts Forge v5 publisher config to v6.
+ */
+function generateForgePublisherConfig(forge5Config: any): IForgeResolvablePublisher[] {
+  const publishers: IForgeResolvablePublisher[] = [];
+
+  for (const [forge5Key, publisherType] of forge5PublisherMappings) {
+    let config = forge5Config[forge5Key];
+    if (config) {
+      if (publisherType === 'github') {
+        config = transformGitHubPublisherConfig(config);
+      }
+      publishers.push({
+        config,
+        name: `@electron-forge/publisher-${publisherType}`,
+        platforms: null,
+      } as IForgeResolvableMaker);
+    }
+  }
+
+  return publishers;
+}
+
+/**
+ * Transforms v5 GitHub publisher config to v6 syntax.
+ */
+function transformGitHubPublisherConfig(config: any) {
+  const { name, owner, options, ...gitHubConfig } = config;
+  gitHubConfig.repository = { name, owner };
+  if (options) {
+    gitHubConfig.octokitOptions = options;
+  }
+
+  return gitHubConfig;
+}
+
+/**
+ * Upgrades Forge v5 config to v6.
+ */
+export default function upgradeForgeConfig(forge5Config: any): ForgeConfig {
+  const forgeConfig: ForgeConfig = ({} as ForgeConfig);
+
+  if (forge5Config.electronPackagerConfig) {
+    delete forge5Config.electronPackagerConfig.packageManager;
+    forgeConfig.packagerConfig = forge5Config.electronPackagerConfig;
+  }
+  if (forge5Config.electronRebuildConfig) {
+    forgeConfig.electronRebuildConfig = forge5Config.electronRebuildConfig;
+  }
+  forgeConfig.makers = generateForgeMakerConfig(forge5Config);
+  forgeConfig.publishers = generateForgePublisherConfig(forge5Config);
+
+  return forgeConfig;
+}
+
+export function updateUpgradedForgeDevDeps(packageJSON: any, devDeps: string[]): string[] {
+  const forgeConfig = packageJSON.config.forge;
+  devDeps = devDeps.filter(dep => !dep.startsWith('@electron-forge/maker-'));
+  devDeps = devDeps.concat(forgeConfig.makers.map((maker: IForgeResolvableMaker) => siblingDep(path.basename(maker.name))));
+  devDeps = devDeps.concat(forgeConfig.publishers.map((publisher: IForgeResolvablePublisher) => siblingDep(path.basename(publisher.name))));
+
+  if (Object.keys(packageJSON.devDependencies).find((dep: string) => dep === 'electron-prebuilt-compile')) {
+    devDeps = devDeps.concat(siblingDep('plugin-compile'));
+  }
+
+  return devDeps;
+}

--- a/packages/api/core/test/fast/electron-version_spec.ts
+++ b/packages/api/core/test/fast/electron-version_spec.ts
@@ -52,6 +52,13 @@ describe('getElectronVersion', () => {
     expect(getElectronVersion(packageJSON)).to.be.equal('1.0.0');
   });
 
+  it('works with electron-nightly', () => {
+    const packageJSON = {
+      devDependencies: { 'electron-nightly': '5.0.0-nightly.20190107' },
+    };
+    expect(getElectronVersion(packageJSON)).to.be.equal('5.0.0-nightly.20190107');
+  });
+
   it('works with electron', () => {
     const packageJSON = {
       devDependencies: { electron: '1.0.0' },

--- a/packages/api/core/test/fast/electron-version_spec.ts
+++ b/packages/api/core/test/fast/electron-version_spec.ts
@@ -1,0 +1,61 @@
+import { expect } from 'chai';
+import { getElectronVersion, updateElectronDependency } from '../../src/util/electron-version';
+import { deps, devDeps, exactDevDeps } from '../../src/api/init-scripts/init-npm';
+
+describe('updateElectronDependency', () => {
+  it('adds an Electron dep if one does not already exist', () => {
+    const packageJSON = { dependencies: {}, devDependencies: {} };
+    const [dev, exact] = updateElectronDependency(packageJSON, devDeps, exactDevDeps);
+    expect(dev).to.deep.equal(devDeps);
+    expect(exact).to.deep.equal(exactDevDeps);
+  });
+  it('does not add an Electron dep if one already exists', () => {
+    const packageJSON = {
+      dependencies: {},
+      devDependencies: { electron: '0.37.0' },
+    };
+    const [dev, exact] = updateElectronDependency(packageJSON, devDeps, exactDevDeps);
+    expect(dev).to.deep.equal(devDeps);
+    expect(exact).to.deep.equal([]);
+  });
+  it('moves an Electron dependency from dependencies to devDependencies', () => {
+    const packageJSON = {
+      dependencies: { electron: '0.37.0'},
+      devDependencies: { },
+    };
+    const [dev, exact] = updateElectronDependency(packageJSON, devDeps, exactDevDeps);
+    expect(dev.includes('electron@0.37.0')).to.equal(true);
+    expect(exact).to.deep.equal([]);
+  });
+});
+
+describe('getElectronVersion', () => {
+  it('fails without devDependencies', () => {
+    expect(() => getElectronVersion({})).to.throw('does not have any devDependencies');
+  });
+
+  it('fails without electron devDependencies', () => {
+    expect(() => getElectronVersion({ devDependencies: {} })).to.throw('Electron packages in devDependencies');
+  });
+
+  it('works with electron-prebuilt-compile', () => {
+    const packageJSON = {
+      devDependencies: { 'electron-prebuilt-compile': '1.0.0' },
+    };
+    expect(getElectronVersion(packageJSON)).to.be.equal('1.0.0');
+  });
+
+  it('works with electron-prebuilt', () => {
+    const packageJSON = {
+      devDependencies: { 'electron-prebuilt': '1.0.0' },
+    };
+    expect(getElectronVersion(packageJSON)).to.be.equal('1.0.0');
+  });
+
+  it('works with electron', () => {
+    const packageJSON = {
+      devDependencies: { 'electron': '1.0.0' },
+    };
+    expect(getElectronVersion(packageJSON)).to.be.equal('1.0.0');
+  });
+});

--- a/packages/api/core/test/fast/electron-version_spec.ts
+++ b/packages/api/core/test/fast/electron-version_spec.ts
@@ -20,7 +20,7 @@ describe('updateElectronDependency', () => {
   });
   it('moves an Electron dependency from dependencies to devDependencies', () => {
     const packageJSON = {
-      dependencies: { electron: '0.37.0'},
+      dependencies: { electron: '0.37.0' },
       devDependencies: { },
     };
     const [dev, exact] = updateElectronDependency(packageJSON, devDeps, exactDevDeps);
@@ -54,7 +54,7 @@ describe('getElectronVersion', () => {
 
   it('works with electron', () => {
     const packageJSON = {
-      devDependencies: { 'electron': '1.0.0' },
+      devDependencies: { electron: '1.0.0' },
     };
     expect(getElectronVersion(packageJSON)).to.be.equal('1.0.0');
   });

--- a/packages/api/core/test/fast/upgrade-forge-config_spec.ts
+++ b/packages/api/core/test/fast/upgrade-forge-config_spec.ts
@@ -1,0 +1,173 @@
+import _merge from 'lodash.merge';
+import { IForgeResolvableMaker, IForgeResolvablePublisher } from '@electron-forge/shared-types';
+import { expect } from 'chai';
+import path from 'path';
+
+import upgradeForgeConfig, { updateUpgradedForgeDevDeps } from '../../src/util/upgrade-forge-config';
+
+describe('upgradeForgeConfig', () => {
+  it('converts Electron Packager config', () => {
+    const oldConfig = {
+      electronPackagerConfig: {
+        asar: true,
+        packageManager: 'npm',
+      },
+    };
+    const expected = { asar: true };
+
+    const newConfig = upgradeForgeConfig(oldConfig);
+    expect(newConfig.packagerConfig).to.deep.equal(expected);
+  });
+
+  it('converts electron-rebuild config', () => {
+    const rebuildConfig = { types: ['prod'] };
+    const oldConfig = { electronRebuildConfig: _merge({}, rebuildConfig) };
+
+    const newConfig = upgradeForgeConfig(oldConfig);
+    expect(newConfig.electronRebuildConfig).to.deep.equal(rebuildConfig);
+  });
+
+  it('converts maker config', () => {
+    const oldConfig = {
+      makeTargets: {
+        linux: ['deb'],
+      },
+      electronInstallerDebian: {
+        depends: ['liboath0'],
+      },
+    };
+    const expected = [
+      {
+        name: '@electron-forge/maker-deb',
+        config: {
+          depends: ['liboath0'],
+        },
+        platforms: ['linux'],
+      },
+    ] as IForgeResolvableMaker[];
+
+    const newConfig = upgradeForgeConfig(oldConfig);
+    expect(newConfig.makers).to.deep.equal(expected);
+  });
+
+  it('adds the zip maker when specified in makeTargets', () => {
+    const oldConfig = {
+      makeTargets: {
+        darwin: ['zip'],
+        linux: ['zip'],
+      },
+    };
+    const expected = [
+      {
+        name: '@electron-forge/maker-zip',
+        platforms: ['darwin', 'linux'],
+      },
+    ] as IForgeResolvableMaker[];
+
+    const newConfig = upgradeForgeConfig(oldConfig);
+    expect(newConfig.makers).to.deep.equal(expected);
+  });
+
+  it('converts publisher config', () => {
+    const oldConfig = {
+      snapStore: {
+        release: 'beta',
+      },
+    };
+    const expected = [
+      {
+        name: '@electron-forge/publisher-snapcraft',
+        config: {
+          release: 'beta',
+        },
+        platforms: null,
+      },
+    ] as IForgeResolvablePublisher[];
+
+    const newConfig = upgradeForgeConfig(oldConfig);
+    expect(newConfig.publishers).to.deep.equal(expected);
+  });
+
+  it('converts GitHub publisher config', () => {
+    const octokitOptions = {
+      timeout: 0,
+    };
+    const repo = {
+      name: 'myapp',
+      owner: 'user',
+    };
+    const oldConfig = {
+      github_repository: Object.assign({
+        options: octokitOptions,
+        draft: true,
+      }, repo),
+    };
+    const newConfig = upgradeForgeConfig(oldConfig);
+    expect(newConfig.publishers).to.have.lengthOf(1);
+    const publisherConfig = (newConfig.publishers[0] as IForgeResolvablePublisher).config;
+    expect(publisherConfig.repository).to.deep.equal(repo);
+    expect(publisherConfig.octokitOptions).to.deep.equal(octokitOptions);
+    expect(publisherConfig.draft).to.equal(true);
+  });
+});
+
+describe('updateUpgradedForgeDevDeps', () => {
+  const skeletonPackageJSON = {
+    config: {
+      forge: {
+        makers: [] as IForgeResolvableMaker[],
+        publishers: [] as IForgeResolvablePublisher[],
+      },
+    },
+    devDependencies: {},
+  };
+
+  it('removes unused makers from devDependencies', () => {
+    const packageJSON = _merge({}, skeletonPackageJSON);
+    const devDeps = updateUpgradedForgeDevDeps(packageJSON, ['@electron-forge/maker-squirrel']);
+    expect(devDeps).to.deep.equal([]);
+  });
+
+  it('adds makers to devDependencies', () => {
+    const packageJSON = _merge({}, skeletonPackageJSON);
+    packageJSON.config.forge.makers = [
+      {
+        name: '@electron-forge/maker-zip',
+        platforms: ['darwin', 'linux'],
+      },
+      {
+        name: '@electron-forge/maker-squirrel',
+        config: {},
+        platforms: ['win32'],
+      },
+    ] as IForgeResolvableMaker[];
+
+    const actual = updateUpgradedForgeDevDeps(packageJSON, []);
+    expect(actual).to.have.lengthOf(2);
+    expect(actual.find(dep => dep.startsWith('@electron-forge/maker-zip'))).to.not.equal(undefined);
+    expect(actual.find(dep => dep.startsWith('@electron-forge/maker-squirrel'))).to.not.equal(undefined);
+  });
+
+  it('adds publishers to devDependencies', () => {
+    const packageJSON = _merge({}, skeletonPackageJSON);
+    packageJSON.config.forge.publishers = [
+      { name: '@electron-forge/publisher-github' },
+      { name: '@electron-forge/publisher-snapcraft' },
+    ];
+
+    const actual = updateUpgradedForgeDevDeps(packageJSON, []);
+    expect(actual).to.have.lengthOf(2);
+    expect(actual.find(dep => dep.startsWith('@electron-forge/publisher-github'))).to.not.equal(undefined);
+    expect(actual.find(dep => dep.startsWith('@electron-forge/publisher-snapcraft'))).to.not.equal(undefined);
+  });
+
+  it('adds electron-compile plugin to devDependencies when electron-prebuilt-compile is in devDependencies', () => {
+    const packageJSON = _merge({}, skeletonPackageJSON, {
+      devDependencies: { 'electron-prebuilt-compile': '2.0.0' },
+    });
+
+    const actual = updateUpgradedForgeDevDeps(packageJSON, []);
+    expect(actual, JSON.stringify(actual)).to.have.lengthOf(1);
+    expect(actual[0]).to.match(/^@electron-forge\/plugin-compile/);
+  });
+});


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Adds support for changing `config.forge` if it doesn't point to a JS file. In the future we could possibly provide `updateForgeConfig` for those JS files.

There was some refactoring involved - as a result, `getElectronVersion` has test coverage.

In general, the feature was written in such a way that it should have complete unit test coverage from a LoC perspective.