### PR TITLE
feat(webpack-constants): add constants package

### DIFF
--- a/packages/utils/webpack-constants/README.md
+++ b/packages/utils/webpack-constants/README.md
@@ -1,0 +1,20 @@
+# @electron-forge/webpack-constants
+
+> Expose electron forges webpack magic constants
+
+This module makes it simple and type safe to use the webpack magic constants
+provided by @electron-forge.
+
+## Usage
+
+```ts
+import { mainWindowWebpackEntry, mainWindowPreloadWebpackEntry } from "@electron-forge/webpack-constants";
+
+const mainWindow = new BrowserWindow({
+  webPreferences: {
+    preload: mainWindowPreloadWebpackEntry
+  }
+});
+
+mainWindow.loadUrl(mainWindowWebpackEntry);
+```

--- a/packages/utils/webpack-constants/package.json
+++ b/packages/utils/webpack-constants/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@electron-forge/webpack-constants",
+  "version": "6.0.0-beta.44",
+  "description": "Expose electron forges webpack magic constants",
+  "repository": "https://github.com/electron-userland/electron-forge",
+  "author": "Samuel Attard",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
+  "devDependencies": {},
+  "dependencies": {},
+  "engines": {
+    "node": ">= 8.0"
+  }
+}

--- a/packages/utils/webpack-constants/src/index.ts
+++ b/packages/utils/webpack-constants/src/index.ts
@@ -1,0 +1,8 @@
+// these are added by @electron-forge/plugin-webpack
+// https://www.electronforge.io/config/plugins/webpack
+
+declare const MAIN_WINDOW_WEBPACK_ENTRY: string;
+declare const MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY: string;
+
+export const mainWindowWebpackEntry: string = MAIN_WINDOW_WEBPACK_ENTRY;
+export const mainWindowPreloadWebpackEntry: string = MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY;


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

I was planning on diving into the webpack setup to further investigate https://github.com/electron-userland/electron-forge/issues/1113 and figured it would be good to familiarise myself with the projects code by picking up an existing issue. 

This was proposed in https://github.com/electron-userland/electron-forge/issues/704.

I tested this locally by running yarn build locally, and then manually copying the webpack-constants folder into my projects node_modules.

While I've added a `README.md` I've also created [this matching documentation pull request](https://github.com/MarshallOfSound/electron-forge-docs/pull/2) in the https://github.com/MarshallOfSound/electron-forge-docs repository that adds this information as that seems to be where most of the documentation lives for the project.

(As it was an old issue, I completely understand if this is no longer the direction/solution you'd like to pursue for this issue 👍)

![screenshot of intellisense showing the exported constant having the type of string](https://user-images.githubusercontent.com/848525/63769732-6cc0c600-c8cb-11e9-9ddd-d98c4204037e.png)
☝️ demonstration of constant being used in vscode 