### PR TITLE
fix(maker-flatpak): add eu-strip to required external binaries

### DIFF
--- a/packages/maker/flatpak/src/MakerFlatpak.ts
+++ b/packages/maker/flatpak/src/MakerFlatpak.ts
@@ -21,7 +21,7 @@ export default class MakerFlatpak extends MakerBase<MakerFlatpakConfig> {
 
   defaultPlatforms: ForgePlatform[] = ['linux'];
 
-  requiredExternalBinaries: string[] = ['flatpak-builder'];
+  requiredExternalBinaries: string[] = ['flatpak-builder', 'eu-strip'];
 
   isSupportedOnCurrentPlatform() {
     return this.isInstalled('@malept/electron-installer-flatpak');


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).

**Summarize your changes:**

Needed due to zypak sandboxing for Electron >= 5.

Corresponding docs update: https://github.com/MarshallOfSound/electron-forge-docs/commit/2aa0f59668d630e4100ac82129de53e154c63d06

Fixes #1702
