### PR TITLE
fix: Remove AWS auth checks

### DIFF
--- a/packages/publisher/s3/src/PublisherS3.ts
+++ b/packages/publisher/s3/src/PublisherS3.ts
@@ -43,8 +43,8 @@ export default class PublisherS3 extends PublisherBase<PublisherS3Config> {
       s3ForcePathStyle: !!config.s3ForcePathStyle,
     });
 
-    if (!s3Client.config.credentials || !config.bucket) {
-      throw new Error('In order to publish to s3 you must set the "s3.accessKeyId", "process.env.ELECTRON_FORGE_S3_SECRET_ACCESS_KEY" and "s3.bucket" properties in your Forge config. See the docs for more info');
+    if (!config.bucket) {
+      throw new Error('In order to publish to s3 you must set the "s3.bucket" property in your Forge config. See the docs for more info');
     }
 
     d('creating s3 client with options:', config);


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
Removed unnecessary checks on AWS auth keys that would throw an error if a configuration option other than this module's config was used, such as having an `~/aws/.config` file with your auth keys. The AWS module used supports this authentication method and can succeed, while the removed checks would cause the whole thing to fail. The AWS module can check it's own authentication. Addresses #2226.


