### PR TITLE
fix(maker-snap): allow MakerSnapConfig to also be SnapcraftConfig

### DIFF
--- a/packages/maker/snap/src/Config.ts
+++ b/packages/maker/snap/src/Config.ts
@@ -1,4 +1,4 @@
-import { Options } from 'electron-installer-snap';
+import { Options, SnapcraftConfig } from 'electron-installer-snap';
 
 // eslint-disable-next-line import/prefer-default-export
-export type MakerSnapConfig = Omit<Options, 'arch' | 'dest' | 'src'>;
+export type MakerSnapConfig = Omit<Options, 'arch' | 'dest' | 'src'> & SnapcraftConfig;


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Try to make it more obvious where to put custom `snapcraft.yaml` config.
