### PR TITLE
docs: add FAQ on how to make yarn use the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ By default, Electron Forge only runs vanilla (i.e., non-compiled) JavaScript, bu
 section of our docs site.  We currently have plugins for Webpack and Electron Compile, and a
 [template for Webpack](https://www.electronforge.io/templates/webpack-template).
 
+## `yarn create` does not use the latest `electron-forge` versions
+
+Run `yarn global remove create-electron-app` and rerun the `yarn create ...` command.
+
 # Team
 
 | <img src="https://s.gravatar.com/avatar/1576c987b53868acf73d6ccb08110a78?s=144" width="144" /> | <img src="https://avatars2.githubusercontent.com/u/11417?s=460&v=4" width="144" /> |


### PR DESCRIPTION
`yarn create` will create an electron app using the version of `electron-forge` when it was first invoked on the machine. To get `yarn create` to use the latest version of `electron-forge`, you have to remove the global installed `create-electron-app` and rerun `yarn create...`. This PR adds an FAQ to inform users on how to do this.

<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [ ] The changes have sufficient test coverage (if applicable).
* [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Added an FAQ to document how to get `yarn create` use the latest version of `electron-forge`. I was unable to figure this out till I posted an issue #1935. 
