### PR TITLE
fix(plugin-webpack): throw an error if webpack generates compilation errors when packaging

### DIFF
--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -285,6 +285,10 @@ Your packaged app may be larger than expected if you dont ignore everything othe
           }
 
           if (err) return onceReject(err);
+          if (!watch && stats.hasErrors()) {
+            return onceReject(new Error(`Compilation errors in the main process: ${stats.toString()}`));
+          }
+
           onceResolve();
         };
         if (watch) {
@@ -301,6 +305,10 @@ Your packaged app may be larger than expected if you dont ignore everything othe
       await new Promise(async (resolve, reject) => {
         webpack(await this.getRendererConfig(this.config.renderer.entryPoints)).run((err, stats) => {
           if (err) return reject(err);
+          if (!watch && stats.hasErrors()) {
+            return reject(new Error(`Compilation errors in the renderer: ${stats.toString()}`));
+          }
+
           resolve();
         });
       });


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

This should only throw an error on `package`, not `start`.

Reference: https://webpack.js.org/api/node/#error-handling

ISSUES CLOSED: #579