### PR TITLE
[5.x] chore(maker): force bump debian and snap dependencies to bring in fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,11 +154,11 @@
     }
   },
   "optionalDependencies": {
-    "electron-installer-debian": "^1.0.0",
+    "electron-installer-debian": "^1.1.0",
     "electron-installer-dmg": "^0.2.0",
     "electron-installer-flatpak": "^0.8.0",
     "electron-installer-redhat": "^0.5.0",
-    "electron-installer-snap": "^3.0.1",
+    "electron-installer-snap": "^3.1.0",
     "electron-windows-store": "^0.12.0",
     "electron-winstaller": "^2.5.0",
     "electron-wix-msi": "^2.1.1"

--- a/test/slow/api_spec_slow.js
+++ b/test/slow/api_spec_slow.js
@@ -229,7 +229,9 @@ describe(`electron-forge API (with installer=${nodeInstaller})`, () => {
       packageJSON.name = 'testapp';
       packageJSON.productName = 'Test App';
       packageJSON.config.forge.electronPackagerConfig.asar = false;
-      packageJSON.config.forge.electronPackagerConfig.executableName = 'testapp';
+      if (process.platform === 'linux') {
+        packageJSON.config.forge.electronPackagerConfig.executableName = 'testapp';
+      }
       packageJSON.config.forge.windowsStoreConfig.packageName = 'TestApp';
       if (process.platform === 'win32') {
         await fs.copy(

--- a/test/slow/api_spec_slow.js
+++ b/test/slow/api_spec_slow.js
@@ -229,6 +229,7 @@ describe(`electron-forge API (with installer=${nodeInstaller})`, () => {
       packageJSON.name = 'testapp';
       packageJSON.productName = 'Test App';
       packageJSON.config.forge.electronPackagerConfig.asar = false;
+      packageJSON.config.forge.electronPackagerConfig.executableName = 'testapp';
       packageJSON.config.forge.windowsStoreConfig.packageName = 'TestApp';
       if (process.platform === 'win32') {
         await fs.copy(


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

* [`electron-installer-debian`](https://github.com/electron-userland/electron-installer-debian/releases/tag/v1.1.0)
* [`electron-installer-snap`](https://github.com/electron-userland/electron-installer-snap/releases/tag/v3.1.0)

Cannot bump `-redhat` dependency due to breaking changes.

Addresses #654.