### PR TITLE
fix(maker-windows): handle versions with prerelease information

### DIFF
--- a/packages/api/core/test/slow/api_spec_slow.ts
+++ b/packages/api/core/test/slow/api_spec_slow.ts
@@ -341,13 +341,21 @@ describe(`electron-forge API (with installer=${nodeInstaller})`, () => {
             return maker.isSupportedOnCurrentPlatform() === good
               && maker.externalBinariesExist() === good;
           })
-          .map((makerPath) => () => ({
-            name: makerPath,
-            platforms: [process.platform],
-            config: {
-              devCert,
-            },
-          }));
+          .map((makerPath) => () => {
+            const makerDefinition = {
+              name: makerPath,
+              platforms: [process.platform],
+              config: {
+                devCert,
+              },
+            };
+
+            if (process.platform === 'win32') {
+              (makerDefinition.config as any).makeVersionWinStoreCompatible = true;
+            }
+
+            return makerDefinition;
+          });
       }
 
       const goodMakers = getMakers(true);

--- a/packages/api/core/test/slow/api_spec_slow.ts
+++ b/packages/api/core/test/slow/api_spec_slow.ts
@@ -232,6 +232,7 @@ describe(`electron-forge API (with installer=${nodeInstaller})`, () => {
 
       const packageJSON = await readRawPackageJson(dir);
       packageJSON.name = 'testapp';
+      packageJSON.version = '1.0.0-beta.1';
       packageJSON.productName = 'Test-App';
       packageJSON.config.forge.packagerConfig.asar = false;
       if (process.platform === 'win32') {

--- a/packages/maker/appx/src/MakerAppX.ts
+++ b/packages/maker/appx/src/MakerAppX.ts
@@ -123,10 +123,9 @@ export default class MakerAppX extends MakerBase<MakerAppXConfig> {
       );
     }
 
-    if (opts.packageVersion.match(/-/)) {
+    if (opts.packageVersion.includes('-')) {
       if (opts.makeVersionWinStoreCompatible) {
-        const noBeta = opts.packageVersion.replace(/-.*/, '');
-        opts.packageVersion = `${noBeta}.0`;
+        opts.packageVersion = this.normalizeWindowsVersion(opts.packageVersion);
       } else {
         throw new Error(
           "Windows Store version numbers don't support semver beta tags. To "

--- a/packages/maker/base/src/Maker.ts
+++ b/packages/maker/base/src/Maker.ts
@@ -162,4 +162,13 @@ export default abstract class Maker<C> implements IForgeMaker {
       return false;
     }
   }
+
+  /**
+   * Normalize the given semver-formatted version to a 4-part dot delimited version number without
+   * prerelease information for use in Windows apps.
+   */
+  normalizeWindowsVersion(version: string): string {
+    const noPrerelease = version.replace(/-.*/, '');
+    return `${noPrerelease}.0`;
+  }
 }

--- a/packages/maker/base/test/version_spec.ts
+++ b/packages/maker/base/test/version_spec.ts
@@ -1,0 +1,22 @@
+import { expect } from 'chai';
+
+import MakerBase from '../src/Maker';
+
+class MakerImpl extends MakerBase<{}> {
+  name = 'test';
+
+  defaultPlatforms = [];
+}
+
+describe('normalizeWindowsVersion', () => {
+  const maker = new MakerImpl({}, []);
+
+  it('removes everything after the dash', () => {
+    for (const version of ['1.0.0-alpha', '1.0.0-alpha.1', '1.0.0-0.3.7', '1.0.0-x.7.z.92']) {
+      expect(maker.normalizeWindowsVersion(version)).to.equal('1.0.0.0');
+    }
+  });
+  it('does not truncate the version when there is no dash', () => {
+    expect(maker.normalizeWindowsVersion('2.0.0')).to.equal('2.0.0.0');
+  });
+});

--- a/packages/maker/squirrel/src/MakerSquirrel.ts
+++ b/packages/maker/squirrel/src/MakerSquirrel.ts
@@ -1,7 +1,7 @@
 import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';
 
-import { createWindowsInstaller, Options as ElectronWinstallerOptions } from 'electron-winstaller';
+import { convertVersion, createWindowsInstaller, Options as ElectronWinstallerOptions } from 'electron-winstaller';
 import fs from 'fs-extra';
 import path from 'path';
 
@@ -39,12 +39,14 @@ export default class MakerSquirrel extends MakerBase<MakerSquirrelConfig> {
 
     await createWindowsInstaller(winstallerConfig);
 
+    const nupkgVersion = convertVersion(packageJSON.version);
+
     const artifacts = [
       path.resolve(outPath, 'RELEASES'),
       path.resolve(outPath, winstallerConfig.setupExe || `${appName}Setup.exe`),
-      path.resolve(outPath, `${winstallerConfig.name}-${packageJSON.version}-full.nupkg`),
+      path.resolve(outPath, `${winstallerConfig.name}-${nupkgVersion}-full.nupkg`),
     ];
-    const deltaPath = path.resolve(outPath, `${winstallerConfig.name}-${packageJSON.version}-delta.nupkg`);
+    const deltaPath = path.resolve(outPath, `${winstallerConfig.name}-${nupkgVersion}-delta.nupkg`);
     if (winstallerConfig.remoteReleases || await fs.pathExists(deltaPath)) {
       artifacts.push(deltaPath);
     }

--- a/packages/maker/wix/package.json
+++ b/packages/maker/wix/package.json
@@ -17,7 +17,9 @@
   "dependencies": {
     "@electron-forge/maker-base": "6.0.0-beta.45",
     "@electron-forge/shared-types": "6.0.0-beta.45",
+    "colors": "^1.4.0",
     "electron-wix-msi": "^2.1.1",
+    "log-symbols": "^3.0.0",
     "parse-author": "^2.0.0"
   }
 }

--- a/packages/maker/wix/src/MakerWix.ts
+++ b/packages/maker/wix/src/MakerWix.ts
@@ -1,7 +1,7 @@
 import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';
 
-import colors;
+import 'colors';
 import logSymbols from 'log-symbols';
 import path from 'path';
 
@@ -30,9 +30,10 @@ export default class MakerWix extends MakerBase<MakerWixConfig> {
     const outPath = path.resolve(makeDir, `wix/${targetArch}`);
     await this.ensureDirectory(outPath);
 
-    let version = packageJSON.version;
+    let { version } = packageJSON;
     if (version.includes('-')) {
-      console.warn(logSymbols.warning, 'WARNING: WiX distributables does not handle prerelease information in the app version, removing it from the MSI'.yellow);
+      // eslint-disable-next-line no-console
+      console.warn(logSymbols.warning, 'WARNING: WiX distributables do not handle prerelease information in the app version, removing it from the MSI'.yellow);
       version = this.normalizeWindowsVersion(version);
     }
 

--- a/packages/maker/wix/src/MakerWix.ts
+++ b/packages/maker/wix/src/MakerWix.ts
@@ -1,6 +1,8 @@
 import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';
 
+import colors;
+import logSymbols from 'log-symbols';
 import path from 'path';
 
 import { MSICreator, MSICreatorOptions } from 'electron-wix-msi/lib/creator';
@@ -28,10 +30,16 @@ export default class MakerWix extends MakerBase<MakerWixConfig> {
     const outPath = path.resolve(makeDir, `wix/${targetArch}`);
     await this.ensureDirectory(outPath);
 
+    let version = packageJSON.version;
+    if (version.includes('-')) {
+      console.warn(logSymbols.warning, 'WARNING: WiX distributables does not handle prerelease information in the app version, removing it from the MSI'.yellow);
+      version = this.normalizeWindowsVersion(version);
+    }
+
     const creator = new MSICreator(({
       description: packageJSON.description,
       name: appName,
-      version: packageJSON.version,
+      version,
       manufacturer: getNameFromAuthor(packageJSON.author),
       exe: `${appName}.exe`,
       ...this.config,


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

The WiX and Squirrel makers don't handle prerelease information in the version, so we need to handle it in a similar manner to the AppX maker (except not making the user set a flag to normalize the version).

Fixes #1245.