### PR TITLE
feat(core): allow packagerConfig to override the "dir" setting

### DIFF
--- a/packages/api/core/src/api/package.ts
+++ b/packages/api/core/src/api/package.ts
@@ -175,8 +175,8 @@ export default async ({
   const packageOpts: packager.Options = {
     asar: false,
     overwrite: true,
-    ...forgeConfig.packagerConfig,
     dir,
+    ...forgeConfig.packagerConfig,
     arch: arch as PackagerArch,
     platform,
     afterCopy: sequentialHooks(afterCopyHooks),


### PR DESCRIPTION
By moving the "dir" property above packageConfig spread, the user can
override the detected "dir" in their configuration. This allows a user
to point forge at a "source dir" much like you can with electron-packager.

This makes forge flexible to using alternative webpack versions or build
scripts to create the "source dir" while benefiting from the package and make
features of forge.

<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

----

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [ ] The changes are appropriately documented (if applicable).
* [ ] The changes have sufficient test coverage (if applicable).
* [ ] The testsuite passes successfully on my local machine (if applicable).



