### PR TITLE
Set a opaque background for the browser window

### DIFF
--- a/packages/api/core/tmpl/index.js
+++ b/packages/api/core/tmpl/index.js
@@ -14,6 +14,7 @@ const createWindow = () => {
   mainWindow = new BrowserWindow({
     width: 800,
     height: 600,
+    backgroundColor: '#fff',
   });
 
   // and load the index.html of the app.


### PR DESCRIPTION
As I new electron-forge user I want to have anti-aliasing activated, that my electron app looks as good as possible.

In Electron 0.37.3 the default background color has changed from white to transparent, and as per the sub pixel anti-aliasing specification, the layer which hosts the glyphs that need to be rendered needs to have an opaque background.
Source: https://github.com/electron/electron/issues/6344#issuecomment-420371918

<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**


