### PR TITLE
feat(core): add `platform` and `arch` to `generateAssets` hook parameters

### DIFF
--- a/packages/api/core/src/api/package.ts
+++ b/packages/api/core/src/api/package.ts
@@ -200,7 +200,7 @@ export default async ({
     throw new Error('config.forge.packagerConfig.prebuiltAsar is not supported by Electron Forge');
   }
 
-  await runHook(forgeConfig, 'generateAssets');
+  await runHook(forgeConfig, 'generateAssets', platform, arch);
   await runHook(forgeConfig, 'prePackage');
 
   d('packaging with options', packageOpts);

--- a/packages/api/core/src/api/start.ts
+++ b/packages/api/core/src/api/start.ts
@@ -44,15 +44,18 @@ export default async ({
     throw new Error(`Please set your application's 'version' in '${dir}/package.json'.`);
   }
 
+  const platform = process.env.npm_config_platform || process.platform;
+  const arch = process.env.npm_config_arch || process.arch;
+
   await rebuild(
     dir,
     await getElectronVersion(dir, packageJSON),
-    process.platform as ForgePlatform,
-    process.arch as ForgeArch,
+    platform as ForgePlatform,
+    arch as ForgeArch,
     forgeConfig.electronRebuildConfig,
   );
 
-  await runHook(forgeConfig, 'generateAssets', process.platform, process.arch);
+  await runHook(forgeConfig, 'generateAssets', platform, arch);
 
   let lastSpawned: ElectronProcess | null = null;
 

--- a/packages/api/core/src/api/start.ts
+++ b/packages/api/core/src/api/start.ts
@@ -52,7 +52,7 @@ export default async ({
     forgeConfig.electronRebuildConfig,
   );
 
-  await runHook(forgeConfig, 'generateAssets');
+  await runHook(forgeConfig, 'generateAssets', process.platform, process.arch);
 
   let lastSpawned: ElectronProcess | null = null;
 


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [ ] The changes have sufficient test coverage (if applicable).
* [ ] The testsuite passes successfully on my local machine (if applicable).

This adds `platform` and `arch` parameters to the `generateAssets` hook so it can be used to generate or copy native assets.

```ts
{
  hooks: {
    generateAssets: async (config: ForgeConfig, platform: string, arch: string) => {
      console.log('We should generate some assets here');
    }
  }
}
```
