### PR TITLE
feat(plugin-webpack): Webpack config factory

### DIFF
--- a/packages/plugin/webpack/src/Config.ts
+++ b/packages/plugin/webpack/src/Config.ts
@@ -1,4 +1,7 @@
-import { Configuration as WebpackConfiguration } from 'webpack';
+import {
+  Configuration as RawWebpackConfiguration,
+  ConfigurationFactory as WebpackConfigurationFactory,
+} from 'webpack';
 
 export interface WebpackPluginEntryPoint {
   /**
@@ -90,3 +93,5 @@ export interface WebpackPluginConfig {
    */
   loggerPort?: number;
 }
+
+export type WebpackConfiguration = RawWebpackConfiguration | WebpackConfigurationFactory;

--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -48,9 +48,12 @@ export default class WebpackConfigGenerator {
 
   // Users can override this method in a subclass to provide custom logic or
   // configuraqtion parameters.
-  async preprocessConfig(config: ConfigurationFactory): Promise<Configuration> {
-    return config({}, { mode: this.mode });
-  }
+  preprocessConfig = async (config: ConfigurationFactory): Promise<Configuration> => config(
+    {},
+    {
+      mode: this.mode,
+    },
+  )
 
   get mode() {
     return this.isProd ? 'production' : 'development';

--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -1,10 +1,11 @@
 import debug from 'debug';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import path from 'path';
-import webpack, { Configuration } from 'webpack';
+import webpack, { Configuration, ConfigurationFactory } from 'webpack';
 import { merge as webpackMerge } from 'webpack-merge';
 
 import { WebpackPluginConfig, WebpackPluginEntryPoint, WebpackPreloadEntryPoint } from './Config';
+import processConfig from './util/processConfig';
 
 type EntryType = string | string[] | Record<string, string | string[]>;
 
@@ -36,13 +37,19 @@ export default class WebpackConfigGenerator {
     d('Config mode:', this.mode);
   }
 
-  resolveConfig(config: Configuration | string) {
-    if (typeof config === 'string') {
+  async resolveConfig(config: Configuration | ConfigurationFactory | string) {
+    const rawConfig = (typeof config === 'string')
       // eslint-disable-next-line import/no-dynamic-require, global-require
-      return require(path.resolve(this.projectDir, config)) as Configuration;
-    }
+      ? (require(path.resolve(this.projectDir, config)) as Configuration | ConfigurationFactory)
+      : config;
 
-    return config;
+    return processConfig(this.preprocessConfig, rawConfig);
+  }
+
+  // Users can override this method in a subclass to provide custom logic or
+  // configuraqtion parameters.
+  async preprocessConfig(config: ConfigurationFactory): Promise<Configuration> {
+    return config({}, { mode: this.mode });
   }
 
   get mode() {
@@ -121,8 +128,8 @@ export default class WebpackConfigGenerator {
     return defines;
   }
 
-  getMainConfig() {
-    const mainConfig = this.resolveConfig(this.pluginConfig.mainConfig);
+  async getMainConfig() {
+    const mainConfig = await this.resolveConfig(this.pluginConfig.mainConfig);
 
     if (!mainConfig.entry) {
       throw new Error('Required option "mainConfig.entry" has not been defined');
@@ -170,7 +177,7 @@ export default class WebpackConfigGenerator {
     parentPoint: WebpackPluginEntryPoint,
     entryPoint: WebpackPreloadEntryPoint,
   ) {
-    const rendererConfig = this.resolveConfig(this.pluginConfig.renderer.config);
+    const rendererConfig = await this.resolveConfig(this.pluginConfig.renderer.config);
     const prefixedEntries = entryPoint.prefixedEntries || [];
 
     return webpackMerge({
@@ -193,7 +200,7 @@ export default class WebpackConfigGenerator {
   }
 
   async getRendererConfig(entryPoints: WebpackPluginEntryPoint[]) {
-    const rendererConfig = this.resolveConfig(this.pluginConfig.renderer.config);
+    const rendererConfig = await this.resolveConfig(this.pluginConfig.renderer.config);
     const entry: webpack.Entry = {};
     for (const entryPoint of entryPoints) {
       const prefixedEntries = entryPoint.prefixedEntries || [];

--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -47,7 +47,7 @@ export default class WebpackConfigGenerator {
   }
 
   // Users can override this method in a subclass to provide custom logic or
-  // configuraqtion parameters.
+  // configuration parameters.
   preprocessConfig = async (config: ConfigurationFactory): Promise<Configuration> => config(
     {},
     {

--- a/packages/plugin/webpack/src/util/processConfig.ts
+++ b/packages/plugin/webpack/src/util/processConfig.ts
@@ -1,0 +1,17 @@
+import { Configuration, ConfigurationFactory } from 'webpack';
+
+const trivialConfigurationFactory = (config: Configuration): ConfigurationFactory => () => config;
+
+export type ConfigProcessor = (config: ConfigurationFactory) => Promise<Configuration>;
+
+// Ensure processing logic is run for both `Configuration` and
+// `ConfigurationFactory` config variants.
+const processConfig = async (
+  processor: ConfigProcessor,
+  config: Configuration | ConfigurationFactory,
+): Promise<Configuration> => {
+  const configFactory = (typeof config === 'function') ? config : trivialConfigurationFactory(config);
+  return processor(configFactory);
+};
+
+export default processConfig;

--- a/packages/plugin/webpack/test/WebpackConfig_spec.ts
+++ b/packages/plugin/webpack/test/WebpackConfig_spec.ts
@@ -111,12 +111,12 @@ describe('WebpackConfigGenerator', () => {
   });
 
   describe('getMainConfig', () => {
-    it('fails when there is no mainConfig.entry', () => {
+    it('fails when there is no mainConfig.entry', async () => {
       const config = {
         mainConfig: {},
       } as WebpackPluginConfig;
       const generator = new WebpackConfigGenerator(config, '/', false, 3000);
-      expect(() => generator.getMainConfig()).to.throw('Required option "mainConfig.entry" has not been defined');
+      await expect(generator.getMainConfig()).to.be.rejectedWith('Required option "mainConfig.entry" has not been defined');
     });
 
     it('generates a development config', async () => {

--- a/packages/plugin/webpack/test/util/processConfig_spec.ts
+++ b/packages/plugin/webpack/test/util/processConfig_spec.ts
@@ -1,0 +1,61 @@
+import { expect } from 'chai';
+import { ConfigurationFactory } from 'webpack';
+import processConfig, { ConfigProcessor } from '../../src/util/processConfig';
+
+const sampleWebpackConfig = {
+  module: {
+    rules: [{
+      test: /\.(png|jpg|gif|webp)$/,
+      use: 'file-loader',
+    }],
+  },
+};
+
+const sampleConfigFactoryParams: Parameters<ConfigurationFactory> = [{}, { mode: 'production' }];
+
+describe('processConfig', () => {
+  it('works for object config', async () => {
+    let invoked = 0;
+    const processor: ConfigProcessor = async (configFactory) => {
+      invoked += 1;
+      return configFactory(sampleConfigFactoryParams[0], sampleConfigFactoryParams[1]);
+    };
+
+    expect(await processConfig(processor, sampleWebpackConfig)).to.deep.equal(sampleWebpackConfig);
+    expect(invoked).to.equal(1);
+  });
+
+  it('works for fn config', async () => {
+    let invoked = 0;
+    const processor: ConfigProcessor = async (configFactory) => {
+      invoked += 1;
+      return configFactory(sampleConfigFactoryParams[0], sampleConfigFactoryParams[1]);
+    };
+
+    const fnConfig: ConfigurationFactory = async (arg0, arg1) => {
+      expect(arg0).to.be.equal(sampleConfigFactoryParams[0]);
+      expect(arg1).to.be.equal(sampleConfigFactoryParams[1]);
+      return sampleWebpackConfig;
+    };
+
+    expect(await processConfig(processor, fnConfig)).to.deep.equal(sampleWebpackConfig);
+    expect(invoked).to.equal(1);
+  });
+
+  it('works for promise config', async () => {
+    let invoked = 0;
+    const processor: ConfigProcessor = async (configFactory) => {
+      invoked += 1;
+      return configFactory(sampleConfigFactoryParams[0], sampleConfigFactoryParams[1]);
+    };
+
+    const promiseConfig: ConfigurationFactory = async (arg0, arg1) => {
+      expect(arg0).to.be.equal(sampleConfigFactoryParams[0]);
+      expect(arg1).to.be.equal(sampleConfigFactoryParams[1]);
+      return sampleWebpackConfig;
+    };
+
+    expect(await processConfig(processor, promiseConfig)).to.deep.equal(sampleWebpackConfig);
+    expect(invoked).to.equal(1);
+  });
+});


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This PR provides support for function form of the webpack config.

A lot of thought went into the code design, and the resulting patch is very terse yet it provides a lot of flexibility, such as support for reimplementing the config evaluation logic in subclass, which should provide a lot of flexibility. I'm planing to rely on that functionality myself.

Closes #1529.

To do:

- [x] make preexisting tests pass
- [x] add test for a non-promise function config variant
- [x] add test for a promise function config variant
- [x] add test for the ability to overwrite the `preprocessConfig` at `WebpackConfigGenerator` subclass
- [x] add tests to ensure `preprocessConfig` is run during `resolveConfig` for any config variant: object, function and promise.
