### PR TITLE
fix: Fix npm install message on error

### DIFF
--- a/packages/api/core/src/api/init-scripts/init-custom.ts
+++ b/packages/api/core/src/api/init-scripts/init-custom.ts
@@ -31,7 +31,7 @@ export default async (dir: string, template: string) => {
               templateModulePath = require.resolve(template);
               d('using absolute template');
             } catch (err5) {
-              throw new Error(`Failed to locate custom template: "${template}"\n\nTry \`npm install -g @electron-forge-template-${template}\``);
+              throw new Error(`Failed to locate custom template: "${template}"\n\nTry \`npm install -g electron-forge-template-${template}\``);
             }
           }
         }

--- a/packages/api/core/src/api/init-scripts/init-custom.ts
+++ b/packages/api/core/src/api/init-scripts/init-custom.ts
@@ -31,7 +31,7 @@ export default async (dir: string, template: string) => {
               templateModulePath = require.resolve(template);
               d('using absolute template');
             } catch (err5) {
-              throw new Error(`Failed to locate custom template: "${template}"\n\nTry \`npm install -g electron-forge-template-${template}\``);
+              throw new Error(`Failed to locate custom template: "${template}"\n\nTry \`npm install -g @electron-forge/template-${template}\` or \`npm install -g electron-forge-template-${template}\``);
             }
           }
         }


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

The old install message is wrong. `npm install -g @electron-forge-template-${template}`.

It should be
`npm install -g electron-forge-template-${template}`
or
`npm install -g @electron-forge/template-${template}`

