### PR TITLE
fix(plugin-webpack): properly reference `index.js` in production

### DIFF
--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -425,6 +425,7 @@ Your packaged app may be larger than expected if you dont ignore everything othe
           error: tab.log.bind(tab),
           warn: tab.log.bind(tab),
         },
+        ...(this.isProd ? {} : publicPath: '/'),
         hot: true,
         historyApiFallback: true,
         writeToDisk: true,

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -425,7 +425,7 @@ Your packaged app may be larger than expected if you dont ignore everything othe
           error: tab.log.bind(tab),
           warn: tab.log.bind(tab),
         },
-        ...(this.isProd ? {} : publicPath: '/'),
+        ...(this.isProd ? {} : { publicPath: '/' }),
         hot: true,
         historyApiFallback: true,
         writeToDisk: true,

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -425,7 +425,6 @@ Your packaged app may be larger than expected if you dont ignore everything othe
           error: tab.log.bind(tab),
           warn: tab.log.bind(tab),
         },
-        publicPath: '/',
         hot: true,
         historyApiFallback: true,
         writeToDisk: true,


### PR DESCRIPTION
When building an executable using `electron-forge make`, setting `publicPath` as `/` leads (for example) to `index.js` being referenced as `file:///main_window/index.js`, which cannot be found. (The URL points to `/main_window/index.js`, which is incorrect. It should be `../main_window/index.js`.)

When it is unset, the build runs properly and provides the correct URL. (This still works with `electron-forge start` ~~as well~~ _with manual reloading_.)

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [ ] The changes are appropriately documented (if applicable).
* [ ] The changes have sufficient test coverage (if applicable).
* [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

~~Removed the (apparently unnecessary) reference to `publicPath`.~~
Removed the reference to `publicPath` when building for production.
