### PR TITLE
build: use v2 of dependabolt

### DIFF
--- a/.github/workflows/dependabolt.yml
+++ b/.github/workflows/dependabolt.yml
@@ -10,6 +10,6 @@ jobs:
       if: github.event.ref_type == 'branch' && startsWith(github.event.ref, 'dependabot/')
       uses: actions/checkout@v1
     - name: Run dependabolt
-      uses: docker://malept/gha-dependabolt:1.1.0
+      uses: docker://malept/gha-dependabolt:2.0.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

The action migrates to GitHub Actions v2. There should be no difference in functionality.