### PR TITLE
refactor: sudo-prompt provides its own typings

### DIFF
--- a/typings/sudo-prompt/index.d.ts
+++ b/typings/sudo-prompt/index.d.ts
@@ -1,3 +1,0 @@
-declare module 'sudo-prompt' {
-  export const exec: (command: string, options?: object, callback?: (error?: Error, stdout?: string, stderr?: string) => void) => void;
-}


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**


