### PR TITLE
fix(core): be more descriptive when a plugin/maker/publisher module isn't found

### DIFF
--- a/packages/api/core/src/api/make.ts
+++ b/packages/api/core/src/api/make.ts
@@ -103,7 +103,7 @@ export default async ({
       const resolvableTarget: IForgeResolvableMaker = target as IForgeResolvableMaker;
       const MakerClass = requireSearch<typeof MakerImpl>(dir, [resolvableTarget.name]);
       if (!MakerClass) {
-        throw `Could not find module with name: ${resolvableTarget.name}`;
+        throw `Could not find module with name: ${resolvableTarget.name}. Make sure it's listed in the devDependencies of your package.json`;
       }
 
       maker = new MakerClass(resolvableTarget.config, resolvableTarget.platforms || undefined);

--- a/packages/api/core/src/api/publish.ts
+++ b/packages/api/core/src/api/publish.ts
@@ -160,7 +160,7 @@ const publish = async ({
       await asyncOra(`Resolving publish target: ${`${resolvablePublishTarget.name}`.cyan}`, async () => { // eslint-disable-line no-loop-func
         PublisherClass = requireSearch(dir, [resolvablePublishTarget.name]);
         if (!PublisherClass) {
-          throw `Could not find a publish target with the name: ${resolvablePublishTarget.name}`;
+          throw `Could not find a publish target with the name: ${resolvablePublishTarget.name}. Make sure it's listed in the devDependencies of your package.json`;
         }
       });
 

--- a/packages/api/core/src/util/plugin-interface.ts
+++ b/packages/api/core/src/util/plugin-interface.ts
@@ -26,7 +26,7 @@ export default class PluginInterface implements IForgePluginInterface {
         if (typeof plugin[1] !== 'undefined') opts = plugin[1];
         const Plugin = requireSearch<any>(dir, [plugin[0]]);
         if (!Plugin) {
-          throw `Could not find module with name: ${plugin[0]}`;
+          throw `Could not find module with name: ${plugin[0]}. Make sure it's listed in the devDependencies of your package.json`;
         }
         return new Plugin(opts);
       }


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).

**Summarize your changes:**

I got a bit confused while I was converting a project to use Electron Forge via `import`.