### PR TITLE
fix(plugin-webpack): check that stats is not empty before sending to multi-logger

### DIFF
--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -360,7 +360,7 @@ Your packaged app may be larger than expected if you dont ignore everything othe
         const compiler = webpack(await this.getMainConfig());
         const [onceResolve, onceReject] = once(resolve, reject);
         const cb: webpack.ICompiler.Handler = (err, stats) => {
-          if (tab) {
+          if (tab && stats) {
             tab.log(stats.toString({
               colors: true,
             }));
@@ -443,9 +443,11 @@ Your packaged app may be larger than expected if you dont ignore everything othe
             const tab = logger.createTab(`${entryPoint.name} - Preload`);
             const [onceResolve, onceReject] = once(resolve, reject);
             const cb: webpack.ICompiler.Handler = (err, stats) => {
-              tab.log(stats.toString({
-                colors: true,
-              }));
+              if (stats) {
+                tab.log(stats.toString({
+                  colors: true,
+                }));
+              }
 
               if (err) return onceReject(err);
               return onceResolve();


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Fixes #1017.