### PR TITLE
fix(publisher-electron-release-server): throw an exception for 4xx/5xx HTTP status codes

### DIFF
--- a/packages/publisher/electron-release-server/package.json
+++ b/packages/publisher/electron-release-server/package.json
@@ -9,7 +9,9 @@
   "typings": "dist/PublisherERS.d.ts",
   "devDependencies": {
     "chai": "4.2.0",
-    "mocha": "^7.1.0"
+    "mocha": "^7.1.0",
+    "proxyquire": "^2.1.3",
+    "fetch-mock": "^9.0.0"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/publisher/electron-release-server/test/PublisherERS_spec.ts
+++ b/packages/publisher/electron-release-server/test/PublisherERS_spec.ts
@@ -1,0 +1,29 @@
+import { expect } from 'chai';
+import { ForgeConfig } from '@electron-forge/shared-types';
+import fetchMock from 'fetch-mock';
+import proxyquire from 'proxyquire';
+
+describe('PublisherERS', () => {
+  let fetch: typeof fetchMock;
+  beforeEach(() => {
+    fetch = fetchMock.sandbox();
+  });
+  it('fail if the server returns 4xx', async () => {
+    fetch.mock('begin:http://example.com', { body: {}, status: 400 });
+    const PublisherERS = proxyquire.noCallThru().load('../src/PublisherERS', {
+      'node-fetch': fetch,
+    }).default;
+
+
+    const publisher = new PublisherERS({
+      baseUrl: 'http://example.com',
+      username: 'test',
+      password: 'test',
+    });
+    return expect(publisher.publish({ makeResults: [], dir: '', forgeConfig: {} as ForgeConfig })).to.eventually.be.rejectedWith('ERS publish failed with status code: 400 (http://example.com/api/auth/login)');
+  });
+
+  afterEach(() => {
+    fetch.restore();
+  });
+});


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

`node-fetch` doesn't fail when a `4xx` is raised (https://www.npmjs.com/package/node-fetch#handling-client-and-server-errors).

Our release process rely on this to make sure the files are properly updated during a `electron-forge publish`, but sometimes the Electron Release Server might send `4xx` or `5xx` errors and we are fooled into thinking "everything is ok" 🙂

Do not hesitate if you need more information !
