### PR TITLE
test(rebuild): sync native modules with the ones used in the electron-rebuild testsuite

### DIFF
--- a/packages/api/core/test/fixture/native_app/package.json
+++ b/packages/api/core/test/fixture/native_app/package.json
@@ -14,14 +14,14 @@
     "forge": "./forge.config.js"
   },
   "devDependencies": {
-    "ffi": "2.2.0"
+    "ffi-napi": "2.4.5"
   },
   "dependencies": {
-    "ref": "1.3.3",
-    "benchr": "3.2.0",
-    "@newrelic/native-metrics": "2.1.1"
+    "@nlv8/signun": "1.3.4",
+    "electron-markdown": "0.6.0",
+    "ref-napi": "1.4.2"
   },
   "optionalDependencies": {
-    "zipfile": "0.5.11"
+    "bcrypt": "3.0.6"
   }
 }

--- a/packages/api/core/test/slow/api_spec_slow.ts
+++ b/packages/api/core/test/slow/api_spec_slow.ts
@@ -284,14 +284,14 @@ describe(`electron-forge API (with installer=${nodeInstaller})`, () => {
     });
 
     it('can package without errors with native pre-gyp deps installed', async () => {
-      await installDeps(dir, ['ref']);
+      await installDeps(dir, ['ref-napi']);
       await forge.package({ dir });
-      await fs.remove(path.resolve(dir, 'node_modules/ref'));
+      await fs.remove(path.resolve(dir, 'node_modules/ref-napi'));
     });
 
     it('can package without errors', async () => {
       const packageJSON = await readRawPackageJson(dir);
-      delete packageJSON.dependencies.ref;
+      delete packageJSON.dependencies['ref-napi'];
       packageJSON.config.forge.packagerConfig.asar = true;
       await fs.writeJson(path.resolve(dir, 'package.json'), packageJSON);
 

--- a/packages/api/core/test/slow/rebuild_spec_slow.ts
+++ b/packages/api/core/test/slow/rebuild_spec_slow.ts
@@ -23,7 +23,7 @@ describe('rebuilder', () => {
   }
 
   async function doRebuild(config?: Partial<RebuildOptions>) {
-    await rebuild(testModulePath, '1.4.12', process.platform as ForgePlatform, process.arch as ForgeArch, config);
+    await rebuild(testModulePath, '5.0.12', process.platform as ForgePlatform, process.arch as ForgeArch, config);
   }
 
   describe('no config', () => {
@@ -33,45 +33,45 @@ describe('rebuilder', () => {
     });
 
     it('should have rebuilt top level prod dependencies', async () => {
-      const forgeMeta = path.resolve(testModulePath, 'node_modules', 'ref', 'build', 'Release', '.forge-meta');
-      expect(await fs.pathExists(forgeMeta), 'ref build meta should exist').to.equal(true);
+      const forgeMeta = path.resolve(testModulePath, 'node_modules', 'ref-napi', 'build', 'Release', '.forge-meta');
+      expect(await fs.pathExists(forgeMeta), 'ref-napi build meta should exist').to.equal(true);
     });
 
     it('should have rebuilt children of top level prod dependencies', async () => {
-      const forgeMeta = path.resolve(testModulePath, 'node_modules', 'microtime', 'build', 'Release', '.forge-meta');
-      expect(await fs.pathExists(forgeMeta), 'microtime build meta should exist').to.equal(true);
+      const forgeMeta = path.resolve(testModulePath, 'node_modules', 'cmark-gfm', 'build', 'Release', '.forge-meta');
+      expect(await fs.pathExists(forgeMeta), 'cmark-gfm build meta should exist').to.equal(true);
     });
 
     it('should have rebuilt children of scoped top level prod dependencies', async () => {
-      const forgeMeta = path.resolve(testModulePath, 'node_modules', '@newrelic/native-metrics', 'build', 'Release', '.forge-meta');
-      expect(await fs.pathExists(forgeMeta), '@newrelic/native-metrics build meta should exist').to.equal(true);
+      const forgeMeta = path.resolve(testModulePath, 'node_modules', '@nlv8/signun', 'build', 'Release', '.forge-meta');
+      expect(await fs.pathExists(forgeMeta), '@nlv8/signun build meta should exist').to.equal(true);
     });
 
     it('should have rebuilt top level optional dependencies', async () => {
-      const forgeMeta = path.resolve(testModulePath, 'node_modules', 'zipfile', 'build', 'Release', '.forge-meta');
-      expect(await fs.pathExists(forgeMeta), 'zipfile build meta should exist').to.equal(true);
+      const forgeMeta = path.resolve(testModulePath, 'node_modules', 'bcrypt', 'build', 'Release', '.forge-meta');
+      expect(await fs.pathExists(forgeMeta), 'bcrypt build meta should exist').to.equal(true);
     });
 
     it('should not have rebuilt top level devDependencies', async () => {
-      const forgeMeta = path.resolve(testModulePath, 'node_modules', 'ffi', 'build', 'Release', '.forge-meta');
-      expect(await fs.pathExists(forgeMeta), 'ffi build meta should not exist').to.equal(false);
+      const forgeMeta = path.resolve(testModulePath, 'node_modules', 'ffi-napi', 'build', 'Release', '.forge-meta');
+      expect(await fs.pathExists(forgeMeta), 'ffi-napi build meta should not exist').to.equal(false);
     });
   });
 
   describe('with config', () => {
     before(async () => {
       await setupProject();
-      await doRebuild({ onlyModules: ['ref'] });
+      await doRebuild({ onlyModules: ['ref-napi'] });
     });
 
     it('should have rebuilt module in onlyModules', async () => {
-      const forgeMeta = path.resolve(testModulePath, 'node_modules', 'ref', 'build', 'Release', '.forge-meta');
-      expect(await fs.pathExists(forgeMeta), 'ref build meta should exist').to.equal(true);
+      const forgeMeta = path.resolve(testModulePath, 'node_modules', 'ref-napi', 'build', 'Release', '.forge-meta');
+      expect(await fs.pathExists(forgeMeta), 'ref-napi build meta should exist').to.equal(true);
     });
 
     it('should not have rebuilt module not in onlyModules', async () => {
-      const forgeMeta = path.resolve(testModulePath, 'node_modules', 'zipfile', 'build', 'Release', '.forge-meta');
-      expect(await fs.pathExists(forgeMeta), 'zipfile build meta should not exist').to.equal(false);
+      const forgeMeta = path.resolve(testModulePath, 'node_modules', 'bcrypt', 'build', 'Release', '.forge-meta');
+      expect(await fs.pathExists(forgeMeta), 'bcrypt build meta should not exist').to.equal(false);
     });
   });
 


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).