### PR TITLE
fix(plugin-webpack): allow port to be configurable

### DIFF
--- a/packages/plugin/webpack/src/Config.ts
+++ b/packages/plugin/webpack/src/Config.ts
@@ -68,4 +68,8 @@ export interface WebpackPluginConfig {
    * Electron Forge webpack configuration for your renderer process
    */
   renderer: WebpackPluginRendererConfig;
+  /**
+   * The TCP port for the dev servers. Defaults to 3000.
+   */
+  port?: number;
 }

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -20,7 +20,7 @@ import once from './util/once';
 import { WebpackPluginConfig, WebpackPluginEntryPoint, WebpackPreloadEntryPoint } from './Config';
 
 const d = debug('electron-forge:plugin:webpack');
-const BASE_PORT = 3000;
+const DEFAULT_PORT = 3000;
 
 export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
   name = 'webpack';
@@ -30,9 +30,14 @@ export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
   private watchers: webpack.Compiler.Watching[] = [];
   private servers: http.Server[] = [];
   private loggers: Logger[] = [];
+  private port = DEFAULT_PORT;
 
   constructor(c: WebpackPluginConfig) {
     super(c);
+
+    if (c.port) {
+      this.port = c.port;
+    }
 
     this.startLogic = this.startLogic.bind(this);
     this.getHook = this.getHook.bind(this);
@@ -153,12 +158,12 @@ Your packaged app may be larger than expected if you dont ignore everything othe
         defines[`${entryPoint.name.toUpperCase().replace(/ /g, '_')}_WEBPACK_ENTRY`] =
           this.isProd
           ? `\`file://\$\{require('path').resolve(__dirname, '../renderer', '${upOneMore ? '..' : '.'}', '${entryPoint.name}', 'index.html')\}\``
-          : `'http://localhost:${BASE_PORT}/${entryPoint.name}'`;
+          : `'http://localhost:${this.port}/${entryPoint.name}'`;
       } else {
         defines[`${entryPoint.name.toUpperCase().replace(/ /g, '_')}_WEBPACK_ENTRY`] =
           this.isProd
           ? `\`file://\$\{require('path').resolve(__dirname, '../renderer', '${upOneMore ? '..' : '.'}', '${entryPoint.name}', 'index.js')\}\``
-          : `'http://localhost:${BASE_PORT}/${entryPoint.name}/index.js'`;
+          : `'http://localhost:${this.port}/${entryPoint.name}/index.js'`;
       }
 
       const preloadDefineKey = `${entryPoint.name.toUpperCase().replace(/ /g, '_')}_PRELOAD_WEBPACK_ENTRY`;
@@ -340,7 +345,7 @@ Your packaged app may be larger than expected if you dont ignore everything othe
       const app = express();
       app.use(server);
       app.use(webpackHotMiddleware(compiler));
-      this.servers.push(app.listen(BASE_PORT));
+      this.servers.push(app.listen(this.port));
     });
 
     await asyncOra('Compiling Preload Scripts', async () => {

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -36,7 +36,13 @@ export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
     super(c);
 
     if (c.port) {
-      this.port = c.port;
+      if (c.port < 1024) {
+        throw new Error(`Cannot specify port (${c.port}) below 1024, as they are privileged`);
+      } else if (c.port > 65535) {
+        throw new Error(`Port specified (${c.port}) is not a valid TCP port.`);
+      } else {
+        this.port = c.port;
+      }
     }
 
     this.startLogic = this.startLogic.bind(this);


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).

**Summarize your changes:**

Allows the webpack plugin config entry `port` to override the default port number of `3000`, as that is a common port for various other dev servers.

This should be added to the v6 docs if merged.

ISSUES CLOSED: #691