### PR TITLE
feat(plugin-webpack): add devContentSecurityPolicy config option

### DIFF
--- a/packages/plugin/webpack/src/Config.ts
+++ b/packages/plugin/webpack/src/Config.ts
@@ -102,4 +102,18 @@ export interface WebpackPluginConfig {
    * The TCP port for web-multi-logger. Defaults to 9000.
    */
   loggerPort?: number;
+  /**
+   * Sets the [`Content-Security-Policy` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy)
+   * for the Webpack development server.
+   *
+   * Normally you would want to only specify this as a `<meta>` tag. However, in development mode,
+   * the Webpack plugin uses the `devtool: eval-source-map` source map setting for efficiency
+   * purposes. This requires the `'unsafe-eval'` source for the `script-src` directive that wouldn't
+   * normally be recommended to use. If this value is set, make sure that you keep this
+   * directive-source pair intact if you want to use source maps.
+   *
+   * Default: `default-src 'self' 'unsafe-inline' data:;`
+   * `script-src 'self' 'unsafe-eval' 'unsafe-inline' data:`
+   */
+  devContentSecurityPolicy?: string
 }

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -293,6 +293,10 @@ Your packaged app may be larger than expected if you dont ignore everything othe
       const config = await this.configGenerator.getRendererConfig(this.config.renderer.entryPoints);
       if (!config.plugins) config.plugins = [];
       config.plugins.push(pluginLogs);
+
+      const cspDirectives = this.config.devContentSecurityPolicy
+        ?? "default-src 'self' 'unsafe-inline' data:; script-src 'self' 'unsafe-eval' 'unsafe-inline' data:";
+
       const compiler = webpack(config);
       const webpackDevServer = new WebpackDevServer(compiler, {
         hot: true,
@@ -303,6 +307,9 @@ Your packaged app may be larger than expected if you dont ignore everything othe
         },
         setupExitSignals: true,
         historyApiFallback: true,
+        headers: {
+          'Content-Security-Policy': cspDirectives,
+        },
       });
       const server = await webpackDevServer.listen(this.port);
       this.servers.push(server);


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [ ] The changes are appropriately documented (if applicable).

**Summarize your changes:**

Fixes #2331 (probably). At the very least, it allows for a workaround.

This is difficult to test automatically, because it's an option passed to `webpack-dev-server`.

This needs to be documented in the Webpack plugin guide.
