### PR TITLE
[5.x] fixed --auth-token and --tag cli options

### DIFF
--- a/src/electron-forge-publish.js
+++ b/src/electron-forge-publish.js
@@ -11,8 +11,8 @@ import { getMakeOptions } from './electron-forge-make';
   program
     .version(require('../package.json').version)
     .arguments('[cwd]')
-    .option('--auth-token', 'Authorization token for your publisher target (if required)')
-    .option('--tag', 'The tag to publish to on GitHub')
+    .option('--auth-token [auth-token]', 'Authorization token for your publisher target (if required)')
+    .option('--tag [tag]', 'The tag to publish to on GitHub')
     .option('--target [target[,target...]]', 'The comma-separated deployment targets, defaults to "github"')
     .option('--dry-run', 'Triggers a publish dry run which saves state and doesn\'t upload anything')
     .option('--from-dry-run', 'Attempts to publish artifacts from the last saved dry run')


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
The library Commander.js wasn't used correctly. 
These two command line arguments were interpreted as a boolean instead of a string.

Fixes these Issues: #458, #125, #699

