### PR TITLE
fix(package): allow unknown CLI options

### DIFF
--- a/packages/api/cli/src/electron-forge-package.ts
+++ b/packages/api/cli/src/electron-forge-package.ts
@@ -15,6 +15,7 @@ import workingDir from './util/working-dir';
     .arguments('[cwd]')
     .option('-a, --arch [arch]', 'Target architecture')
     .option('-p, --platform [platform]', 'Target build platform')
+    .allowUnknownOption(true)
     .action((cwd) => { dir = workingDir(dir, cwd); })
     .parse(process.argv);
 


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Ignores unknown options passed to `electron-forge package` - enables better upstream/downstream workflow compatibility.

Mirrors the behavior in `make`: https://github.com/electron-userland/electron-forge/blob/d65f33e73f5afe14597135755aa795edf6a818f2/packages/api/cli/src/electron-forge-make.ts#L21

