### PR TITLE
fix(maker): allow Linux makers to run on non-Linux hosts if possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@electron/get": "^1.3.1",
     "@octokit/rest": "^16.28.5",
+    "@types/which": "^1.3.1",
     "aws-sdk": "^2.472.0",
     "colors": "^1.2.0",
     "commander": "^2.9.0",
@@ -80,6 +81,7 @@
     "webpack-dev-middleware": "^3.7.0",
     "webpack-hot-middleware": "^2.25.0",
     "webpack-merge": "^4.1.1",
+    "which": "^1.3.1",
     "xterm": "^3.14.5",
     "yarn-or-npm": "^3.0.0"
   },

--- a/packages/maker/base/package.json
+++ b/packages/maker/base/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@electron-forge/shared-types": "6.0.0-beta.43",
-    "fs-extra": "^8.1.0"
+    "fs-extra": "^8.1.0",
+    "which": "^1.3.1"
   }
 }

--- a/packages/maker/base/src/Maker.ts
+++ b/packages/maker/base/src/Maker.ts
@@ -3,6 +3,7 @@ import {
 } from '@electron-forge/shared-types';
 import fs from 'fs-extra';
 import path from 'path';
+import which from 'which';
 
 export interface MakerOptions {
   /**
@@ -125,6 +126,13 @@ export default abstract class Maker<C> implements IForgeMaker {
       await fs.remove(file);
     }
     await fs.mkdirs(path.dirname(file));
+  }
+
+  /**
+   * Checks if the specified binaries exist, which are required for the maker to be used.
+   */
+  externalBinariesExist(binaries: string[]): boolean {
+    return binaries.every(binary => which.sync(binary, { nothrow: true }) !== null);
   }
 
   /**

--- a/packages/maker/deb/src/MakerDeb.ts
+++ b/packages/maker/deb/src/MakerDeb.ts
@@ -20,7 +20,7 @@ export default class MakerDeb extends MakerBase<MakerDebConfig> {
   defaultPlatforms: ForgePlatform[] = ['linux'];
 
   isSupportedOnCurrentPlatform() {
-    return this.isInstalled('electron-installer-debian');
+    return this.isInstalled('electron-installer-debian') && this.externalBinariesExist(['dpkg', 'fakeroot']);
   }
 
   async make({

--- a/packages/maker/deb/src/MakerDeb.ts
+++ b/packages/maker/deb/src/MakerDeb.ts
@@ -20,7 +20,7 @@ export default class MakerDeb extends MakerBase<MakerDebConfig> {
   defaultPlatforms: ForgePlatform[] = ['linux'];
 
   isSupportedOnCurrentPlatform() {
-    return this.isInstalled('electron-installer-debian') && process.platform === 'linux';
+    return this.isInstalled('electron-installer-debian');
   }
 
   async make({

--- a/packages/maker/flatpak/src/MakerFlatpak.ts
+++ b/packages/maker/flatpak/src/MakerFlatpak.ts
@@ -22,7 +22,7 @@ export default class MakerFlatpak extends MakerBase<MakerFlatpakConfig> {
   defaultPlatforms: ForgePlatform[] = ['linux'];
 
   isSupportedOnCurrentPlatform() {
-    return this.isInstalled('@malept/electron-installer-flatpak');
+    return this.isInstalled('@malept/electron-installer-flatpak') && this.externalBinariesExist(['flatpak-builder']);
   }
 
   async make({

--- a/packages/maker/flatpak/src/MakerFlatpak.ts
+++ b/packages/maker/flatpak/src/MakerFlatpak.ts
@@ -22,7 +22,7 @@ export default class MakerFlatpak extends MakerBase<MakerFlatpakConfig> {
   defaultPlatforms: ForgePlatform[] = ['linux'];
 
   isSupportedOnCurrentPlatform() {
-    return this.isInstalled('@malept/electron-installer-flatpak') && process.platform === 'linux';
+    return this.isInstalled('@malept/electron-installer-flatpak');
   }
 
   async make({

--- a/packages/maker/rpm/src/MakerRpm.ts
+++ b/packages/maker/rpm/src/MakerRpm.ts
@@ -20,7 +20,7 @@ export default class MakerRpm extends MakerBase<MakerRpmConfig> {
   defaultPlatforms: ForgePlatform[] = ['linux'];
 
   isSupportedOnCurrentPlatform() {
-    return this.isInstalled('electron-installer-redhat') && process.platform === 'linux';
+    return this.isInstalled('electron-installer-redhat');
   }
 
   async make({

--- a/packages/maker/rpm/src/MakerRpm.ts
+++ b/packages/maker/rpm/src/MakerRpm.ts
@@ -20,7 +20,7 @@ export default class MakerRpm extends MakerBase<MakerRpmConfig> {
   defaultPlatforms: ForgePlatform[] = ['linux'];
 
   isSupportedOnCurrentPlatform() {
-    return this.isInstalled('electron-installer-redhat');
+    return this.isInstalled('electron-installer-redhat') && this.externalBinariesExist(['rpmbuild']);
   }
 
   async make({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1200,6 +1200,11 @@
     "@types/uglify-js" "*"
     source-map "^0.6.0"
 
+"@types/which@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@types/which/-/which-1.3.1.tgz#7802c380887986ca909008afea4e08025b130f8d"
+  integrity sha512-ZrJDWpvg75LTGX4XwuneY9s6bF3OeZcGTpoGh3zDV9ytzcHMFsRrMIaLBRJZQMBoGyKs6unBQfVdrLZiYfb1zQ==
+
 "@types/ws@*":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-6.0.1.tgz#ca7a3f3756aa12f62a0a62145ed14c6db25d5a28"
@@ -8825,7 +8830,7 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@1, which@1.3.1, which@^1.2.14, which@^1.2.9, which@^1.3.0:
+which@1, which@1.3.1, which@^1.2.14, which@^1.2.9, which@^1.3.0, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Adds a method that checks for the binaries required for a maker to run. For example, `@electron-forge/maker-deb` requires `dpkg` and `fakeroot`.

Fixes #539.
