### PR TITLE
fix(maker-squirrel): use executableName for exe when available

### DIFF
--- a/packages/maker/squirrel/src/MakerSquirrel.ts
+++ b/packages/maker/squirrel/src/MakerSquirrel.ts
@@ -22,6 +22,7 @@ export default class MakerSquirrel extends MakerBase<MakerSquirrelConfig> {
     targetArch,
     packageJSON,
     appName,
+    forgeConfig,
   }: MakerOptions) {
     const outPath = path.resolve(makeDir, `squirrel.windows/${targetArch}`);
     await this.ensureDirectory(outPath);
@@ -30,7 +31,7 @@ export default class MakerSquirrel extends MakerBase<MakerSquirrelConfig> {
       name: packageJSON.name,
       title: appName,
       noMsi: true,
-      exe: `${appName}.exe`,
+      exe: `${forgeConfig.packagerConfig.executableName || appName}.exe`,
       setupExe: `${appName}-${packageJSON.version} Setup.exe`,
       ...this.config,
       appDirectory: dir,


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

Fixes a bug reported in Discord.

**Steps to reproduce**:

```shell
npx create-electron-app example-app
cd example-app
```
Update package.json and merge the following instructions in:

```json
{
  "productName": "My Example App",
  "config": {
    "forge": {
      "packagerConfig": {
        "executableName": "MyExampleApp"
      }
    }
  }
}
```

**Expected**: Squirrel installer finds `MyExampleApp.exe`

**Actual**: Squirrel installer tries and fails to look for `My Example App.exe`.

**Solution**: fix the default `exe` option to check `forgeConfig.packagerConfig.executableName` first.