### PR TITLE
fix(core): throw an error when no make targets for the given platform are found

### DIFF
--- a/packages/api/core/src/api/make.ts
+++ b/packages/api/core/src/api/make.ts
@@ -153,6 +153,10 @@ export default async ({
 
   targets = targets.filter((_, i) => makers[i]);
 
+  if (targets.length === 0) {
+    throw new Error(`Could not find any make targets configured for the "${actualTargetPlatform}" platform.`);
+  }
+
   info(interactive, `Making for the following targets: ${`${targets.map((t, i) => makers[i].name).join(', ')}`.cyan}`);
 
   const packageJSON = await readMutatedPackageJson(dir, forgeConfig);

--- a/packages/api/core/test/fixture/maker-wrong-platform.ts
+++ b/packages/api/core/test/fixture/maker-wrong-platform.ts
@@ -1,0 +1,3 @@
+export default class Maker {
+  platforms = ['win32'];
+}

--- a/packages/api/core/test/slow/api_spec_slow.ts
+++ b/packages/api/core/test/slow/api_spec_slow.ts
@@ -385,7 +385,7 @@ describe(`electron-forge API (with installer=${nodeInstaller})`, () => {
             }],
             platform: 'linux',
             skipPackage: true,
-          })).to.eventually.be.rejectedWith(`Could not find any make targets configured for the "linux" platform.`);
+          })).to.eventually.be.rejectedWith('Could not find any make targets configured for the "linux" platform.');
         });
 
         it('can make for the MAS platform successfully', async () => {

--- a/packages/api/core/test/slow/api_spec_slow.ts
+++ b/packages/api/core/test/slow/api_spec_slow.ts
@@ -377,6 +377,17 @@ describe(`electron-forge API (with installer=${nodeInstaller})`, () => {
           })).to.eventually.be.rejectedWith(/incompatible with this version/);
         });
 
+        it('throws an error when no makers are configured for the given platform', async () => {
+          await expect(forge.make({
+            dir,
+            overrideTargets: [{
+              name: path.resolve(__dirname, '../fixture/maker-wrong-platform'),
+            }],
+            platform: 'linux',
+            skipPackage: true,
+          })).to.eventually.be.rejectedWith(`Could not find any make targets configured for the "linux" platform.`);
+        });
+
         it('can make for the MAS platform successfully', async () => {
           if (process.platform !== 'darwin') return;
           await expect(forge.make({


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Currently, if there are no make targets for the given platform and make is run, it prints out:

```
Making for the following targets:
```

which is confusing. This PR notifies the user in the form of an exception that there are no make targets found.

Addresses #1514 (but unknown whether it fixes it at this time).