### PR TITLE
fix(publisher-github): don't reexport Octokit type

### DIFF
--- a/packages/publisher/github/src/Config.ts
+++ b/packages/publisher/github/src/Config.ts
@@ -1,4 +1,4 @@
-import { OctokitOptions } from './util/github';
+import { OctokitOptions } from '@octokit/core/dist-types/types.d';
 
 export interface GitHubRepository {
   /**

--- a/packages/publisher/github/src/util/github.ts
+++ b/packages/publisher/github/src/util/github.ts
@@ -2,8 +2,6 @@ import { Octokit } from '@octokit/rest';
 import { OctokitOptions } from '@octokit/core/dist-types/types.d';
 import { merge } from 'lodash';
 
-export { OctokitOptions } from '@octokit/core/dist-types/types.d';
-
 export default class GitHub {
   private options: OctokitOptions;
 


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

Re-exporting TypeScript types results in broken JavaScript (the type doesn't exist in JS, resulting in a require error that's hidden by `@electron-forge/core`'s `require-search`).

Fixes #1951 