### PR TITLE
fix(plugin-webpack): add missing debug level for webpack-dev-middleware

### DIFF
--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -423,6 +423,7 @@ Your packaged app may be larger than expected if you dont ignore everything othe
       const compiler = webpack(config);
       const server = webpackDevMiddleware(compiler, {
         logger: {
+          debug: tab.log.bind(tab),
           log: tab.log.bind(tab),
           info: tab.log.bind(tab),
           error: tab.log.bind(tab),


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x ] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x ] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x ] The changes are appropriately documented (if applicable).
* [x ] The changes have sufficient test coverage (if applicable).
* [x ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This is a one line add to the WebpackPlugin.js, to add the debug method to the logger. Without it projects created with webpack template can't be launched as the "debug" method on the loggert is required. 

I have not made the change myself, but noticed someone did and that there is no pull request with the change, so since it made work again I figured it might be a good idea to fix it on the master branch.
