### PR TITLE
chore: set up typeRoots for package tsconfig

### DIFF
--- a/tools/link-ts.ts
+++ b/tools/link-ts.ts
@@ -4,6 +4,16 @@ import * as path from 'path';
 const BASE_DIR = path.resolve(__dirname, '..');
 const PACKAGES_DIR = path.resolve(BASE_DIR, 'packages');
 
+async function copyTSConfig(packageDir: string): Promise<void> {
+  const relativeBaseDir = path.relative(packageDir, BASE_DIR);
+  const tsconfig = await fs.readJson(path.resolve(BASE_DIR, 'tsconfig.json'));
+  tsconfig.compilerOptions.typeRoots = [
+    path.join(relativeBaseDir, 'node_modules', '@types'),
+    path.join(relativeBaseDir, 'typings'),
+  ];
+  await fs.writeJson(path.resolve(packageDir, 'tsconfig.json'), tsconfig, { spaces: 2 });
+}
+
 (async () => {
   const dirsToLink = [];
 
@@ -14,7 +24,7 @@ const PACKAGES_DIR = path.resolve(BASE_DIR, 'packages');
   }
 
   for (const dir of dirsToLink) {
-    await fs.copy(path.resolve(BASE_DIR, 'tsconfig.json'), path.resolve(dir, 'tsconfig.json'));
+    await copyTSConfig(dir);
     await fs.copy(path.resolve(BASE_DIR, '.npmignore'), path.resolve(dir, '.npmignore'));
     const pj = await fs.readJson(path.resolve(dir, 'package.json'));
     if (pj.main) {


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

This should make it a bit easier to run tests for a given package, particularly when they need to use the top-level `typings` folder.