### PR TITLE
fix(plugin-webpack): lazily load config generator so isProd is set correctly

### DIFF
--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -1,3 +1,4 @@
+import debug from 'debug';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import path from 'path';
 import webpack, { Configuration } from 'webpack';
@@ -6,6 +7,8 @@ import webpackMerge from 'webpack-merge';
 import { WebpackPluginConfig, WebpackPluginEntryPoint, WebpackPreloadEntryPoint } from './Config';
 
 type EntryType = string | string[] | Record<string, string | string[]>;
+
+const d = debug('electron-forge:plugin:webpack:webpackconfig');
 
 export default class WebpackConfigGenerator {
   private isProd: boolean;
@@ -29,6 +32,8 @@ export default class WebpackConfigGenerator {
     this.webpackDir = path.resolve(projectDir, '.webpack');
     this.isProd = isProd;
     this.port = port;
+
+    d('Config mode:', this.mode);
   }
 
   resolveConfig(config: Configuration | string) {

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -29,7 +29,7 @@ export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
 
   private baseDir!: string;
 
-  private configGenerator!: WebpackConfigGenerator;
+  private _configGenerator!: WebpackConfigGenerator;
 
   private watchers: webpack.Compiler.Watching[] = [];
 
@@ -128,13 +128,19 @@ export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
   setDirectories = (dir: string) => {
     this.projectDir = dir;
     this.baseDir = path.resolve(dir, '.webpack');
+  }
 
-    this.configGenerator = new WebpackConfigGenerator(
-      this.config,
-      this.projectDir,
-      this.isProd,
-      this.port,
-    );
+  get configGenerator() {
+    if (!this._configGenerator) {
+      this._configGenerator = new WebpackConfigGenerator(
+        this.config,
+        this.projectDir,
+        this.isProd,
+        this.port,
+      );
+    }
+
+    return this._configGenerator;
   }
 
   private loggedOutputUrl = false;

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -131,7 +131,9 @@ export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
   }
 
   get configGenerator() {
+    // eslint-disable-next-line no-underscore-dangle
     if (!this._configGenerator) {
+    // eslint-disable-next-line no-underscore-dangle
       this._configGenerator = new WebpackConfigGenerator(
         this.config,
         this.projectDir,
@@ -140,6 +142,7 @@ export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
       );
     }
 
+    // eslint-disable-next-line no-underscore-dangle
     return this._configGenerator;
   }
 


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

Fixes #1479 