### PR TITLE
docs: clean up README wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ With these goals in mind, under the hood this project uses, among others:
 * [`electron-rebuild`](https://github.com/electron/electron-rebuild):
   Automatically recompiles native Node.js modules against the correct
   Electron version.
-* [`electron-packager`](https://github.com/electron-userland/electron-packager):
+* [Electron Packager](https://github.com/electron/electron-packager):
   Customizes and bundles your Electron app to get it ready for distribution.
 
 # Docs and Usage
@@ -85,7 +85,7 @@ For Electron Forge documentation and usage you should check out our website:
 
 # FAQ
 
-## How do I use this with `webpack`/`babel`/`typescript`/`other` build tool?
+## How do I use this with `webpack`/`babel`/`typescript`/other build tool?
 
 By default, Electron Forge only runs vanilla (i.e., non-compiled) JavaScript, but for typescript, webpack, and other build tool support check out the [plugins](https://www.electronforge.io/config/plugins)
 section of our docs site.  We currently have plugins for Webpack and Electron Compile, and a

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ With these goals in mind, under the hood this project uses, among others:
 * [`electron-rebuild`](https://github.com/electron/electron-rebuild):
   Automatically recompiles native Node.js modules against the correct
   Electron version.
-* [Electron Packager](https://github.com/electron-userland/electron-packager):
+* [`electron-packager`](https://github.com/electron-userland/electron-packager):
   Customizes and bundles your Electron app to get it ready for distribution.
 
 # Docs and Usage
@@ -85,10 +85,9 @@ For Electron Forge documentation and usage you should check out our website:
 
 # FAQ
 
-## How do I use this with `webpack`/`babel`/`typescript`/`random build tool`?
+## How do I use this with `webpack`/`babel`/`typescript`/`other` build tool?
 
-By default, Electron Forge only runs vanilla (i.e., non-compiled) JavaScript, but if you want
-to do some fancy build tool stuff you should check out the [plugins](https://www.electronforge.io/config/plugins)
+By default, Electron Forge only runs vanilla (i.e., non-compiled) JavaScript, but for typescript, webpack, and other build tool support check out the [plugins](https://www.electronforge.io/config/plugins)
 section of our docs site.  We currently have plugins for Webpack and Electron Compile, and a
 [template for Webpack](https://www.electronforge.io/templates/webpack-template).
 


### PR DESCRIPTION
A few wording changes that were more professional to me as well as some formatting consistency with links and project slugs.

<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**


