### PR TITLE
test(core): re-enable & refactor native module test

### DIFF
--- a/packages/api/core/test/slow/api_spec_slow.ts
+++ b/packages/api/core/test/slow/api_spec_slow.ts
@@ -246,16 +246,25 @@ describe('Electron Forge API', () => {
       await fs.remove(path.resolve(dir, 'out'));
     });
 
-    // TODO(malept): unskip when Electron 13 works correctly
-    it.skip('can package without errors with native pre-gyp deps installed', async () => {
-      await installDeps(dir, ['ref-napi']);
-      await forge.package({ dir });
-      await fs.remove(path.resolve(dir, 'node_modules/ref-napi'));
+    describe('with native pre-gyp deps installed', () => {
+      before(async () => {
+        await installDeps(dir, ['ref-napi']);
+      });
+
+      it('can package without errors', async () => {
+        await forge.package({ dir });
+      });
+
+      after(async () => {
+        await fs.remove(path.resolve(dir, 'node_modules/ref-napi'));
+        await updatePackageJSON(dir, async (packageJSON) => {
+          delete packageJSON.dependencies['ref-napi'];
+        });
+      });
     });
 
     it('can package without errors', async () => {
       await updatePackageJSON(dir, async (packageJSON) => {
-        delete packageJSON.dependencies['ref-napi'];
         packageJSON.config.forge.packagerConfig.asar = true;
       });
 


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Re-enabled after upgrading transitive dependencies (I guess the older node-abi dependency was causing it to hang??). Also refactored so it's more self-contained and more idiomatic Mocha.