### PR TITLE
fix(publisher-electron-release-server): set knownLength option for asset upload

### DIFF
--- a/packages/publisher/electron-release-server/src/PublisherERS.ts
+++ b/packages/publisher/electron-release-server/src/PublisherERS.ts
@@ -128,7 +128,12 @@ export default class PublisherERS extends PublisherBase<PublisherERSConfig> {
           artifactForm.append('token', token);
           artifactForm.append('version', packageJSON.version);
           artifactForm.append('platform', ersPlatform(makeResult.platform, makeResult.arch));
-          artifactForm.append('file', fs.createReadStream(artifactPath));
+
+          // see https://github.com/form-data/form-data/issues/426
+          const fileOptions = {
+            knownLength: fs.statSync(artifactPath).size,
+          };
+          artifactForm.append('file', fs.createReadStream(artifactPath), fileOptions);
           await authFetch('api/asset', {
             method: 'POST',
             body: artifactForm,


### PR DESCRIPTION
closes: #2087

<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
As mentioned in the README of the [`form-data`](https://github.com/form-data/form-data) package (see also https://github.com/form-data/form-data/issues/426), the `knownLength` option is now set for the asset upload in the Publisher Electron Release Server.

Note that the issue may affect other publishers in a similar way (but I did not check this).

