### PR TITLE
fix: ensure that makers do not overwrite existing un-similar outputs

### DIFF
--- a/packages/maker/deb/src/MakerDeb.ts
+++ b/packages/maker/deb/src/MakerDeb.ts
@@ -31,7 +31,7 @@ export default class MakerDeb extends MakerBase<MakerDebConfig> {
     // eslint-disable-next-line global-require, import/no-unresolved
     const installer = require('electron-installer-debian');
 
-    const outDir = path.resolve(makeDir);
+    const outDir = path.resolve(makeDir, 'deb', targetArch);
 
     await this.ensureDirectory(outDir);
     const { packagePaths } = await installer({

--- a/packages/maker/deb/test/MakerDeb_spec.ts
+++ b/packages/maker/deb/test/MakerDeb_spec.ts
@@ -54,7 +54,7 @@ describe('MakerDeb', () => {
       arch: debianArch(process.arch as ForgeArch),
       options: {},
       src: dir,
-      dest: makeDir,
+      dest: path.join(makeDir, 'deb', process.arch),
       rename: undefined,
     });
     expect(maker.config).to.deep.equal(config);
@@ -80,7 +80,7 @@ describe('MakerDeb', () => {
         productName: 'Debian',
       },
       src: dir,
-      dest: makeDir,
+      dest: path.join(makeDir, 'deb', process.arch),
       rename: undefined,
     });
   });

--- a/packages/maker/flatpak/src/MakerFlatpak.ts
+++ b/packages/maker/flatpak/src/MakerFlatpak.ts
@@ -34,7 +34,7 @@ export default class MakerFlatpak extends MakerBase<MakerFlatpakConfig> {
     const installer = require('@malept/electron-installer-flatpak');
 
     const arch = flatpakArch(targetArch);
-    const outDir = path.resolve(makeDir, 'flatpak');
+    const outDir = path.resolve(makeDir, 'flatpak', arch);
 
     await this.ensureDirectory(outDir);
     const flatpakConfig = Object.assign({}, this.config, {

--- a/packages/maker/flatpak/test/MakerFlatpak_spec.ts
+++ b/packages/maker/flatpak/test/MakerFlatpak_spec.ts
@@ -52,10 +52,11 @@ describe('MakerFlatpak', () => {
       dir, makeDir, appName, targetArch, packageJSON,
     });
     const opts = eifStub.firstCall.args[0];
+    const expectedArch = flatpakArch(process.arch as ForgeArch);
     expect(opts).to.deep.equal({
-      arch: flatpakArch(process.arch as ForgeArch),
+      arch: expectedArch,
       src: dir,
-      dest: path.resolve(makeDir, 'flatpak'),
+      dest: path.resolve(makeDir, 'flatpak', expectedArch),
     });
   });
 
@@ -72,13 +73,14 @@ describe('MakerFlatpak', () => {
       dir, makeDir, appName, targetArch, packageJSON,
     });
     const opts = eifStub.firstCall.args[0];
+    const expectedArch = flatpakArch(process.arch as ForgeArch);
     expect(opts).to.deep.equal({
-      arch: flatpakArch(process.arch as ForgeArch),
+      arch: expectedArch,
       options: {
         productName: 'Flatpak',
       },
       src: dir,
-      dest: path.resolve(makeDir, 'flatpak'),
+      dest: path.resolve(makeDir, 'flatpak', expectedArch),
     });
   });
 });

--- a/packages/maker/rpm/src/MakerRpm.ts
+++ b/packages/maker/rpm/src/MakerRpm.ts
@@ -31,7 +31,7 @@ export default class MakerRpm extends MakerBase<MakerRpmConfig> {
     // eslint-disable-next-line global-require, import/no-unresolved
     const installer = require('electron-installer-redhat');
 
-    const outDir = path.resolve(makeDir);
+    const outDir = path.resolve(makeDir, 'rpm', targetArch);
 
     await this.ensureDirectory(outDir);
     const { packagePaths } = await installer({

--- a/packages/maker/rpm/test/MakerRpm_spec.ts
+++ b/packages/maker/rpm/test/MakerRpm_spec.ts
@@ -53,7 +53,7 @@ describe('MakerRpm', () => {
     expect(opts).to.deep.equal({
       arch: rpmArch(process.arch as ForgeArch),
       src: dir,
-      dest: makeDir,
+      dest: path.join(makeDir, 'rpm', process.arch),
       rename: undefined,
     });
   });
@@ -77,7 +77,7 @@ describe('MakerRpm', () => {
         productName: 'Redhat',
       },
       src: dir,
-      dest: makeDir,
+      dest: path.join(makeDir, 'rpm', process.arch),
       rename: undefined,
     });
   });

--- a/packages/maker/snap/src/MakerSnap.ts
+++ b/packages/maker/snap/src/MakerSnap.ts
@@ -22,7 +22,7 @@ export default class MakerSnap extends MakerBase<MakerSnapConfig> {
     // eslint-disable-next-line global-require
     const installer = require('electron-installer-snap');
 
-    const outPath = path.resolve(makeDir, 'snap');
+    const outPath = path.resolve(makeDir, 'snap', targetArch);
 
     await this.ensureDirectory(outPath);
 

--- a/packages/maker/snap/test/MakerSnap_spec.ts
+++ b/packages/maker/snap/test/MakerSnap_spec.ts
@@ -51,7 +51,7 @@ describe('MakerSnap', () => {
     expect(opts).to.deep.equal({
       arch: process.arch,
       src: dir,
-      dest: path.resolve(makeDir, 'snap'),
+      dest: path.resolve(makeDir, 'snap', process.arch),
     });
   });
 
@@ -69,7 +69,7 @@ describe('MakerSnap', () => {
     expect(opts).to.deep.equal({
       arch: process.arch,
       src: dir,
-      dest: path.resolve(makeDir, 'snap'),
+      dest: path.resolve(makeDir, 'snap', process.arch),
       description: 'Snap description',
     });
   });

--- a/packages/maker/zip/src/MakerZIP.ts
+++ b/packages/maker/zip/src/MakerZIP.ts
@@ -20,6 +20,7 @@ export default class MakerZIP extends MakerBase<MakerZIPConfig> {
     makeDir,
     appName,
     packageJSON,
+    targetArch,
     targetPlatform,
   }: MakerOptions) {
     // eslint-disable-next-line global-require
@@ -27,7 +28,7 @@ export default class MakerZIP extends MakerBase<MakerZIPConfig> {
 
     const zipDir = ['darwin', 'mas'].includes(targetPlatform) ? path.resolve(dir, `${appName}.app`) : dir;
 
-    const zipPath = path.resolve(makeDir, `${path.basename(dir)}-${packageJSON.version}.zip`);
+    const zipPath = path.resolve(makeDir, 'zip', targetPlatform, targetArch, `${path.basename(dir)}-${packageJSON.version}.zip`);
 
     await this.ensureFile(zipPath);
     await promisify(zip)(zipDir, zipPath);


### PR DESCRIPTION
Fixes #1081

Previously some makers claimed the entire out directory as their out directory (`deb` and `rpm`) which resulted in subsequent calls to `ensureDirectory` wiping the entire out directory.

This PR ensures that all makers output things to their own directory + arch sub directory of the relevant platform supports both ia32 and x64.

