### PR TITLE
fix: abstract base classes should implement shared type interfaces

### DIFF
--- a/packages/maker/base/src/Maker.ts
+++ b/packages/maker/base/src/Maker.ts
@@ -36,7 +36,7 @@ export interface MakerOptions {
   packageJSON: any;
 }
 
-export default abstract class Maker<C> {
+export default abstract class Maker<C> implements IForgeMaker {
   public config!: C;
   public abstract name: string;
   public abstract defaultPlatforms: ForgePlatform[];

--- a/packages/plugin/base/src/Plugin.ts
+++ b/packages/plugin/base/src/Plugin.ts
@@ -17,7 +17,7 @@ export default abstract class Plugin<C> implements IForgePlugin {
     });
   }
 
-  init(_dir: string, _config: ForgeConfig) {
+  init(dir: string, config: ForgeConfig) {
   }
 
   getHook(hookName: string): ForgeHookFn | null {

--- a/packages/plugin/base/src/Plugin.ts
+++ b/packages/plugin/base/src/Plugin.ts
@@ -1,9 +1,9 @@
-import { ForgeHookFn, StartOptions } from '@electron-forge/shared-types';
+import { ForgeConfig, ForgeHookFn, IForgePlugin, StartOptions } from '@electron-forge/shared-types';
 import { ChildProcess } from 'child_process';
 
 export { StartOptions };
 
-export default abstract class Plugin<C> {
+export default abstract class Plugin<C> implements IForgePlugin {
   public abstract name: string;
   /* tslint:disable variable-name */
   __isElectronForgePlugin!: true;
@@ -15,6 +15,9 @@ export default abstract class Plugin<C> {
       enumerable: false,
       configurable: false,
     });
+  }
+
+  init(_dir: string, _config: ForgeConfig) {
   }
 
   getHook(hookName: string): ForgeHookFn | null {

--- a/packages/publisher/base/src/Publisher.ts
+++ b/packages/publisher/base/src/Publisher.ts
@@ -1,4 +1,4 @@
-import { ForgePlatform, ForgeConfig, ForgeMakeResult } from '@electron-forge/shared-types';
+import { ForgePlatform, ForgeConfig, ForgeMakeResult, IForgePublisher } from '@electron-forge/shared-types';
 
 /* eslint-disable no-unused-vars */
 
@@ -19,7 +19,7 @@ export interface PublisherOptions {
   forgeConfig: ForgeConfig;
 }
 
-export default abstract class Publisher<C> {
+export default abstract class Publisher<C> implements IForgePublisher {
   public abstract name: string;
   public defaultPlatforms?: ForgePlatform[];
   /* tslint:disable variable-name */
@@ -38,7 +38,7 @@ export default abstract class Publisher<C> {
   get platforms() {
     if (this.providedPlatforms) return this.providedPlatforms;
     if (this.defaultPlatforms) return this.defaultPlatforms;
-    return ['win32', 'linux', 'darwin', 'mas'];
+    return ['win32', 'linux', 'darwin', 'mas'] as ForgePlatform[];
   }
 
   /**

--- a/packages/utils/types/src/index.ts
+++ b/packages/utils/types/src/index.ts
@@ -60,7 +60,7 @@ export interface IForgePlugin {
 
   init(dir: string, forgeConfig: ForgeConfig): void;
   getHook?(hookName: string): ForgeHookFn | null;
-  startLogic?(opts: StartOptions): Promise<ChildProcess | false>;
+  startLogic?(opts: StartOptions): Promise<ChildProcess | string | string[] | false>;
 }
 
 export interface IForgeResolvableMaker {
@@ -71,7 +71,7 @@ export interface IForgeResolvableMaker {
 
 export interface IForgeMaker {
   __isElectronForgeMaker: boolean;
-  platforms?: undefined;
+  readonly platforms?: ForgePlatform[];
 }
 
 export interface IForgeResolvablePublisher {
@@ -82,7 +82,7 @@ export interface IForgeResolvablePublisher {
 
 export interface IForgePublisher {
   __isElectronForgePublisher: boolean;
-  platforms?: undefined;
+  readonly platforms?: ForgePlatform[];
 }
 
 export interface StartOptions {


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* ~~The changes are appropriately documented~~ (not applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

When I was researching #683, I found it odd that the abstract `Base` classes didn't implement the interfaces that are in use in `@electron-forge/core` when executing the plugins. If this is some TypeScript pattern, let me know and I'll update the PR to just have the empty `init()` method.

Fixes #683.