### PR TITLE
feat(plugin-webpack): do not override existing HtmlWebpackPlugin config

### DIFF
--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -202,7 +202,12 @@ export default class WebpackConfigGenerator {
     }
 
     const defines = this.getDefines(false);
-    const plugins = entryPoints.filter((entryPoint) => Boolean(entryPoint.html))
+
+    const useHtmlWebpackPlugin = !rendererConfig.plugins || !rendererConfig.plugins
+      .find((plugin) => plugin.constructor && plugin.constructor.name === 'HtmlWebpackPlugin');
+
+    const plugins = entryPoints
+      .filter((entryPoint) => Boolean(entryPoint.html) && useHtmlWebpackPlugin)
       .map((entryPoint) => new HtmlWebpackPlugin({
         title: entryPoint.name,
         template: entryPoint.html,


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

If the user already has the HtmlWebpackPlugin in their configuration this tool shouldn't override that option.