### PR TITLE
fix(template-webpack): use css-loader instead of file-loader

### DIFF
--- a/packages/template/webpack/src/WebpackTemplate.ts
+++ b/packages/template/webpack/src/WebpackTemplate.ts
@@ -29,7 +29,6 @@ class WebpackTemplate implements ForgeTemplate {
     // TODO: Use the @zeit publish once https://github.com/zeit/webpack-asset-relocator-loader/pull/41 has been merged
     '@marshallofsound/webpack-asset-relocator-loader@^0.5.0',
     'css-loader@^3.0.0',
-    'file-loader@^4.0.0',
     'node-loader@^0.6.0',
     'style-loader@^0.23.1',
   ];

--- a/packages/template/webpack/src/WebpackTemplate.ts
+++ b/packages/template/webpack/src/WebpackTemplate.ts
@@ -28,6 +28,7 @@ class WebpackTemplate implements ForgeTemplate {
     `@electron-forge/plugin-webpack@${currentVersion}`,
     // TODO: Use the @zeit publish once https://github.com/zeit/webpack-asset-relocator-loader/pull/41 has been merged
     '@marshallofsound/webpack-asset-relocator-loader@^0.5.0',
+    'css-loader@^3.0.0',
     'file-loader@^4.0.0',
     'node-loader@^0.6.0',
     'style-loader@^0.23.1',

--- a/packages/template/webpack/tmpl/webpack.renderer.config.js
+++ b/packages/template/webpack/tmpl/webpack.renderer.config.js
@@ -2,7 +2,7 @@ const rules = require('./webpack.rules');
 
 rules.push({
   test: /\.css$/,
-  use: [{ loader: 'style-loader/url' }, { loader: 'file-loader' }],
+  use: [{ loader: 'style-loader' }, { loader: 'css-loader' }],
 });
 
 module.exports = {


### PR DESCRIPTION

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [ ] The changes are appropriately documented (if applicable).
* [ ] The changes have sufficient test coverage (if applicable).
* [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Instead of relying on the `style-loader/url`/`file-loader` pipeline, we use the `style-loader`/`css-loader` pipeline. This means the CSS ends up embedded in the JavaScript code generated by webpack, but it appears to work better.
