### PR TITLE
fix(plugin-webpack): handle package.json files without config keys

### DIFF
--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -113,12 +113,16 @@ export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
   });
 
   init = (dir: string) => {
-    this.projectDir = dir;
-    this.baseDir = path.resolve(dir, '.webpack');
+    this.setDirectories(dir);
 
     d('hooking process events');
     process.on('exit', (_code) => this.exitHandler({ cleanup: true }));
     process.on('SIGINT' as NodeJS.Signals, (_signal) => this.exitHandler({ exit: true }));
+  }
+
+  setDirectories = (dir: string) => {
+    this.projectDir = dir;
+    this.baseDir = path.resolve(dir, '.webpack');
   }
 
   private loggedOutputUrl = false;
@@ -173,7 +177,9 @@ Your packaged app may be larger than expected if you dont ignore everything othe
 
   packageAfterCopy = async (_: any, buildPath: string) => {
     const pj = await fs.readJson(path.resolve(this.projectDir, 'package.json'));
-    delete pj.config.forge;
+    if (pj.config) {
+      delete pj.config.forge;
+    }
     pj.devDependencies = {};
     pj.dependencies = {};
     pj.optionalDependencies = {};

--- a/packages/plugin/webpack/test/WebpackPlugin_spec.ts
+++ b/packages/plugin/webpack/test/WebpackPlugin_spec.ts
@@ -1,8 +1,13 @@
 import { expect } from 'chai';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { tmpdir } from 'os';
 
 import WebpackPlugin from '../src/WebpackPlugin';
 
 describe('WebpackPlugin', () => {
+  const webpackTestDir = path.resolve(tmpdir(), 'electron-forge-plugin-webpack-test');
+
   describe('PRELOAD_WEBPACK_ENTRY', () => {
     it('should assign absolute preload script path in development', () => {
       const p = new WebpackPlugin({
@@ -50,6 +55,45 @@ describe('WebpackPlugin', () => {
       (p as any).isProd = true;
       const defines = p.getDefines();
       expect(defines.WINDOW_PRELOAD_WEBPACK_ENTRY).to.be.eq("require('path').resolve(__dirname, '../renderer', 'window', 'preload.js')");
+    });
+  });
+
+  describe('packageAfterCopy', () => {
+    const packageJSONPath = path.join(webpackTestDir, 'package.json');
+    const packagedPath = path.join(webpackTestDir, 'packaged');
+    const packagedPackageJSONPath = path.join(packagedPath, 'package.json');
+    let plugin: WebpackPlugin;
+
+    before(async () => {
+      await fs.ensureDir(packagedPath);
+      plugin = new WebpackPlugin({
+        mainConfig: {},
+        renderer: {
+          config: {},
+          entryPoints: [],
+        },
+      });
+      plugin.setDirectories(webpackTestDir);
+    });
+
+    it('should remove config.forge from package.json', async () => {
+      const packageJSON = { config: { forge: 'config.js' } };
+      await fs.writeJson(packageJSONPath, packageJSON);
+      await plugin.packageAfterCopy(null, packagedPath);
+      expect(await fs.pathExists(packagedPackageJSONPath)).to.equal(true);
+      expect((await fs.readJson(packagedPackageJSONPath)).config).to.not.have.property('forge');
+    });
+
+    it('should succeed if there is no config.forge', async () => {
+      const packageJSON = { name: 'test' };
+      await fs.writeJson(packageJSONPath, packageJSON);
+      await plugin.packageAfterCopy(null, packagedPath);
+      expect(await fs.pathExists(packagedPackageJSONPath)).to.equal(true);
+      expect((await fs.readJson(packagedPackageJSONPath))).to.not.have.property('config');
+    });
+
+    after(async () => {
+      await fs.remove(webpackTestDir);
     });
   });
 });


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Fixes #1326.