### PR TITLE
fix: remove `.webpack` from exclude rule setting

### DIFF
--- a/packages/template/typescript-webpack/tmpl/webpack.rules.js
+++ b/packages/template/typescript-webpack/tmpl/webpack.rules.js
@@ -16,7 +16,7 @@ module.exports = [
   },
   {
     test: /\.tsx?$/,
-    exclude: /(node_modules|.webpack)/,
+    exclude: /(node_modules)/,
     loaders: [{
       loader: 'ts-loader',
       options: {

--- a/packages/template/webpack/tmpl/webpack.rules.js
+++ b/packages/template/webpack/tmpl/webpack.rules.js
@@ -21,7 +21,7 @@ module.exports = [
    *
    * {
    *   test: /\.tsx?$/,
-   *   exclude: /(node_modules|.webpack)/,
+   *   exclude: /(node_modules)/,
    *   loaders: [{
    *     loader: 'ts-loader',
    *     options: {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [ ] The changes are appropriately documented (if applicable).
* [ ] The changes have sufficient test coverage (if applicable).
* [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
Thank you for good project.
I try to use `@electron-forge/template-webpack` and found that commented out part is not collect.

When append excluding `.webpack` directory, my some codes not compiled.
I think that may need remove ( and removed setting version work collect in my environment [example](https://github.com/terrierscript/example-electron-forge-ts-babel-loader-webpack/blob/master/webpack.rules.js) )  

If this is my misunderstanding, please close this PR.
