### PR TITLE
fix(plugin-webpack): change preload target from electron-renderer to electron-preload

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "@types/semver": "^7.1.0",
     "@types/sinon": "^7.5.1",
     "@types/username": "^3.0.0",
-    "@types/webpack": "^4.41.5",
+    "@types/webpack": "^4.41.7",
     "@types/webpack-dev-middleware": "^3.7.0",
     "@types/webpack-hot-middleware": "^2.25.0",
     "@types/webpack-merge": "^4.1.5",

--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -175,7 +175,7 @@ export default class WebpackConfigGenerator {
 
     return webpackMerge.smart({
       devtool: 'inline-source-map',
-      target: 'electron-renderer',
+      target: 'electron-preload',
       mode: this.mode,
       entry: prefixedEntries.concat([
         entryPoint.js,

--- a/packages/plugin/webpack/test/WebpackConfig_spec.ts
+++ b/packages/plugin/webpack/test/WebpackConfig_spec.ts
@@ -220,7 +220,7 @@ describe('WebpackConfigGenerator', () => {
         entryPoint,
         entryPoint.preload!,
       );
-      expect(webpackConfig.target).to.equal('electron-renderer');
+      expect(webpackConfig.target).to.equal('electron-preload');
       expect(webpackConfig.mode).to.equal('development');
       expect(webpackConfig.entry).to.deep.equal(['preloadScript.js']);
       expect(webpackConfig.output).to.deep.equal({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1422,10 +1422,22 @@
     "@types/source-list-map" "*"
     source-map "^0.6.1"
 
-"@types/webpack@*", "@types/webpack@^4.41.5":
+"@types/webpack@*":
   version "4.41.6"
   resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.6.tgz#c76afbdef59159d12e3e1332dc264b75574722a2"
   integrity sha512-iWRpV5Ej+8uKrgxp6jXz3v7ZTjgtuMXY+rsxQjFNU0hYCnHkpA7vtiNffgxjuxX4feFHBbz0IF76OzX2OqDYPw==
+  dependencies:
+    "@types/anymatch" "*"
+    "@types/node" "*"
+    "@types/tapable" "*"
+    "@types/uglify-js" "*"
+    "@types/webpack-sources" "*"
+    source-map "^0.6.0"
+
+"@types/webpack@^4.41.7":
+  version "4.41.7"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.7.tgz#22be27dbd4362b01c3954ca9b021dbc9328d9511"
+  integrity sha512-OQG9viYwO0V1NaNV7d0n79V+n6mjOV30CwgFPIfTzwmk8DHbt+C4f2aBGdCYbo3yFyYD6sjXfqqOjwkl1j+ulA==
   dependencies:
     "@types/anymatch" "*"
     "@types/node" "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1422,7 +1422,7 @@
     "@types/source-list-map" "*"
     source-map "^0.6.1"
 
-"@types/webpack@*", @types/webpack@^4.41.7":
+"@types/webpack@*", "@types/webpack@^4.41.7":
   version "4.41.7"
   resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.7.tgz#22be27dbd4362b01c3954ca9b021dbc9328d9511"
   integrity sha512-OQG9viYwO0V1NaNV7d0n79V+n6mjOV30CwgFPIfTzwmk8DHbt+C4f2aBGdCYbo3yFyYD6sjXfqqOjwkl1j+ulA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1422,19 +1422,7 @@
     "@types/source-list-map" "*"
     source-map "^0.6.1"
 
-"@types/webpack@*":
-  version "4.41.6"
-  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.6.tgz#c76afbdef59159d12e3e1332dc264b75574722a2"
-  integrity sha512-iWRpV5Ej+8uKrgxp6jXz3v7ZTjgtuMXY+rsxQjFNU0hYCnHkpA7vtiNffgxjuxX4feFHBbz0IF76OzX2OqDYPw==
-  dependencies:
-    "@types/anymatch" "*"
-    "@types/node" "*"
-    "@types/tapable" "*"
-    "@types/uglify-js" "*"
-    "@types/webpack-sources" "*"
-    source-map "^0.6.0"
-
-"@types/webpack@^4.41.7":
+"@types/webpack@*", @types/webpack@^4.41.7":
   version "4.41.7"
   resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.7.tgz#22be27dbd4362b01c3954ca9b021dbc9328d9511"
   integrity sha512-OQG9viYwO0V1NaNV7d0n79V+n6mjOV30CwgFPIfTzwmk8DHbt+C4f2aBGdCYbo3yFyYD6sjXfqqOjwkl1j+ulA==


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

Added in [Webpack 4.33.0](https://github.com/webpack/webpack/releases/tag/v4.33.0).

See also:
  * https://github.com/webpack/webpack/pull/9188
  * https://v4.webpack.js.org/configuration/target/#target
