### PR TITLE
chore(core): re-enable built-in template tests

### DIFF
--- a/packages/api/core/test/slow/api_spec_slow.ts
+++ b/packages/api/core/test/slow/api_spec_slow.ts
@@ -104,25 +104,25 @@ describe(`electron-forge API (with installer=${nodeInstaller})`, () => {
     });
   });
 
-  describe.skip('init (with built-in templater)', () => {
+  describe('init (with built-in templater)', () => {
     before(ensureTestDirIsNonexistent);
 
     it('should succeed in initializing', async () => {
       await forge.init({
         dir,
-        template: 'react-typescript',
+        template: 'webpack',
       });
     });
 
     it('should fail in initializing an already initialized directory', async () => {
       await expect(forge.init({
         dir,
-        template: 'react-typescript',
+        template: 'webpack',
       })).to.eventually.be.rejected;
     });
 
     it('should add a dependency on react', async () => {
-      expect(Object.keys(require(path.resolve(dir, 'package.json')).dependencies)).to.contain('react');
+      expect(Object.keys(require(path.resolve(dir, 'package.json')).dependencies)).to.contain('@electron-forge/plugin-webpack');
     });
 
     after(async () => {

--- a/packages/api/core/test/slow/api_spec_slow.ts
+++ b/packages/api/core/test/slow/api_spec_slow.ts
@@ -121,8 +121,8 @@ describe(`electron-forge API (with installer=${nodeInstaller})`, () => {
       })).to.eventually.be.rejected;
     });
 
-    it('should add a dependency on react', async () => {
-      expect(Object.keys(require(path.resolve(dir, 'package.json')).dependencies)).to.contain('@electron-forge/plugin-webpack');
+    it('should add a devDependency on @electron-forge/plugin-webpack', async () => {
+      expect(Object.keys(require(path.resolve(dir, 'package.json')).devDependencies)).to.contain('@electron-forge/plugin-webpack');
     });
 
     after(async () => {


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Originally disabled in #874.