### PR TITLE
fix(cli): warn on unknown commands

### DIFF
--- a/packages/api/cli/package.json
+++ b/packages/api/cli/package.json
@@ -12,6 +12,8 @@
   },
   "devDependencies": {
     "chai": "4.2.0",
+    "chai-as-promised": "^7.0.0",
+    "cross-spawn-promise": "^0.10.1",
     "mocha": "^6.2.2"
   },
   "dependencies": {

--- a/packages/api/cli/src/electron-forge.ts
+++ b/packages/api/cli/src/electron-forge.ts
@@ -34,7 +34,13 @@ program
   .command('make', 'Generate distributables for the current Electron application')
   .command('start', 'Start the current Electron application')
   .command('publish', 'Publish the current Electron application to GitHub')
-  .command('install', 'Install an Electron application from GitHub');
+  .command('install', 'Install an Electron application from GitHub')
+  .on('command:*', () => {
+    console.error();
+    console.error(`Unknown command "${program.args.join(' ')}".`.red);
+    console.error('See --help for a list of available commands.');
+    process.exit(1);
+  });
 
 (async () => {
   let goodSystem;

--- a/packages/api/cli/test/cli_spec.ts
+++ b/packages/api/cli/test/cli_spec.ts
@@ -5,9 +5,14 @@ import spawnPromise from 'cross-spawn-promise';
 
 chai.use(chaiAsPromised);
 
+function tsNodePath() {
+  const tsNode = path.resolve(__dirname, '../../../../node_modules/.bin/ts-node');
+  return process.platform === 'win32' ? `${tsNode}.cmd` : tsNode;
+}
+
 describe('cli', () => {
   it('should fail on unknown subcommands', async () => {
-    const error = await expect(spawnPromise(path.resolve(__dirname, '../../../../node_modules/.bin/ts-node'), [path.resolve(__dirname, '../src/electron-forge.ts'), 'nonexistent'])).to.eventually.be.rejected;
+    const error = await expect(spawnPromise(tsNodePath(), [path.resolve(__dirname, '../src/electron-forge.ts'), 'nonexistent'])).to.eventually.be.rejected;
     expect(error.exitStatus).to.equal(1);
     expect(error.stderr.toString()).to.match(/Unknown command "nonexistent"/);
   });

--- a/packages/api/cli/test/cli_spec.ts
+++ b/packages/api/cli/test/cli_spec.ts
@@ -1,0 +1,14 @@
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import path from 'path';
+import spawnPromise from 'cross-spawn-promise';
+
+chai.use(chaiAsPromised);
+
+describe('cli', () => {
+  it('should fail on unknown subcommands', async () => {
+    const error = await expect(spawnPromise(path.resolve(__dirname, '../../../../node_modules/.bin/ts-node'), [path.resolve(__dirname, '../src/electron-forge.ts'), 'nonexistent'])).to.eventually.be.rejected;
+    expect(error.exitStatus).to.equal(1);
+    expect(error.stderr.toString()).to.match(/Unknown command "nonexistent"/);
+  });
+});


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Emit a warning and exit with status code 1.

Based on https://github.com/tj/commander.js/issues/1088#issuecomment-549018472

Example:

```bash
$ electron-forge foobar foo
✔ Checking your system

Unknown command "foobar foo".
See --help for a list of available commands.
```

Fixes #1300
Closes #1301 _(This is a simpler version, with an integration test added.)_