### PR TITLE
build: disable docs CI step until NOW_TOKEN is defined

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,6 @@ jobs:
         if: matrix.os != 'windows-latest'
         run: bolt coverage
         env:
-          CI: true
           NODE_INSTALLER: ${{ matrix.node-installer }}
           DEBUG: electron-installer-snap:snapcraft
       - name: Codecov
@@ -86,34 +85,34 @@ jobs:
           CI_OS: ${{ matrix.os }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           NODE_INSTALLER: ${{ matrix.node-installer }}
-  docs:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    needs: build
-    runs-on: [ubuntu-latest]
-    steps:
-      - uses: actions/checkout@v1
-      - name: Use Node.js 12.x
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
-      - name: Cache node_modules
-        uses: actions/cache@v1
-        with:
-          path: node_modules
-          key: ${{ runner.OS }}-build-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.OS }}-build-${{ env.cache-name }}-
-            ${{ runner.OS }}-build-
-            ${{ runner.OS }}-
-      - name: Install bolt
-        shell: bash
-        run: |
-          case "$(uname -s)" in
-            Windows*|CYGWIN*|MINGW*|MSYS*) BOLT_VERSION=0.21.2 ;;
-            *) BOLT_VERSION=latest ;;
-          esac
-          npm install -g bolt@$BOLT_VERSION
-      - name: Deploy docs
-        run: ci/docs.sh
-        env:
-          NOW_TOKEN: ${{ secrets.NOW_TOKEN }}
+  # docs:
+  #   if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+  #   needs: build
+  #   runs-on: [ubuntu-latest]
+  #   steps:
+  #     - uses: actions/checkout@v1
+  #     - name: Use Node.js 12.x
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 12.x
+  #     - name: Cache node_modules
+  #       uses: actions/cache@v1
+  #       with:
+  #         path: node_modules
+  #         key: ${{ runner.OS }}-build-${{ hashFiles('**/yarn.lock') }}
+  #         restore-keys: |
+  #           ${{ runner.OS }}-build-${{ env.cache-name }}-
+  #           ${{ runner.OS }}-build-
+  #           ${{ runner.OS }}-
+  #     - name: Install bolt
+  #       shell: bash
+  #       run: |
+  #         case "$(uname -s)" in
+  #           Windows*|CYGWIN*|MINGW*|MSYS*) BOLT_VERSION=0.21.2 ;;
+  #           *) BOLT_VERSION=latest ;;
+  #         esac
+  #         npm install -g bolt@$BOLT_VERSION
+  #     - name: Deploy docs
+  #       run: ci/docs.sh
+  #       env:
+  #         NOW_TOKEN: ${{ secrets.NOW_TOKEN }}


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

@MarshallOfSound I'm disabling the docs job until the `NOW_TOKEN` variable is defined in the GitHub secrets for the repository.