### PR TITLE
fix(template-typescript-webpack): adjust ts-loader module rule syntax

### DIFF
--- a/packages/template/typescript-webpack/tmpl/webpack.rules.js
+++ b/packages/template/typescript-webpack/tmpl/webpack.rules.js
@@ -16,12 +16,12 @@ module.exports = [
   },
   {
     test: /\.tsx?$/,
-    exclude: /(node_modules|.webpack)/,
-    loaders: [{
+    exclude: /(node_modules|\.webpack)/,
+    use: {
       loader: 'ts-loader',
       options: {
         transpileOnly: true
       }
-    }]
+    }
   },
 ];


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

`ts-loader` was not being loaded for TypeScript files.

Also, be more strict about the exclude regex.

ISSUES CLOSED: #1378