### PR TITLE
feat(core): add params to the postPackage hook

### DIFF
--- a/packages/api/core/src/api/package.ts
+++ b/packages/api/core/src/api/package.ts
@@ -205,9 +205,14 @@ export default async ({
 
   d('packaging with options', packageOpts);
 
-  await packager(packageOpts);
+  const outputPaths = await packager(packageOpts);
 
-  await runHook(forgeConfig, 'postPackage');
+  await runHook(forgeConfig, 'postPackage', {
+    arch,
+    outputPaths,
+    platform,
+    spinner: packagerSpinner,
+  });
 
   if (packagerSpinner) packagerSpinner!.succeed();
 };


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Adds the following parameters to `postPackage`:

* `platform`
* `arch`
* `outputPaths` (the result of `await packager(...)`)
* `spinner` (the `ora` spinner, if defined)

Docs are at https://github.com/electron-forge/electron-forge-docs/pull/12

Also, DRYs up the "update `package.json`" code.

Fixes #1630.