### PR TITLE
fix(typescript-webpack): remove async=false option from ts-checker to avoid preload compile hang

### DIFF
--- a/packages/template/typescript-webpack/tmpl/webpack.plugins.js
+++ b/packages/template/typescript-webpack/tmpl/webpack.plugins.js
@@ -1,7 +1,5 @@
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
 module.exports = [
-  new ForkTsCheckerWebpackPlugin({
-    async: false
-  })
+  new ForkTsCheckerWebpackPlugin()
 ];


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Fixes #1386.