### PR TITLE
fix(plugin-electronegativity): add `parserPlugins` option

### DIFF
--- a/packages/plugin/electronegativity/src/ElectronegativityPlugin.ts
+++ b/packages/plugin/electronegativity/src/ElectronegativityPlugin.ts
@@ -49,6 +49,12 @@ export type ElectronegativityConfig = {
    * from Electron 7 to Electron 8.
    */
   electronUpgrade?: string;
+  /**
+   * Specify additional parser plugins to use. For example, `optionalChaining`.
+   *
+   * Defaults to empty array (`[]`)
+   */
+  parserPlugins: Array<string>;
 };
 
 export default class ElectronegativityPlugin extends PluginBase<ElectronegativityConfig> {
@@ -64,6 +70,7 @@ export default class ElectronegativityPlugin extends PluginBase<Electronegativit
   postPackage = async (_forgeConfig: ForgeConfig, options: PostPackageOptions) => {
     await runElectronegativity({
       ...this.config,
+      parserPlugins: this.config.parserPlugins ?? [],
       input: options.outputPaths[0],
     }, true);
   }


### PR DESCRIPTION

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [ ] The changes have sufficient test coverage (if applicable).
* [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

In the `1.8.0` version of Electronegativity (6 months old 😐), added the option `parserPlugins`, which for programmatic usage doesn't have a default value, this PR provides the default value which used in the CLI interface, an empty array. Not sure if this is an upstream bug, but if needed I can try to upstream this change.