### PR TITLE
refactor(plugin-webpack): cleanup

### DIFF
--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -48,6 +48,10 @@ export default class WebpackConfigGenerator {
     return this.isProd ? 'production' : 'development';
   }
 
+  get rendererSourceMapOption() {
+    return this.isProd ? 'source-map' : 'eval-source-map';
+  }
+
   get rendererTarget() {
     return this.pluginConfig.renderer.nodeIntegration ? 'electron-renderer' : 'web';
   }
@@ -124,10 +128,6 @@ export default class WebpackConfigGenerator {
     return defines;
   }
 
-  sourceMapOption() {
-    return this.isProd ? 'source-map' : 'eval-source-map';
-  }
-
   getMainConfig() {
     const mainConfig = this.resolveConfig(this.pluginConfig.mainConfig);
 
@@ -181,7 +181,7 @@ export default class WebpackConfigGenerator {
     const prefixedEntries = entryPoint.prefixedEntries || [];
 
     return webpackMerge({
-      devtool: this.sourceMapOption(),
+      devtool: this.rendererSourceMapOption,
       mode: this.mode,
       entry: prefixedEntries.concat([
         entryPoint.js,
@@ -218,7 +218,7 @@ export default class WebpackConfigGenerator {
       }) as WebpackPluginInstance).concat([new webpack.DefinePlugin(defines)]);
     return webpackMerge({
       entry,
-      devtool: this.sourceMapOption(),
+      devtool: this.rendererSourceMapOption,
       target: this.rendererTarget,
       mode: this.mode,
       output: {

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -160,7 +160,7 @@ export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
           await this.compileRenderers();
         };
       case 'postStart':
-        return async (_: any, child: ElectronProcess) => {
+        return async (_config: ForgeConfig, child: ElectronProcess) => {
           if (!this.loggedOutputUrl) {
             console.info(`\n\nWebpack Output Available: ${(`http://localhost:${this.loggerPort}`).cyan}\n`);
             this.loggedOutputUrl = true;

--- a/packages/plugin/webpack/test/WebpackPlugin_spec.ts
+++ b/packages/plugin/webpack/test/WebpackPlugin_spec.ts
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 import { ForgeConfig } from '@electron-forge/shared-types';
 import * as fs from 'fs-extra';
+import * as os from 'os';
 import * as path from 'path';
-import { tmpdir } from 'os';
 
 import { WebpackPluginConfig } from '../src/Config';
 import WebpackPlugin from '../src/WebpackPlugin';
@@ -16,7 +16,7 @@ describe('WebpackPlugin', () => {
     },
   };
 
-  const webpackTestDir = path.resolve(tmpdir(), 'electron-forge-plugin-webpack-test');
+  const webpackTestDir = path.resolve(os.tmpdir(), 'electron-forge-plugin-webpack-test');
 
   describe('TCP port', () => {
     it('should fail for privileged ports', () => {
@@ -105,41 +105,6 @@ describe('WebpackPlugin', () => {
         expect(ignore(path.join('foo', 'bar', '.webpack', 'main', 'stats.json'))).to.equal(true);
         expect(ignore(path.join('foo', 'bar', '.webpack', 'renderer', 'stats.json'))).to.equal(true);
       });
-    });
-  });
-
-  describe('WebpackDevServer', () => {
-    let plugin: WebpackPlugin;
-    const webpackDevServerConfig: WebpackPluginConfig = {
-      mainConfig: {
-        entry: './foo/main.js',
-      },
-      renderer: {
-        config: {},
-        entryPoints: [
-          {
-            js: './foo/main.js',
-            name: 'main_window',
-          },
-        ],
-      },
-    };
-    const mainFile = path.join(webpackTestDir, 'main', 'index.js');
-    const rendererFile = path.join(webpackTestDir, 'renderer', 'main_window', 'index.js');
-    before(async () => {
-      plugin = new WebpackPlugin(webpackDevServerConfig);
-      plugin.setDirectories(webpackTestDir);
-      await plugin.startLogic();
-    });
-
-    after(async () => {
-      plugin.exitHandler({ cleanup: true, exit: true });
-      await fs.remove(webpackTestDir);
-    });
-
-    it('writesToDisk', async () => {
-      expect(await fs.pathExists(mainFile)).to.equal(true);
-      expect(await fs.pathExists(rendererFile)).to.equal(true);
     });
   });
 });


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [ ] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Follow-up from #2225:

* Code refactors for clarity
* Removes the webpack-dev-server test, because it caused the testsuite to `process.exit()` early. This will likely be rewritten after #2320 lands since it has better support for webpack-based integration tests.
