### PR TITLE
feat(s3): add options to allow use custom instance

### DIFF
--- a/packages/publisher/s3/src/Config.ts
+++ b/packages/publisher/s3/src/Config.ts
@@ -32,6 +32,24 @@ export interface PublisherS3Config {
    */
   public?: boolean;
   /**
+   * The endpoint URI to send requests to.
+   *
+   * E.g. `https://s3.example.com`
+   */
+  endpoint?: string;
+  /**
+   * The region to send service requests to.
+   *
+   * E.g. `eu-west-1`
+   */
+  region?: string;
+  /**
+   * Whether to force path style URLs for S3 objects.
+   *
+   * Default: false
+   */
+  s3ForcePathStyle?: boolean;
+  /**
    * Custom function to provide the key to upload a given file to
    */
   keyResolver?: (fileName: string, platform: string, arch: string) => string;

--- a/packages/publisher/s3/src/PublisherS3.ts
+++ b/packages/publisher/s3/src/PublisherS3.ts
@@ -38,6 +38,9 @@ export default class PublisherS3 extends PublisherBase<PublisherS3Config> {
     const s3Client = new S3({
       accessKeyId: config.accessKeyId || process.env.AWS_ACCESS_KEY_ID,
       secretAccessKey: config.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY,
+      region: config.region || undefined,
+      endpoint: config.endpoint || undefined,
+      s3ForcePathStyle: config.s3ForcePathStyle || false,
     });
 
     if (!s3Client.config.credentials || !config.bucket) {

--- a/packages/publisher/s3/src/PublisherS3.ts
+++ b/packages/publisher/s3/src/PublisherS3.ts
@@ -40,7 +40,7 @@ export default class PublisherS3 extends PublisherBase<PublisherS3Config> {
       secretAccessKey: config.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY,
       region: config.region || undefined,
       endpoint: config.endpoint || undefined,
-      s3ForcePathStyle: config.s3ForcePathStyle || false,
+      s3ForcePathStyle: !!config.s3ForcePathStyle,
     });
 
     if (!s3Client.config.credentials || !config.bucket) {


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [ ] The changes have sufficient test coverage (if applicable).
* [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This PR adds the `endpoint` option what's adds the ability to change default S3 endpoint, to custom S3 instance. Also added `s3ForcePathStyle` and `region` for the same reasons.
