### PR TITLE
use git to check that you're in a Git repository

### DIFF
--- a/packages/api/core/src/api/init-scripts/init-git.ts
+++ b/packages/api/core/src/api/init-scripts/init-git.ts
@@ -1,24 +1,28 @@
 import { asyncOra } from '@electron-forge/async-ora';
 import { exec } from 'child_process';
 import debug from 'debug';
-import fs from 'fs-extra';
-import path from 'path';
 
 const d = debug('electron-forge:init:git');
 
 export default async (dir: string) => {
   await asyncOra('Initializing Git Repository', async () => {
-    await new Promise(async (resolve, reject) => {
-      if (await fs.pathExists(path.resolve(dir, '.git'))) {
-        d('.git directory already exists, skipping git initialization');
-        return resolve();
-      }
-      d('executing "git init" in directory:', dir);
-      exec('git init', {
+    await new Promise((resolve, reject) => {
+      exec('git rev-parse --show-toplevel', {
         cwd: dir,
       }, (err) => {
-        if (err) return reject(err);
-        resolve();
+        if (err) {
+          // not run within a Git repository
+          d('executing "git init" in directory:', dir);
+          exec('git init', {
+            cwd: dir,
+          }, (err) => {
+            if (err) return reject(err);
+            resolve();
+          });
+        } else {
+          d('.git directory already exists, skipping git initialization');
+          resolve();
+        }
       });
     });
   });

--- a/packages/api/core/test/slow/init_git_spec_slow.ts
+++ b/packages/api/core/test/slow/init_git_spec_slow.ts
@@ -1,0 +1,46 @@
+import { execSync } from 'child_process';
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+
+import { expect } from 'chai';
+
+import initGit from '../../src/api/init-scripts/init-git';
+
+let dir: string;
+let dirID = Date.now();
+
+const ensureTestDirIsNonexistent = async () => {
+  dir = path.resolve(os.tmpdir(), `electron-forge-git-test-${dirID}`);
+  dirID += 1;
+  await fs.remove(dir);
+};
+
+describe('init-git', () => {
+  beforeEach(async () => {
+    await ensureTestDirIsNonexistent();
+    await fs.mkdir(dir);
+  });
+
+  it('creates Git repository when run inside non-Git directory', async () => {
+    await initGit(dir);
+    const gitDir = path.join(dir, '.git');
+    expect(await fs.pathExists(gitDir), 'the .git directory inside the folder').to.equal(true);
+  });
+
+  it('skips when run at root of Git repository', async () => {
+    await execSync('git init', { cwd: dir });
+
+    const gitDir = path.join(dir, '.git');
+    const config = path.join(gitDir, 'config');
+    const statBefore = await fs.lstat(config);
+    const before = statBefore.mtimeMs;
+
+    await initGit(dir);
+
+    const statAfter = await fs.lstat(config);
+    const after = statAfter.mtimeMs;
+
+    expect(after, 'the config file in the repository').to.equal(before);
+  });
+});

--- a/packages/api/core/test/slow/init_git_spec_slow.ts
+++ b/packages/api/core/test/slow/init_git_spec_slow.ts
@@ -43,4 +43,26 @@ describe('init-git', () => {
 
     expect(after, 'the config file in the repository').to.equal(before);
   });
+
+  it('skips when run in subdirectory of Git repository', async () => {
+    await execSync('git init', { cwd: dir });
+
+    const gitDir = path.join(dir, '.git');
+    const config = path.join(gitDir, 'config');
+    const statBefore = await fs.lstat(config);
+    const before = statBefore.mtimeMs;
+
+    const subdir = path.join(dir, 'some', 'other', 'folder');
+    const innerGitDir = path.join(subdir, '.git');
+
+    await fs.mkdirp(subdir);
+
+    await initGit(subdir);
+
+    const statAfter = await fs.lstat(config);
+    const after = statAfter.mtimeMs;
+
+    expect(after, 'the config file in the repository').to.equal(before);
+    expect(await fs.pathExists(innerGitDir), 'a nested .git directory inside the repository').to.equal(false);
+  });
 });


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

I was running `v5.2.4` and `electron-forge init` to scaffold up a test project within an existing repository, and because I was running it within a subdirectory (rather than at the root of a repository) it didn't see the root `.git` directory, and instead initialized a Git repository inside a Git repository.

Not sure how many encounter this, but after remembering to cleanup this new `.git` directory a second time I got caremad enough to look at the code.

I added some tests to cover the scenarios that I think are important here (including the failing case I found), and ported `init-git` to use `git` itself to see whether you're in a repository.

Let me know if there's any extra work you'd like me to do while I'm in here, or if there's stuff I've indirectly affected.
