### PR TITLE
fix(plugin-webpack): don't specify resolve.modules by default

### DIFF
--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -148,13 +148,6 @@ export default class WebpackConfigGenerator {
         __dirname: false,
         __filename: false,
       },
-      resolve: {
-        modules: [
-          path.resolve(path.dirname(this.webpackDir), './'),
-          path.resolve(path.dirname(this.webpackDir), 'node_modules'),
-          path.resolve(__dirname, '..', 'node_modules'),
-        ],
-      },
     }, mainConfig || {});
   }
 


### PR DESCRIPTION
* [ ] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [ ] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [ ] The changes are appropriately documented (if applicable).
* [ ] The changes have sufficient test coverage (if applicable).
* [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Specify modules in resolve will cause application not resolve to correct version of dependencies

Fixes #1845.
FIxes #1929.