### PR TITLE
chore: remove unnecessary direct node-gyp dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "log-symbols": "^3.0.0",
     "mime-types": "^2.1.24",
     "node-fetch": "^2.6.0",
-    "node-gyp": "^4.0.0",
     "nugget": "^2.0.1",
     "open": "^6.0.0",
     "ora": "^3.0.0",


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This was from way back in the beginning of Forge development, when it didn't depend on `electron-rebuild`.