### PR TITLE
refactor(plugin-webpack): move webpack config generation code to its own file

### DIFF
--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -1,0 +1,225 @@
+import HtmlWebpackPlugin from 'html-webpack-plugin';
+import path from 'path';
+import webpack, { Configuration } from 'webpack';
+import webpackMerge from 'webpack-merge';
+
+import { WebpackPluginConfig, WebpackPluginEntryPoint, WebpackPreloadEntryPoint } from './Config';
+
+type EntryType = string | string[] | Record<string, string | string[]>;
+
+export default class WebpackConfigGenerator {
+  private isProd: boolean;
+
+  private pluginConfig: WebpackPluginConfig;
+
+  private port: number;
+
+  private projectDir: string;
+
+  private webpackDir: string;
+
+  constructor(
+    pluginConfig: WebpackPluginConfig,
+    projectDir: string,
+    isProd: boolean,
+    port: number,
+  ) {
+    this.pluginConfig = pluginConfig;
+    this.projectDir = projectDir;
+    this.webpackDir = path.resolve(projectDir, '.webpack');
+    this.isProd = isProd;
+    this.port = port;
+  }
+
+  resolveConfig(config: Configuration | string) {
+    if (typeof config === 'string') {
+      // eslint-disable-next-line import/no-dynamic-require, global-require
+      return require(path.resolve(path.dirname(this.webpackDir), config)) as Configuration;
+    }
+
+    return config;
+  }
+
+  get mode() {
+    return this.isProd ? 'production' : 'development';
+  }
+
+  getMainConfig() {
+    const mainConfig = this.resolveConfig(this.pluginConfig.mainConfig);
+
+    if (!mainConfig.entry) {
+      throw new Error('Required config option "entry" has not been defined');
+    }
+    const fix = (item: EntryType): EntryType => {
+      if (typeof item === 'string') return (fix([item]) as string[])[0];
+      if (Array.isArray(item)) {
+        return item.map((val) => (val.startsWith('./') ? path.resolve(this.projectDir, val) : val));
+      }
+      const ret: Record<string, string | string[]> = {};
+      for (const key of Object.keys(item)) {
+        ret[key] = fix(item[key]) as string | string[];
+      }
+      return ret;
+    };
+    mainConfig.entry = fix(mainConfig.entry as EntryType);
+
+    return webpackMerge.smart({
+      devtool: 'source-map',
+      target: 'electron-main',
+      mode: this.mode,
+      output: {
+        path: path.resolve(this.webpackDir, 'main'),
+        filename: 'index.js',
+        libraryTarget: 'commonjs2',
+      },
+      plugins: [
+        new webpack.DefinePlugin(this.getDefines()),
+      ],
+      node: {
+        __dirname: false,
+        __filename: false,
+      },
+      resolve: {
+        modules: [
+          path.resolve(path.dirname(this.webpackDir), './'),
+          path.resolve(path.dirname(this.webpackDir), 'node_modules'),
+          path.resolve(__dirname, '..', 'node_modules'),
+        ],
+      },
+    }, mainConfig || {});
+  }
+
+  rendererEntryPoint(
+    entryPoint: WebpackPluginEntryPoint,
+    inRendererDir: boolean,
+    basename: string,
+  ): string {
+    if (this.isProd) {
+      return `\`file://$\{require('path').resolve(__dirname, '..', '${inRendererDir ? 'renderer' : '.'}', '${entryPoint.name}', '${basename}')}\``;
+    }
+    const baseUrl = `http://localhost:${this.port}/${entryPoint.name}`;
+    if (basename !== 'index.html') {
+      return `'${baseUrl}/${basename}'`;
+    }
+    return `'${baseUrl}'`;
+  }
+
+  toEnvironmentVariable(entryPoint: WebpackPluginEntryPoint, preload = false): string {
+    const suffix = preload ? '_PRELOAD_WEBPACK_ENTRY' : '_WEBPACK_ENTRY';
+    return `${entryPoint.name.toUpperCase().replace(/ /g, '_')}${suffix}`;
+  }
+
+  getPreloadDefine(entryPoint: WebpackPluginEntryPoint): string {
+    if (entryPoint.preload) {
+      if (this.isProd) {
+        return `require('path').resolve(__dirname, '../renderer', '${entryPoint.name}', 'preload.js')`;
+      }
+      return `'${path.resolve(this.webpackDir, 'renderer', entryPoint.name, 'preload.js').replace(/\\/g, '\\\\')}'`;
+    }
+    // If this entry-point has no configured preload script just map this constant to `undefined`
+    // so that any code using it still works.  This makes quick-start / docs simpler.
+    return 'undefined';
+  }
+
+  assetRelocatorBaseDir(inRendererDir = true) {
+    if (this.isProd) {
+      return `process.resourcesPath + "/" + (__filename.includes(".asar") ? "app.asar" : "app") + "/.webpack/${inRendererDir ? 'main' : 'renderer/any_folder'}"`;
+    }
+
+    return JSON.stringify(
+      path.resolve(
+        this.webpackDir,
+        inRendererDir ? 'main' : 'renderer',
+        inRendererDir ? '.' : 'any_folder',
+      ),
+    );
+  }
+
+  getDefines(inRendererDir = true) {
+    const defines: { [key: string]: string; } = {
+      ASSET_RELOCATOR_BASE_DIR: this.assetRelocatorBaseDir(),
+    };
+    if (
+      !this.pluginConfig.renderer.entryPoints
+      || !Array.isArray(this.pluginConfig.renderer.entryPoints)
+    ) {
+      throw new Error('Required config option "renderer.entryPoints" has not been defined');
+    }
+    for (const entryPoint of this.pluginConfig.renderer.entryPoints) {
+      const entryKey = this.toEnvironmentVariable(entryPoint);
+      if (entryPoint.html) {
+        defines[entryKey] = this.rendererEntryPoint(entryPoint, inRendererDir, 'index.html');
+      } else {
+        defines[entryKey] = this.rendererEntryPoint(entryPoint, inRendererDir, 'index.js');
+      }
+      defines[`process.env.${entryKey}`] = defines[entryKey];
+
+      const preloadDefineKey = this.toEnvironmentVariable(entryPoint, true);
+      defines[preloadDefineKey] = this.getPreloadDefine(entryPoint);
+      defines[`process.env.${preloadDefineKey}`] = defines[preloadDefineKey];
+    }
+    return defines;
+  }
+
+  async getPreloadRendererConfig(
+    parentPoint: WebpackPluginEntryPoint,
+    entryPoint: WebpackPreloadEntryPoint,
+  ) {
+    const rendererConfig = this.resolveConfig(this.pluginConfig.renderer.config);
+    const prefixedEntries = entryPoint.prefixedEntries || [];
+
+    return webpackMerge.smart({
+      devtool: 'inline-source-map',
+      target: 'electron-renderer',
+      mode: this.mode,
+      entry: prefixedEntries.concat([
+        entryPoint.js,
+      ]),
+      output: {
+        path: path.resolve(this.webpackDir, 'renderer', parentPoint.name),
+        filename: 'preload.js',
+      },
+      node: {
+        __dirname: false,
+        __filename: false,
+      },
+    }, rendererConfig);
+  }
+
+  async getRendererConfig(entryPoints: WebpackPluginEntryPoint[]) {
+    const rendererConfig = this.resolveConfig(this.pluginConfig.renderer.config);
+    const entry: webpack.Entry = {};
+    for (const entryPoint of entryPoints) {
+      const prefixedEntries = entryPoint.prefixedEntries || [];
+      entry[entryPoint.name] = prefixedEntries
+        .concat([entryPoint.js])
+        .concat(this.isProd || !entryPoint.html ? [] : ['webpack-hot-middleware/client']);
+    }
+
+    const defines = this.getDefines(false);
+    return webpackMerge.smart({
+      entry,
+      devtool: 'inline-source-map',
+      target: 'electron-renderer',
+      mode: this.mode,
+      output: {
+        path: path.resolve(this.webpackDir, 'renderer'),
+        filename: '[name]/index.js',
+        globalObject: 'self',
+        ...(this.isProd ? {} : { publicPath: '/' }),
+      },
+      node: {
+        __dirname: false,
+        __filename: false,
+      },
+      plugins: entryPoints.filter((entryPoint) => Boolean(entryPoint.html))
+        .map((entryPoint) => new HtmlWebpackPlugin({
+          title: entryPoint.name,
+          template: entryPoint.html,
+          filename: `${entryPoint.name}/index.html`,
+          chunks: [entryPoint.name].concat(entryPoint.additionalChunks || []),
+        })).concat([new webpack.DefinePlugin(defines)])
+        .concat(this.isProd ? [] : [new webpack.HotModuleReplacementPlugin()]),
+    }, rendererConfig);
+  }
+}

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -5,7 +5,6 @@ import { ElectronProcess, ForgeConfig } from '@electron-forge/shared-types';
 import Logger, { Tab } from '@electron-forge/web-multi-logger';
 import debug from 'debug';
 import fs from 'fs-extra';
