### PR TITLE
when HMR fails, it should fallback to page reload

### DIFF
--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -331,7 +331,7 @@ Your packaged app may be larger than expected if you dont ignore everything othe
       const prefixedEntries = entryPoint.prefixedEntries || [];
       entry[entryPoint.name] = prefixedEntries
         .concat([entryPoint.js])
-        .concat(this.isProd || !entryPoint.html ? [] : ['webpack-hot-middleware/client']);
+        .concat(this.isProd || !entryPoint.html ? [] : ['webpack-hot-middleware/client?reload=true']);
     }
 
     const defines = this.getDefines(false);


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [ ] The changes are appropriately documented (if applicable).
* [ ] The changes have sufficient test coverage (if applicable).
* [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

when HMR fails (in case of React for example), it should do a page reload.

see #1247 and #1164 