### PR TITLE
fix(plugin-webpack): throw error if something bad happened in preload compilation

### DIFF
--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -282,7 +282,7 @@ Your packaged app may be larger than expected if you dont ignore everything othe
           );
 
           if (stats?.hasErrors()) {
-            throw new Error(`Compilation errors in the preload: ${stats.toString()}`);
+            throw new Error(`Compilation errors in the preload (${entryPoint.name}): ${stats.toString()}`);
           }
         });
       }

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -277,9 +277,13 @@ Your packaged app may be larger than expected if you dont ignore everything othe
     for (const entryPoint of this.config.renderer.entryPoints) {
       if (entryPoint.preload) {
         await asyncOra(`Compiling Renderer Preload: ${entryPoint.name}`, async () => {
-          await this.runWebpack(
+          const stats = await this.runWebpack(
             await this.configGenerator.getPreloadRendererConfig(entryPoint, entryPoint.preload!),
           );
+
+          if (stats?.hasErrors()) {
+            throw new Error(`Compilation errors in the preload: ${stats.toString()}`);
+          }
         });
       }
     }


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [ ] The changes are appropriately documented (if applicable).
* [ ] The changes have sufficient test coverage (if applicable).
* [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Do the same as the renderer do, report and exit if all going bad