### PR TITLE
fix(plugin-webpack): add missing debug level for webpack-dev-middleware

### DIFF
--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -423,6 +423,7 @@ Your packaged app may be larger than expected if you dont ignore everything othe
       const compiler = webpack(config);
       const server = webpackDevMiddleware(compiler, {
         logger: {
+          debug: tab.log.bind(tab),
           log: tab.log.bind(tab),
           info: tab.log.bind(tab),
           error: tab.log.bind(tab),


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Tried to bootstrap new Electron app with `elector-forge` (TS + `plugin-webpack`). Got such error:

```
An unhandled exception has occurred inside Forge:
log.debug is not a function
TypeError: log.debug is not a function
    at /Users/project/node_modules/webpack-dev-middleware/lib/fs.js:63:21
    at /Users/project/node_modules/graceful-fs/graceful-fs.js:57:14
    at FSReqCallback.oncomplete (fs.js:153:23)
```

Thought it could be on my end and tried to create brand new project following setup guide:

```sh
$ yarn create electron-app my-new-app --template=webpack
```

It fail with same error as well. After checking where problem actually appears, found that `webpack-dev-middleware` has `log.debug` method in use: https://github.com/webpack/webpack-dev-middleware/blob/master/lib/fs.js#L63

In their README they mention `debug` as required logger level as well: https://github.com/webpack/webpack-dev-middleware#logger

`plugin-webpack` has `debug` logger level missing. One-line fix solving the issue.