### PR TITLE
refactor(template-typescript): use main script to start app

### DIFF
--- a/packages/template/typescript/src/TypeScriptTemplate.ts
+++ b/packages/template/typescript/src/TypeScriptTemplate.ts
@@ -22,7 +22,8 @@ class TypeScriptTemplate implements ForgeTemplate {
 
       // Configure scripts for TS template
       packageJSON.scripts.lint = 'tslint -c tslint.json -p tsconfig.json';
-      packageJSON.scripts.start = 'tsc && electron-forge start -p dist';
+      packageJSON.scripts.start = 'tsc && electron-forge start';
+      packageJSON.main = 'dist/index.js';
 
       await fs.writeJson(packageJSONPath, packageJSON, { spaces: 2 });
     });


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Fixes up the scripts to set `main` in `package.json` to dist instead of baking it into the start script.
