### PR TITLE
feat(template): move devDependencies to fake package.json for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,27 @@
 version: 2
 updates:
-  # Enable version updates for npm
   - package-ecosystem: "npm"
-    # Look for `package.json` and `lock` files in the `root` directory
     directory: "/"
     # Check the npm registry for updates every weekday
     schedule:
       interval: "daily"
     ignore:
       - dependency-name: aws-sdk
+  - package-ecosystem: "npm"
+    directory: "/packages/template/typescript/tmpl"
+    # Check the npm registry for updates every weekday
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/packages/template/typescript-webpack/tmpl"
+    # Check the npm registry for updates every weekday
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/packages/template/webpack/tmpl"
+    # Check the npm registry for updates every weekday
+    schedule:
+      interval: "daily"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/packages/template/base/src/BaseTemplate.ts
+++ b/packages/template/base/src/BaseTemplate.ts
@@ -18,7 +18,7 @@ export class BaseTemplate implements ForgeTemplate {
     const packageJSONPath = path.join(this.templateDir, 'package.json');
     if (fs.pathExistsSync(packageJSONPath)) {
       const packageDevDeps = fs.readJsonSync(packageJSONPath).devDependencies;
-      return (Object.values(packageDevDeps) as string[][]).map(([packageName, version]) => {
+      return Object.entries(packageDevDeps).map(([packageName, version]) => {
         if (version === 'ELECTRON_FORGE/VERSION') {
           version = currentForgeVersion;
         }

--- a/packages/template/base/src/BaseTemplate.ts
+++ b/packages/template/base/src/BaseTemplate.ts
@@ -6,11 +6,28 @@ import path from 'path';
 
 import determineAuthor from './determine-author';
 
+const currentForgeVersion = require('../package.json').version;
+
 const d = debug('electron-forge:template:base');
 const tmplDir = path.resolve(__dirname, '../tmpl');
 
 export class BaseTemplate implements ForgeTemplate {
   public templateDir = tmplDir;
+
+  get devDependencies(): string[] {
+    const packageJSONPath = path.join(this.templateDir, 'package.json');
+    if (fs.pathExistsSync(packageJSONPath)) {
+      const packageDevDeps = fs.readJsonSync(packageJSONPath).devDependencies;
+      return (Object.values(packageDevDeps) as string[][]).map(([packageName, version]) => {
+        if (version === 'ELECTRON_FORGE/VERSION') {
+          version = currentForgeVersion;
+        }
+        return `${packageName}@${version}`;
+      });
+    }
+
+    return [];
+  }
 
   public async initializeTemplate(directory: string, { copyCIFiles }: InitTemplateOptions) {
     await asyncOra('Copying Starter Files', async () => {

--- a/packages/template/base/src/BaseTemplate.ts
+++ b/packages/template/base/src/BaseTemplate.ts
@@ -18,12 +18,14 @@ export class BaseTemplate implements ForgeTemplate {
     const packageJSONPath = path.join(this.templateDir, 'package.json');
     if (fs.pathExistsSync(packageJSONPath)) {
       const packageDevDeps = fs.readJsonSync(packageJSONPath).devDependencies;
-      return Object.entries(packageDevDeps).map(([packageName, version]) => {
-        if (version === 'ELECTRON_FORGE/VERSION') {
-          version = currentForgeVersion;
-        }
-        return `${packageName}@${version}`;
-      });
+      if (packageDevDeps) {
+        return Object.entries(packageDevDeps).map(([packageName, version]) => {
+          if (version === 'ELECTRON_FORGE/VERSION') {
+            version = currentForgeVersion;
+          }
+          return `${packageName}@${version}`;
+        });
+      }
     }
 
     return [];

--- a/packages/template/typescript-webpack/src/TypeScriptWebpackTemplate.ts
+++ b/packages/template/typescript-webpack/src/TypeScriptWebpackTemplate.ts
@@ -4,25 +4,8 @@ import fs from 'fs-extra';
 import { InitTemplateOptions } from '@electron-forge/shared-types';
 import path from 'path';
 
-const currentVersion = require('../package').version;
-
 class TypeScriptWebpackTemplate extends BaseTemplate {
   public templateDir = path.resolve(__dirname, '..', 'tmpl');
-
-  public devDependencies = [
-    `@electron-forge/plugin-webpack@${currentVersion}`,
-    '@marshallofsound/webpack-asset-relocator-loader@^0.5.0',
-    'css-loader@^3.0.0',
-    'node-loader@^0.6.0',
-    'ts-loader@^6.2.1',
-    'style-loader@^0.23.1',
-    'typescript@^3.7.0',
-    'fork-ts-checker-webpack-plugin@^3.1.1',
-    'eslint@^6.8.0',
-    'eslint-plugin-import@^2.20.0',
-    '@typescript-eslint/eslint-plugin@^2.18.0',
-    '@typescript-eslint/parser@^2.18.0',
-  ];
 
   async initializeTemplate(directory: string, options: InitTemplateOptions) {
     await super.initializeTemplate(directory, options);

--- a/packages/template/typescript-webpack/tmpl/package.json
+++ b/packages/template/typescript-webpack/tmpl/package.json
@@ -1,0 +1,16 @@
+{
+  "devDependencies": {
+    "@electron-forge/plugin-webpack": "ELECTRON_FORGE/VERSION",
+    "@marshallofsound/webpack-asset-relocator-loader": "^0.5.0",
+    "css-loader": "^3.0.0",
+    "node-loader": "^0.6.0",
+    "ts-loader": "^6.2.1",
+    "style-loader": "^0.23.1",
+    "typescript": "^3.7.0",
+    "fork-ts-checker-webpack-plugin": "^3.1.1",
+    "eslint": "^6.8.0",
+    "eslint-plugin-import": "^2.20.0",
+    "@typescript-eslint/eslint-plugin": "^2.18.0",
+    "@typescript-eslint/parser": "^2.18.0"
+  }
+}

--- a/packages/template/typescript/src/TypeScriptTemplate.ts
+++ b/packages/template/typescript/src/TypeScriptTemplate.ts
@@ -6,14 +6,6 @@ import path from 'path';
 class TypeScriptTemplate extends BaseTemplate {
   public templateDir = path.resolve(__dirname, '..', 'tmpl');
 
-  public devDependencies = [
-    'typescript@^3.7.0',
-    'eslint@^6.8.0',
-    'eslint-plugin-import@^2.20.0',
-    '@typescript-eslint/eslint-plugin@^2.18.0',
-    '@typescript-eslint/parser@^2.18.0',
-  ];
-
   async initializeTemplate(directory: string) {
     await super.initializeTemplate(directory, {});
     await asyncOra('Setting up Forge configuration', async () => {

--- a/packages/template/typescript/tmpl/package.json
+++ b/packages/template/typescript/tmpl/package.json
@@ -1,0 +1,9 @@
+{
+  "devDependencies": {
+    "typescript": "^3.7.0",
+    "eslint": "^6.8.0",
+    "eslint-plugin-import": "^2.20.0",
+    "@typescript-eslint/eslint-plugin": "^2.18.0",
+    "@typescript-eslint/parser": "^2.18.0"
+  }
+}

--- a/packages/template/webpack/src/WebpackTemplate.ts
+++ b/packages/template/webpack/src/WebpackTemplate.ts
@@ -4,19 +4,9 @@ import fs from 'fs-extra';
 import { InitTemplateOptions } from '@electron-forge/shared-types';
 import path from 'path';
 
-const currentVersion = require('../package').version;
-
+// TODO: Use the @zeit publish once https://github.com/zeit/webpack-asset-relocator-loader/pull/41 has been merged
 class WebpackTemplate extends BaseTemplate {
   public templateDir = path.resolve(__dirname, '..', 'tmpl');
-
-  public devDependencies = [
-    `@electron-forge/plugin-webpack@${currentVersion}`,
-    // TODO: Use the @zeit publish once https://github.com/zeit/webpack-asset-relocator-loader/pull/41 has been merged
-    '@marshallofsound/webpack-asset-relocator-loader@^0.5.0',
-    'css-loader@^3.0.0',
-    'node-loader@^0.6.0',
-    'style-loader@^0.23.1',
-  ];
 
   public async initializeTemplate(directory: string, options: InitTemplateOptions) {
     await super.initializeTemplate(directory, options);

--- a/packages/template/webpack/tmpl/package.json
+++ b/packages/template/webpack/tmpl/package.json
@@ -1,0 +1,9 @@
+{
+  "devDependencies": {
+    "@electron-forge/plugin-webpack": "ELECTRON_FORGE/VERSION",
+    "@marshallofsound/webpack-asset-relocator-loader": "^0.5.0",
+    "css-loader": "^3.0.0",
+    "node-loader": "^0.6.0",
+    "style-loader": "^0.23.1"
+  }
+}


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

In theory this should allow Dependabot to upgrade the template `devDependencies` at the same time as the monorepo dependencies. If not, this will make it easier to write a GitHub Action to do so.