-import merge from 'webpack-merge';
 import path from 'path';
 import webpack, { Configuration } from 'webpack';
 import webpackHotMiddleware from 'webpack-hot-middleware';
@@ -13,16 +12,13 @@ import webpackDevMiddleware from 'webpack-dev-middleware';
 import express from 'express';
 import http from 'http';
 
-import HtmlWebpackPlugin from 'html-webpack-plugin';
-
 import once from './util/once';
-import { WebpackPluginConfig, WebpackPluginEntryPoint, WebpackPreloadEntryPoint } from './Config';
+import { WebpackPluginConfig } from './Config';
+import WebpackConfigGenerator from './WebpackConfig';
 
 const d = debug('electron-forge:plugin:webpack');
 const DEFAULT_PORT = 3000;
 const DEFAULT_LOGGER_PORT = 9000;
-
-type EntryType = string | string[] | Record<string, string | string[]>;
 
 export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
   name = 'webpack';
@@ -32,6 +28,8 @@ export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
   private projectDir!: string;
 
   private baseDir!: string;
+
+  private configGenerator!: WebpackConfigGenerator;
 
   private watchers: webpack.Compiler.Watching[] = [];
 
@@ -71,12 +69,6 @@ export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
     }
   }
 
-  private resolveConfig = (config: Configuration | string) => {
-    // eslint-disable-next-line import/no-dynamic-require, global-require
-    if (typeof config === 'string') return require(path.resolve(path.dirname(this.baseDir), config)) as Configuration;
-    return config;
-  }
-
   private exitHandler = (options: { cleanup?: boolean; exit?: boolean }, err?: Error) => {
     d('handling process exit with:', options);
     if (options.cleanup) {
@@ -101,7 +93,7 @@ export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
   }
 
   // eslint-disable-next-line max-len
-  private runWebpack = async (options: webpack.Configuration): Promise<webpack.Stats> => new Promise((resolve, reject) => {
+  private runWebpack = async (options: Configuration): Promise<webpack.Stats> => new Promise((resolve, reject) => {
     webpack(options)
       .run((err, stats) => {
         if (err) {
@@ -122,6 +114,13 @@ export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
   setDirectories = (dir: string) => {
     this.projectDir = dir;
     this.baseDir = path.resolve(dir, '.webpack');
+
+    this.configGenerator = new WebpackConfigGenerator(
+      this.config,
+      this.projectDir,
+      this.isProd,
+      this.port,
+    );
   }
 
   private loggedOutputUrl = false;
@@ -195,181 +194,13 @@ Your packaged app may be larger than expected if you dont ignore everything othe
     await fs.mkdirp(path.resolve(buildPath, 'node_modules'));
   }
 
-  // eslint-disable-next-line max-len
-  rendererEntryPoint = (entryPoint: WebpackPluginEntryPoint, inRendererDir: boolean, basename: string): string => {
-    if (this.isProd) {
-      return `\`file://$\{require('path').resolve(__dirname, '..', '${inRendererDir ? 'renderer' : '.'}', '${entryPoint.name}', '${basename}')}\``;
-    }
-    const baseUrl = `http://localhost:${this.port}/${entryPoint.name}`;
-    if (basename !== 'index.html') {
-      return `'${baseUrl}/${basename}'`;
-    }
-    return `'${baseUrl}'`;
-  }
-
-  toEnvironmentVariable = (entryPoint: WebpackPluginEntryPoint, preload = false): string => {
-    const suffix = preload ? '_PRELOAD_WEBPACK_ENTRY' : '_WEBPACK_ENTRY';
-    return `${entryPoint.name.toUpperCase().replace(/ /g, '_')}${suffix}`;
-  }
-
-  getPreloadDefine = (entryPoint: WebpackPluginEntryPoint): string => {
-    if (entryPoint.preload) {
-      if (this.isProd) {
-        return `require('path').resolve(__dirname, '../renderer', '${entryPoint.name}', 'preload.js')`;
-      }
-      return `'${path.resolve(this.baseDir, 'renderer', entryPoint.name, 'preload.js').replace(/\\/g, '\\\\')}'`;
-    }
-    // If this entry-point has no configured preload script just map this constant to `undefined`
-    // so that any code using it still works.  This makes quick-start / docs simpler.
-    return 'undefined';
-  }
-
-  getDefines = (inRendererDir = true) => {
-    const defines: { [key: string]: string; } = {
-      ASSET_RELOCATOR_BASE_DIR: this.isProd
-        ? `process.resourcesPath + "/" + (__filename.includes(".asar") ? "app.asar" : "app") + "/.webpack/${inRendererDir ? 'main' : 'renderer/any_folder'}"`
-        : JSON.stringify(
-          path.resolve(
-            this.baseDir,
-            inRendererDir ? 'main' : 'renderer',
-            inRendererDir ? '.' : 'any_folder',
-          ),
-        ),
-    };
-    if (!this.config.renderer.entryPoints || !Array.isArray(this.config.renderer.entryPoints)) {
-      throw new Error('Required config option "renderer.entryPoints" has not been defined');
-    }
-    for (const entryPoint of this.config.renderer.entryPoints) {
-      const entryKey = this.toEnvironmentVariable(entryPoint);
-      if (entryPoint.html) {
-        defines[entryKey] = this.rendererEntryPoint(entryPoint, inRendererDir, 'index.html');
-      } else {
-        defines[entryKey] = this.rendererEntryPoint(entryPoint, inRendererDir, 'index.js');
-      }
-      defines[`process.env.${entryKey}`] = defines[entryKey];
-
-      const preloadDefineKey = this.toEnvironmentVariable(entryPoint, true);
-      defines[preloadDefineKey] = this.getPreloadDefine(entryPoint);
-      defines[`process.env.${preloadDefineKey}`] = defines[preloadDefineKey];
-    }
-    return defines;
-  }
-
-  getMainConfig = async () => {
-    const mainConfig = this.resolveConfig(this.config.mainConfig);
-
-    if (!mainConfig.entry) {
-      throw new Error('Required config option "entry" has not been defined');
-    }
-    const fix = (item: EntryType): EntryType => {
-      if (typeof item === 'string') return (fix([item]) as string[])[0];
-      if (Array.isArray(item)) {
-        return item.map((val) => (val.startsWith('./') ? path.resolve(this.projectDir, val) : val));
-      }
-      const ret: Record<string, string | string[]> = {};
-      for (const key of Object.keys(item)) {
-        ret[key] = fix(item[key]) as string | string[];
-      }
-      return ret;
-    };
-    mainConfig.entry = fix(mainConfig.entry as EntryType);
-
-    const defines = this.getDefines();
-    return merge.smart({
-      devtool: 'source-map',
-      target: 'electron-main',
-      mode: this.isProd ? 'production' : 'development',
-      output: {
-        path: path.resolve(this.baseDir, 'main'),
-        filename: 'index.js',
-        libraryTarget: 'commonjs2',
-      },
-      plugins: [
-        new webpack.DefinePlugin(defines),
-      ],
-      node: {
-        __dirname: false,
-        __filename: false,
-      },
-      resolve: {
-        modules: [
-          path.resolve(path.dirname(this.baseDir), './'),
-          path.resolve(path.dirname(this.baseDir), 'node_modules'),
-          path.resolve(__dirname, '..', 'node_modules'),
-        ],
-      },
-    }, mainConfig || {});
-  }
-
-  getPreloadRendererConfig = async (
-    parentPoint: WebpackPluginEntryPoint,
-    entryPoint: WebpackPreloadEntryPoint,
-  ) => {
-    const rendererConfig = this.resolveConfig(this.config.renderer.config);
-    const prefixedEntries = entryPoint.prefixedEntries || [];
-
-    return merge.smart({
-      devtool: 'inline-source-map',
-      target: 'electron-renderer',
-      mode: this.isProd ? 'production' : 'development',
-      entry: prefixedEntries.concat([
-        entryPoint.js,
-      ]),
-      output: {
-        path: path.resolve(this.baseDir, 'renderer', parentPoint.name),
-        filename: 'preload.js',
-      },
-      node: {
-        __dirname: false,
-        __filename: false,
-      },
-    }, rendererConfig);
-  }
-
-  getRendererConfig = async (entryPoints: WebpackPluginEntryPoint[]) => {
-    const rendererConfig = this.resolveConfig(this.config.renderer.config);
-    const entry: webpack.Entry = {};
-    for (const entryPoint of entryPoints) {
-      const prefixedEntries = entryPoint.prefixedEntries || [];
-      entry[entryPoint.name] = prefixedEntries
-        .concat([entryPoint.js])
-        .concat(this.isProd || !entryPoint.html ? [] : ['webpack-hot-middleware/client']);
-    }
-
-    const defines = this.getDefines(false);
-    return merge.smart({
-      entry,
-      devtool: 'inline-source-map',
-      target: 'electron-renderer',
-      mode: this.isProd ? 'production' : 'development',
-      output: {
-        path: path.resolve(this.baseDir, 'renderer'),
-        filename: '[name]/index.js',
-        globalObject: 'self',
-        ...(this.isProd ? {} : { publicPath: '/' }),
-      },
-      node: {
-        __dirname: false,
-        __filename: false,
-      },
-      plugins: entryPoints.filter((entryPoint) => Boolean(entryPoint.html))
-        .map((entryPoint) => new HtmlWebpackPlugin({
-          title: entryPoint.name,
-          template: entryPoint.html,
-          filename: `${entryPoint.name}/index.html`,
-          chunks: [entryPoint.name].concat(entryPoint.additionalChunks || []),
-        })).concat([new webpack.DefinePlugin(defines)])
-        .concat(this.isProd ? [] : [new webpack.HotModuleReplacementPlugin()]),
-    }, rendererConfig);
-  }
-
   compileMain = async (watch = false, logger?: Logger) => {
     let tab: Tab;
     if (logger) {
       tab = logger.createTab('Main Process');
     }
     await asyncOra('Compiling Main Process Code', async () => {
-      const config = await this.getMainConfig();
+      const config = await this.configGenerator.getMainConfig();
       await new Promise((resolve, reject) => {
         const compiler = webpack(config);
         const [onceResolve, onceReject] = once(resolve, reject);
@@ -399,7 +230,7 @@ Your packaged app may be larger than expected if you dont ignore everything othe
   compileRenderers = async (watch = false) => { // eslint-disable-line @typescript-eslint/no-unused-vars, max-len
     await asyncOra('Compiling Renderer Template', async () => {
       const stats = await this.runWebpack(
-        await this.getRendererConfig(this.config.renderer.entryPoints),
+        await this.configGenerator.getRendererConfig(this.config.renderer.entryPoints),
       );
       if (!watch && stats.hasErrors()) {
         throw new Error(`Compilation errors in the renderer: ${stats.toString()}`);
@@ -410,7 +241,7 @@ Your packaged app may be larger than expected if you dont ignore everything othe
       if (entryPoint.preload) {
         await asyncOra(`Compiling Renderer Preload: ${entryPoint.name}`, async () => {
           await this.runWebpack(
-            await this.getPreloadRendererConfig(entryPoint, entryPoint.preload!),
+            await this.configGenerator.getPreloadRendererConfig(entryPoint, entryPoint.preload!),
           );
         });
       }
@@ -421,7 +252,7 @@ Your packaged app may be larger than expected if you dont ignore everything othe
     await asyncOra('Launch Dev Servers', async () => {
       const tab = logger.createTab('Renderers');
 
-      const config = await this.getRendererConfig(this.config.renderer.entryPoints);
+      const config = await this.configGenerator.getRendererConfig(this.config.renderer.entryPoints);
       const compiler = webpack(config);
       const server = webpackDevMiddleware(compiler, {
         logger: {
@@ -445,7 +276,7 @@ Your packaged app may be larger than expected if you dont ignore everything othe
     await asyncOra('Compiling Preload Scripts', async () => {
       for (const entryPoint of this.config.renderer.entryPoints) {
         if (entryPoint.preload) {
-          const config = await this.getPreloadRendererConfig(
+          const config = await this.configGenerator.getPreloadRendererConfig(
             entryPoint,
             entryPoint.preload!,
           );

--- a/packages/plugin/webpack/test/WebpackConfig_spec.ts
+++ b/packages/plugin/webpack/test/WebpackConfig_spec.ts
@@ -1,41 +1,203 @@
+import { Entry } from 'webpack';
 import { expect } from 'chai';
+import path from 'path';
 
 import WebpackConfigGenerator from '../src/WebpackConfig';
+import { WebpackPluginConfig, WebpackPluginEntryPoint } from '../src/Config';
 
 describe('WebpackConfigGenerator', () => {
-  describe('PRELOAD_WEBPACK_ENTRY', () => {
-    const config = {
-      mainConfig: {},
-      renderer: {
-        config: {},
-        entryPoints: [
-          {
-            js: 'window.js',
-            name: 'window',
-            preload: {
-              js: 'preload.js',
-            },
-          },
-        ],
-      },
-    };
-    const projectDir = process.platform === 'win32' ? 'C:\\baseDir' : '/baseDir';
-
-    it('should assign absolute preload script path in development', () => {
-      const generator = new WebpackConfigGenerator(config, projectDir, false, 3000);
-      const defines = generator.getDefines();
-
-      if (process.platform === 'win32') {
-        expect(defines.WINDOW_PRELOAD_WEBPACK_ENTRY).to.equal(String.raw`'C:\\baseDir\\.webpack\\renderer\\window\\preload.js'`);
-      } else {
-        expect(defines.WINDOW_PRELOAD_WEBPACK_ENTRY).to.equal("'/baseDir/.webpack/renderer/window/preload.js'");
-      }
+  describe('getDefines', () => {
+    it('throws an error if renderer.entryPoints does not exist', () => {
+      const config = {
+        renderer: {},
+      } as WebpackPluginConfig;
+      const generator = new WebpackConfigGenerator(config, '/', false, 3000);
+      expect(() => generator.getDefines()).to.throw(/renderer.entryPoints.* has not been defined/);
     });
 
-    it('should assign an expression to resolve the preload script in production', () => {
-      const generator = new WebpackConfigGenerator(config, projectDir, true, 3000);
+    it('throws an error if renderer.entryPoints is not an array', () => {
+      const config = {
+        renderer: {
+          entryPoints: {},
+        },
+      } as WebpackPluginConfig;
+      const generator = new WebpackConfigGenerator(config, '/', false, 3000);
+      expect(() => generator.getDefines()).to.throw(/renderer.entryPoints.* has not been defined/);
+    });
+
+    it('sets the renderer entry point to a JS file in development', () => {
+      const config = {
+        renderer: {
+          entryPoints: [{
+            name: 'hello',
+            js: 'foo.js',
+          }],
+        },
+      } as WebpackPluginConfig;
+      const generator = new WebpackConfigGenerator(config, '/', false, 3000);
       const defines = generator.getDefines();
-      expect(defines.WINDOW_PRELOAD_WEBPACK_ENTRY).to.equal("require('path').resolve(__dirname, '../renderer', 'window', 'preload.js')");
+
+      expect(defines.HELLO_WEBPACK_ENTRY).to.equal("'http://localhost:3000/hello/index.js'");
+    });
+
+    it('sets the renderer entry point to a JS file in production', () => {
+      const config = {
+        renderer: {
+          entryPoints: [{
+            name: 'hello',
+            js: 'foo.js',
+          }],
+        },
+      } as WebpackPluginConfig;
+      const generator = new WebpackConfigGenerator(config, '/', true, 3000);
+      const defines = generator.getDefines(false);
+
+      // eslint-disable-next-line no-template-curly-in-string
+      expect(defines.HELLO_WEBPACK_ENTRY).to.equal("`file://${require('path').resolve(__dirname, '..', '.', 'hello', 'index.js')}`");
+    });
+
+    it('sets the renderer entry point to an HTML file if both an HTML & JS file are specified', () => {
+      const config = {
+        renderer: {
+          entryPoints: [{
+            name: 'hello',
+            html: 'foo.html',
+            js: 'foo.js',
+          }],
+        },
+      } as WebpackPluginConfig;
+      const generator = new WebpackConfigGenerator(config, '/', false, 3000);
+      const defines = generator.getDefines();
+
+      expect(defines.HELLO_WEBPACK_ENTRY).to.equal("'http://localhost:3000/hello'");
+    });
+
+    describe('PRELOAD_WEBPACK_ENTRY', () => {
+      const config = {
+        mainConfig: {},
+        renderer: {
+          config: {},
+          entryPoints: [
+            {
+              js: 'window.js',
+              name: 'window',
+              preload: {
+                js: 'preload.js',
+              },
+            },
+          ],
+        },
+      };
+      const projectDir = process.platform === 'win32' ? 'C:\\baseDir' : '/baseDir';
+
+      it('should assign absolute preload script path in development', () => {
+        const generator = new WebpackConfigGenerator(config, projectDir, false, 3000);
+        const defines = generator.getDefines();
+
+        if (process.platform === 'win32') {
+          expect(defines.WINDOW_PRELOAD_WEBPACK_ENTRY).to.equal(String.raw`'C:\\baseDir\\.webpack\\renderer\\window\\preload.js'`);
+        } else {
+          expect(defines.WINDOW_PRELOAD_WEBPACK_ENTRY).to.equal("'/baseDir/.webpack/renderer/window/preload.js'");
+        }
+      });
+
+      it('should assign an expression to resolve the preload script in production', () => {
+        const generator = new WebpackConfigGenerator(config, projectDir, true, 3000);
+        const defines = generator.getDefines();
+        expect(defines.WINDOW_PRELOAD_WEBPACK_ENTRY).to.equal("require('path').resolve(__dirname, '../renderer', 'window', 'preload.js')");
+      });
+    });
+  });
+
+  describe('getMainConfig', () => {
+    it('fails when there is no mainConfig.entry', () => {
+      const config = {
+        mainConfig: {},
+      } as WebpackPluginConfig;
+      const generator = new WebpackConfigGenerator(config, '/', false, 3000);
+      expect(() => generator.getMainConfig()).to.throw('Required option "mainConfig.entry" has not been defined');
+    });
+
+    it('generates a development config', async () => {
+      const config = {
+        mainConfig: {
+          entry: 'main.js',
+        },
+        renderer: {
+          entryPoints: [] as WebpackPluginEntryPoint[],
+        },
+      } as WebpackPluginConfig;
+      const generator = new WebpackConfigGenerator(config, '/path', false, 3000);
+      const webpackConfig = await generator.getMainConfig();
+      expect(webpackConfig.target).to.equal('electron-main');
+      expect(webpackConfig.mode).to.equal('development');
+      expect(webpackConfig.entry).to.equal('main.js');
+      expect(webpackConfig.output).to.deep.equal({
+        path: '/path/.webpack/main',
+        filename: 'index.js',
+        libraryTarget: 'commonjs2',
+      });
+    });
+
+    it('generates a production config', async () => {
+      const config = {
+        mainConfig: {
+          entry: 'main.js',
+        },
+        renderer: {
+          entryPoints: [] as WebpackPluginEntryPoint[],
+        },
+      } as WebpackPluginConfig;
+      const generator = new WebpackConfigGenerator(config, '/path', true, 3000);
+      const webpackConfig = await generator.getMainConfig();
+      expect(webpackConfig.mode).to.equal('production');
+    });
+
+    it('generates a config with a relative entry path', async () => {
+      const config = {
+        mainConfig: {
+          entry: './foo/main.js',
+        },
+        renderer: {
+          entryPoints: [] as WebpackPluginEntryPoint[],
+        },
+      } as WebpackPluginConfig;
+      const generator = new WebpackConfigGenerator(config, '/path', true, 3000);
+      const webpackConfig = await generator.getMainConfig();
+      expect(webpackConfig.entry).to.equal('/path/foo/main.js');
+    });
+
+    it('generates a config with multiple entries', async () => {
+      const config = {
+        mainConfig: {
+          entry: {
+            foo: './foo/main.js',
+            bar: 'bar.js',
+          } as Entry,
+        },
+        renderer: {
+          entryPoints: [] as WebpackPluginEntryPoint[],
+        },
+      } as WebpackPluginConfig;
+      const generator = new WebpackConfigGenerator(config, '/path', true, 3000);
+      const webpackConfig = await generator.getMainConfig();
+      expect(webpackConfig.entry).to.deep.equal({
+        foo: '/path/foo/main.js',
+        bar: 'bar.js',
+      });
+    });
+
+    it('generates a config from a requirable file', async () => {
+      const config = {
+        mainConfig: 'mainConfig.js',
+        renderer: {
+          entryPoints: [] as WebpackPluginEntryPoint[],
+        },
+      } as WebpackPluginConfig;
+      const baseDir = path.resolve(__dirname, 'fixtures/main_config_external');
+      const generator = new WebpackConfigGenerator(config, baseDir, true, 3000);
+      const webpackConfig = await generator.getMainConfig();
+      expect(webpackConfig.entry).to.equal(path.resolve(baseDir, 'foo/main.js'));
     });
   });
 });

--- a/packages/plugin/webpack/test/WebpackConfig_spec.ts
+++ b/packages/plugin/webpack/test/WebpackConfig_spec.ts
@@ -1,0 +1,41 @@
+import { expect } from 'chai';
+
+import WebpackConfigGenerator from '../src/WebpackConfig';
+
+describe('WebpackConfigGenerator', () => {
+  describe('PRELOAD_WEBPACK_ENTRY', () => {
+    const config = {
+      mainConfig: {},
+      renderer: {
+        config: {},
+        entryPoints: [
+          {
+            js: 'window.js',
+            name: 'window',
+            preload: {
+              js: 'preload.js',
+            },
+          },
+        ],
+      },
+    };
+    const projectDir = process.platform === 'win32' ? 'C:\\baseDir' : '/baseDir';
+
+    it('should assign absolute preload script path in development', () => {
+      const generator = new WebpackConfigGenerator(config, projectDir, false, 3000);
+      const defines = generator.getDefines();
+
+      if (process.platform === 'win32') {
+        expect(defines.WINDOW_PRELOAD_WEBPACK_ENTRY).to.equal(String.raw`'C:\\baseDir\\.webpack\\renderer\\window\\preload.js'`);
+      } else {
+        expect(defines.WINDOW_PRELOAD_WEBPACK_ENTRY).to.equal("'/baseDir/.webpack/renderer/window/preload.js'");
+      }
+    });
+
+    it('should assign an expression to resolve the preload script in production', () => {
+      const generator = new WebpackConfigGenerator(config, projectDir, true, 3000);
+      const defines = generator.getDefines();
+      expect(defines.WINDOW_PRELOAD_WEBPACK_ENTRY).to.equal("require('path').resolve(__dirname, '../renderer', 'window', 'preload.js')");
+    });
+  });
+});

--- a/packages/plugin/webpack/test/WebpackPlugin_spec.ts
+++ b/packages/plugin/webpack/test/WebpackPlugin_spec.ts
@@ -6,55 +6,23 @@ import { tmpdir } from 'os';
 import WebpackPlugin from '../src/WebpackPlugin';
 
 describe('WebpackPlugin', () => {
+  const baseConfig = {
+    mainConfig: {},
+    renderer: {
+      config: {},
+      entryPoints: [],
+    },
+  };
+
   const webpackTestDir = path.resolve(tmpdir(), 'electron-forge-plugin-webpack-test');
 
-  describe('PRELOAD_WEBPACK_ENTRY', () => {
-    it('should assign absolute preload script path in development', () => {
-      const p = new WebpackPlugin({
-        mainConfig: {},
-        renderer: {
-          config: {},
-          entryPoints: [
-            {
-              js: 'window.js',
-              name: 'window',
-              preload: {
-                js: 'preload.js',
-              },
-            },
-          ],
-        },
-      });
-      p.init(process.platform === 'win32' ? 'C:\\baseDir' : '/baseDir');
-      const defines = p.getDefines();
-
-      if (process.platform === 'win32') {
-        expect(defines.WINDOW_PRELOAD_WEBPACK_ENTRY).to.be.eq(String.raw`'C:\\baseDir\\.webpack\\renderer\\window\\preload.js'`);
-      } else {
-        expect(defines.WINDOW_PRELOAD_WEBPACK_ENTRY).to.be.eq("'/baseDir/.webpack/renderer/window/preload.js'");
-      }
+  describe('TCP port', () => {
+    it('should fail for privileged ports', () => {
+      expect(() => new WebpackPlugin({ ...baseConfig, loggerPort: 80 })).to.throw(/privileged$/);
     });
 
-    it('should assign an expression to resolve the preload script in production', () => {
-      const p = new WebpackPlugin({
-        mainConfig: {},
-        renderer: {
-          config: {},
-          entryPoints: [
-            {
-              js: 'window.js',
-              name: 'window',
-              preload: {
-                js: 'preload.js',
-              },
-            },
-          ],
-        },
-      });
-      p.init(process.platform === 'win32' ? 'C:\\baseDir' : '/baseDir');
-      (p as any).isProd = true;
-      const defines = p.getDefines();
-      expect(defines.WINDOW_PRELOAD_WEBPACK_ENTRY).to.be.eq("require('path').resolve(__dirname, '../renderer', 'window', 'preload.js')");
+    it('should fail for too-large port numbers', () => {
+      expect(() => new WebpackPlugin({ ...baseConfig, loggerPort: 99999 })).to.throw(/not a valid TCP port/);
     });
   });
 
@@ -66,13 +34,7 @@ describe('WebpackPlugin', () => {
 
     before(async () => {
       await fs.ensureDir(packagedPath);
-      plugin = new WebpackPlugin({
-        mainConfig: {},
-        renderer: {
-          config: {},
-          entryPoints: [],
-        },
-      });
+      plugin = new WebpackPlugin(baseConfig);
       plugin.setDirectories(webpackTestDir);
     });
 

--- a/packages/plugin/webpack/test/fixtures/main_config_external/mainConfig.js
+++ b/packages/plugin/webpack/test/fixtures/main_config_external/mainConfig.js
@@ -1,0 +1,3 @@
+module.exports = {
+  entry: './foo/main.js'
+}


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Splits out the Webpack config generation code to its own file, and adds basic test coverage.