### PR TITLE
fix(plugin-webpack): allow reloading for HMR.

### DIFF
--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -301,6 +301,7 @@ Your packaged app may be larger than expected if you dont ignore everything othe
         hot: true,
         historyApiFallback: true,
         writeToDisk: true,
+        reload: true,
       } as any);
       const app = express();
       app.use(server);


### PR DESCRIPTION
This allows full page refreshes if the user hasn't set up HMR scripts in their code.

<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Turn on the reload option for the webpackDevMiddleware to allow full-page reloads while in development.
