### PR TITLE
fix(publisher-electron-release-server): omit RELEASES file when uploading assets

### DIFF
--- a/packages/publisher/electron-release-server/src/PublisherERS.ts
+++ b/packages/publisher/electron-release-server/src/PublisherERS.ts
@@ -72,7 +72,9 @@ export default class PublisherERS extends PublisherBase<PublisherERSConfig> {
     const versions: ERSVersion[] = await (await authFetch('api/version')).json();
 
     for (const makeResult of makeResults) {
-      const { artifacts, packageJSON } = makeResult;
+      const { packageJSON } = makeResult;
+      const artifacts = makeResult.artifacts
+        .filter((artifactPath) => path.basename(artifactPath).toLowerCase() !== 'releases');
 
       const existingVersion = versions.find((version) => version.name === packageJSON.version);
 


### PR DESCRIPTION
closes: #1873

<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
The RELEASES file is now filtered out from the artifacts and thus not send to electron release server.

