### PR TITLE
feat(core): add "init --force" to allow overwriting an existing dir

### DIFF
--- a/packages/api/cli/src/electron-forge-init.ts
+++ b/packages/api/cli/src/electron-forge-init.ts
@@ -14,6 +14,7 @@ import workingDir from './util/working-dir';
     .arguments('[name]')
     .option('-t, --template [name]', 'Name of the Forge template to use')
     .option('-c, --copy-ci-files', 'Whether to copy the templated CI files (defaults to false)', false)
+    .option('-f, --force', 'Whether to overwrite an existing directory (defaults to false)', false)
     .action((name) => { dir = workingDir(dir, name, false); })
     .parse(process.argv);
 
@@ -21,6 +22,7 @@ import workingDir from './util/working-dir';
     dir,
     interactive: true,
     copyCIFiles: !!program.copyCiFiles,
+    force: !!program.force,
   };
   if (program.template) initOpts.template = program.template;
 

--- a/packages/api/core/src/api/init-scripts/init-directory.ts
+++ b/packages/api/core/src/api/init-scripts/init-directory.ts
@@ -5,16 +5,21 @@ import logSymbols from 'log-symbols';
 
 const d = debug('electron-forge:init:directory');
 
-export default async (dir: string) => {
+export default async (dir: string, force = false) => {
   await asyncOra('Initializing Project Directory', async (initSpinner) => {
     d('creating directory:', dir);
     await fs.mkdirs(dir);
 
     const files = await fs.readdir(dir);
     if (files.length !== 0) {
-      d('found', files.length, 'files in the directory.  warning the user');
-      initSpinner.stop(logSymbols.warning);
-      throw new Error(`The specified path: "${dir}" is not empty.  Please ensure it is empty before initializing a new project`);
+      d(`found ${files.length} files in the directory.  warning the user`);
+
+      if (force) {
+        initSpinner.warn(`The specified path "${dir}" is not empty. "force" was set to true, so proceeding to initialize. Files may be overwritten`);
+      } else {
+        initSpinner.stop(logSymbols.warning);
+        throw new Error(`The specified path: "${dir}" is not empty.  Please ensure it is empty before initializing a new project`);
+      }
     }
   });
 };

--- a/packages/api/core/src/api/init.ts
+++ b/packages/api/core/src/api/init.ts
@@ -23,6 +23,10 @@ export interface InitOptions {
    */
   copyCIFiles?: boolean;
   /**
+   * Whether to overwrite an existing directory
+   */
+  force?: boolean;
+  /**
    * The custom template to use. If left empty, the default template is used
    */
   template?: string;
@@ -32,13 +36,14 @@ export default async ({
   dir = process.cwd(),
   interactive = false,
   copyCIFiles = false,
+  force = false,
   template,
 }: InitOptions) => {
   asyncOra.interactive = interactive;
 
   d(`Initializing in: ${dir}`);
 
-  await initDirectory(dir);
+  await initDirectory(dir, force);
   await initGit(dir);
   await initStarter(dir, { copyCIFiles });
   await initNPM(dir);

--- a/packages/api/core/test/slow/api_spec_slow.ts
+++ b/packages/api/core/test/slow/api_spec_slow.ts
@@ -121,6 +121,14 @@ describe(`electron-forge API (with installer=${nodeInstaller})`, () => {
       })).to.eventually.be.rejected;
     });
 
+    it('should initialize an already initialized directory when forced to', async () => {
+      await forge.init({
+        dir,
+        force: true,
+        template: 'webpack',
+      });
+    });
+
     it('should add a devDependency on @electron-forge/plugin-webpack', async () => {
       expect(Object.keys(require(path.resolve(dir, 'package.json')).devDependencies)).to.contain('@electron-forge/plugin-webpack');
     });


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Part of the [`electron/template` train :steam_locomotive:](https://github.com/electron-userland/electron-forge/pull/950), this lets us create a scheduled GitHub Action that updates the repository with the latest & greatest template.