### PR TITLE
fix(plugin-webpack): don't warn if packagerConfig.ignore hasn't been manually set

### DIFF
--- a/packages/plugin/webpack/package.json
+++ b/packages/plugin/webpack/package.json
@@ -13,7 +13,8 @@
   "devDependencies": {
     "@types/node": "^14.14.16",
     "chai": "4.2.0",
-    "mocha": "^8.1.3"
+    "mocha": "^8.1.3",
+    "sinon": "^9.2.2"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -182,12 +182,14 @@ export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
     if (!forgeConfig.packagerConfig) {
       forgeConfig.packagerConfig = {};
     }
-    if (forgeConfig.packagerConfig.ignore) {
+
+    if (forgeConfig.packagerConfig.ignore && !forgeConfig.defaultPackagerConfigIgnore) {
       console.error(`You have set packagerConfig.ignore, the Electron Forge webpack plugin normally sets this automatically.
 
 Your packaged app may be larger than expected if you dont ignore everything other than the '.webpack' folder`.red);
       return forgeConfig;
     }
+
     forgeConfig.packagerConfig.ignore = (file: string) => {
       if (!file) return false;
 
@@ -201,6 +203,9 @@ Your packaged app may be larger than expected if you dont ignore everything othe
 
       return !/^[/\\]\.webpack($|[/\\]).*$/.test(file);
     };
+
+    forgeConfig.defaultPackagerConfigIgnore = true;
+
     return forgeConfig;
   }
 

--- a/packages/utils/types/src/index.ts
+++ b/packages/utils/types/src/index.ts
@@ -35,6 +35,7 @@ export interface ForgeConfig {
   plugins: (IForgePlugin | [string, any])[];
   electronRebuildConfig: Partial<RebuildOptions>;
   packagerConfig: Partial<Options>;
+  defaultPackagerConfigIgnore?: boolean;
   makers: (IForgeResolvableMaker | IForgeMaker)[];
   publishers: ForgeConfigPublisher[];
 }


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

See #2017.

If `packagerConfig.ignore` has been set automatically via `electron-forge` rather than a manual config change, don't display a misleading error.

