### PR TITLE
fix(template/typescript-webpack): import/resolver

### DIFF
--- a/packages/template/typescript-webpack/tmpl/.eslintrc.json
+++ b/packages/template/typescript-webpack/tmpl/.eslintrc.json
@@ -12,17 +12,5 @@
     "plugin:import/warnings",
     "plugin:import/typescript"
   ],
-  "parser": "@typescript-eslint/parser",
-  "settings": {
-    "import/resolver": {
-      "node": {
-        "extensions": [
-          ".js",
-          ".jsx",
-          ".ts",
-          ".tsx"
-        ]
-      }
-    }
-  }
+  "parser": "@typescript-eslint/parser"
 }


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Fixes (reverts?) PR https://github.com/electron-userland/electron-forge/pull/2139.
The solution is to include `"plugin:import/typescript"` which [includes these rules and some more](https://github.com/benmosher/eslint-plugin-import/blob/master/config/typescript.js):

```js
/**
 * Adds `.jsx`, `.ts` and `.tsx` as an extension, and enables JSX/TSX parsing.
 */

const allExtensions = ['.ts', '.tsx', '.d.ts', '.js', '.jsx'];

module.exports = {

  settings: {
    'import/extensions': allExtensions,
    'import/external-module-folders': ['node_modules', 'node_modules/@types'],
    'import/parsers': {
      '@typescript-eslint/parser': ['.ts', '.tsx', '.d.ts'],
    },
    'import/resolver': {
      'node': {
        'extensions': allExtensions,
      },
    },
  },

  rules: {
    // analysis/correctness

    // TypeScript compilation already ensures that named imports exist in the referenced module
    'import/named': 'off',
  },
};
```
The PR submitter didn't have it enabled in their [config](https://github.com/stevebeauge/sosp-sp-tools/blob/master/.eslintrc.json) so they added it manually.

This was already merged in https://github.com/electron-userland/electron-forge/pull/2048 and the `import/resolver` section does nothing. 