### PR TITLE
fix(publisher-github): use new @octokit .auth property

### DIFF
--- a/packages/publisher/github/src/util/github.ts
+++ b/packages/publisher/github/src/util/github.ts
@@ -26,13 +26,11 @@ export default class GitHub {
   }
 
   getGitHub() {
-    const github = new Octokit(this.options);
+    const options: OctokitOptions = { ...this.options };
     if (this.token) {
-      github.authenticate({
-        type: 'token',
-        token: this.token,
-      });
+      options.auth = this.token;
     }
+    const github = new Octokit(options);
     return github;
   }
 }

--- a/packages/publisher/github/test/github_spec.ts
+++ b/packages/publisher/github/test/github_spec.ts
@@ -7,22 +7,16 @@ import InternalGitHub from '../src/util/github';
 describe('GitHub', () => {
   let GitHub: typeof InternalGitHub;
   let gitHubSpy: SinonSpy;
-  let gitHubAuthSpy: SinonSpy;
   let MockGitHub: any;
 
   beforeEach(() => {
     gitHubSpy = sinon.spy();
-    gitHubAuthSpy = sinon.spy();
     MockGitHub = class {
       private options: any;
 
       constructor(options: any) {
         gitHubSpy();
         this.options = options;
-      }
-
-      authenticate() {
-        gitHubAuthSpy();
       }
     };
     GitHub = proxyquire.noCallThru().load('../src/util/github', {
@@ -57,6 +51,7 @@ describe('GitHub', () => {
       const api = gh.getGitHub();
 
       expect((api as any).options).to.deep.equal({
+        auth: '1234',
         baseUrl: 'https://github.example.com:8443/enterprise',
         headers: {
           'user-agent': 'Electron Forge',
@@ -73,16 +68,25 @@ describe('GitHub', () => {
 
     it('should authenticate if a token is present', () => {
       const gh = new GitHub('token');
-      expect(gitHubAuthSpy.callCount).to.equal(0);
+      const api = gh.getGitHub();
       gh.getGitHub();
-      expect(gitHubAuthSpy.callCount).to.equal(1);
+      expect((api as any).options).to.deep.equal({
+        auth: 'token',
+        headers: {
+          'user-agent': 'Electron Forge',
+        },
+      });
     });
 
     it('should not authenticate if a token is not present', () => {
       const gh = new GitHub();
-      expect(gitHubAuthSpy.callCount).to.equal(0);
+      const api = gh.getGitHub();
       gh.getGitHub();
-      expect(gitHubAuthSpy.callCount).to.equal(0);
+      expect((api as any).options).to.deep.equal({
+        headers: {
+          'user-agent': 'Electron Forge',
+        },
+      });
     });
 
     it('should throw an exception if a token is required', () => {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [ ] ~~The changes are appropriately documented (if applicable).~~ n/a
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

<details>
<summary>The following error was happening when using `@electron-forge/publisher-github`:</summary>

```
$ electron-forge publish --from-dry-run -d
⠋ Checking your system  electron-forge:check-system skipping system check +0ms
✔ Checking your system
  electron-forge:publish attempting to resume from dry run +0ms
  electron-forge:publish publishing for given state set +2ms
  electron-forge:publish restoring publish settings from dry run +2ms
  electron-forge:project-resolver searching for project in: /Users/michael/agoric/wallet +0ms
  electron-forge:project-resolver electron-forge compatible package.json found in /Users/michael/agoric/wallet/package.json +1ms
⠋ Resolving publish target: @electron-forge/publisher-github  electron-forge:require-search searching [
  '@electron-forge/publisher-github',
  '/Users/michael/agoric/wallet/@electron-forge/publisher-github',
  '/Users/michael/agoric/wallet/node_modules/@electron-forge/publisher-github'
] relative to /Users/michael/agoric/wallet +0ms
  electron-forge:require-search testing @electron-forge/publisher-github +2ms
  electron-forge:require-search testing /Users/michael/agoric/wallet/@electron-forge/publisher-github +0ms
  electron-forge:require-search testing /Users/michael/agoric/wallet/node_modules/@electron-forge/publisher-github +0ms
  electron-forge:require-search failed to find a module in [
  '@electron-forge/publisher-github',
  '/Users/michael/agoric/wallet/@electron-forge/publisher-github',
  '/Users/michael/agoric/wallet/node_modules/@electron-forge/publisher-github'
] +1ms
✖ Resolving publish target: @electron-forge/publisher-github

An unhandled error has occurred inside Forge:
Could not find a publish target with the name: @electron-forge/publisher-github. Make sure it's listed in the devDependencies of your package.json
Error: Could not find a publish target with the name: @electron-forge/publisher-github. Make sure it's listed in the devDependencies of your package.json
    at asyncFn (/Users/michael/agoric/wallet/node_modules/@electron-forge/core/src/api/publish.ts:170:17)
    at /Users/michael/agoric/wallet/node_modules/@electron-forge/async-ora/src/ora-handler.ts:35:5
    at new Promise (<anonymous>)
    at asyncOra (/Users/michael/agoric/wallet/node_modules/@electron-forge/async-ora/src/ora-handler.ts:34:10)
    at publish (/Users/michael/agoric/wallet/node_modules/@electron-forge/core/src/api/publish.ts:167:13)
    at publish (/Users/michael/agoric/wallet/node_modules/@electron-forge/core/src/api/publish.ts:92:7)
    at /Users/michael/agoric/wallet/node_modules/@electron-forge/cli/src/electron-forge-publish.ts:36:3
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
</details>

On further investigation, I found that `@electron-forge/publisher-github` was using the obsolete `Octokit.authenticate(...)` method, which has been replaced by `new Octokit({ auth: ... })`.  Changing to the `auth` option on the constructor made everything work like a charm.
