### PR TITLE
refactor(bump): convert to TypeScript

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,5 +104,5 @@ Here are some things to keep in mind as you file pull requests to fix bugs, add 
 
 - if you aren't sure if a release should happen, open an issue
 - make sure the tests pass
-- `node tools/bump.js $NEW_VERSION`
+- `./tools/bump.ts $NEW_VERSION`
 - `node tools/publish.js`

--- a/tools/bump.js
+++ b/tools/bump.js
@@ -1,35 +1,37 @@
 #!/usr/bin/env node
 
 require('colors');
-const childProcess = require('child_process');
 const fs = require('fs-extra');
 const path = require('path');
-const { promisify } = require('util');
+const { spawn } = require('@malept/cross-spawn-promise')
 const semver = require('semver');
 
 const BASE_DIR = path.resolve(__dirname, '..');
 const PACKAGES_DIR = path.resolve(BASE_DIR, 'packages');
 const ELECTRON_FORGE_PREFIX = '@electron-forge/';
 
-const exec = promisify(childProcess.exec);
 
-async function run(command) {
-  return exec(command, { cwd: BASE_DIR });
+async function run(command, args) {
+  return spawn(command, args, { cwd: BASE_DIR });
+}
+
+async function git(*args) {
+  return run('git', args)
 }
 
 async function checkCleanWorkingDir() {
-  if ((await run('git status -s')).stdout !== '') {
+  if ((await git('status', '--short')) !== '') {
     throw 'Your working directory is not clean, please ensure you have a clean working directory before version bumping'.red;
   }
 }
 
 async function updateChangelog(lastVersion, version) {
-  await run(`node_modules/.bin/changelog --tag=v${lastVersion}..v${version}`);
+  await run('node_modules/.bin/changelog', [`--tag=v${lastVersion}..v${version}`]);
 
   require('../ci/fix-changelog'); // eslint-disable-line global-require
 
-  await run('git add CHANGELOG.md');
-  await run(`git commit -m "Update CHANGELOG.md for ${version}"`);
+  await git('add', 'CHANGELOG.md');
+  await git('commit', '-m', `Update CHANGELOG.md for ${version}`);
 }
 
 (async () => {
@@ -68,14 +70,14 @@ async function updateChangelog(lastVersion, version) {
     await fs.writeJson(pjPath, existingPJ, {
       spaces: 2,
     });
-    await run(`git add "${path.relative(BASE_DIR, pjPath)}"`);
+    await git('add', path.relative(BASE_DIR, pjPath));
   }
 
-  await run(`git commit -m "Release ${version}"`);
-  await run(`git tag v${version}`);
+  await git('commit', '-m', `Release ${version}`);
+  await git('tag', `v${version}`);
 
   await updateChangelog(lastVersion, version);
 
   // re-tag to include the changelog
-  await run(`git tag --force v${version}`);
+  await git(`git tag --force v${version}`);
 })().catch(console.error);

--- a/tools/bump.ts
+++ b/tools/bump.ts
@@ -1,31 +1,30 @@
-#!/usr/bin/env node
+#!node_modules/.bin/ts-node
 
-require('colors');
-const fs = require('fs-extra');
-const path = require('path');
-const { spawn } = require('@malept/cross-spawn-promise')
-const semver = require('semver');
+import 'colors';
+import * as fs from 'fs-extra';
+import path from 'path';
+import { spawn } from '@malept/cross-spawn-promise';
+import * as semver from 'semver';
 
 const BASE_DIR = path.resolve(__dirname, '..');
 const PACKAGES_DIR = path.resolve(BASE_DIR, 'packages');
 const ELECTRON_FORGE_PREFIX = '@electron-forge/';
 
-
-async function run(command, args) {
+async function run(command: string, args: string[]): Promise<string> {
   return spawn(command, args, { cwd: BASE_DIR });
 }
 
-async function git(*args) {
-  return run('git', args)
+async function git(...args: string[]): Promise<string> {
+  return run('git', args);
 }
 
-async function checkCleanWorkingDir() {
+async function checkCleanWorkingDir(): Promise<void> {
   if ((await git('status', '--short')) !== '') {
     throw 'Your working directory is not clean, please ensure you have a clean working directory before version bumping'.red;
   }
 }
 
-async function updateChangelog(lastVersion, version) {
+async function updateChangelog(lastVersion: string, version: string): Promise<void> {
   await run('node_modules/.bin/changelog', [`--tag=v${lastVersion}..v${version}`]);
 
   require('../ci/fix-changelog'); // eslint-disable-line global-require
@@ -34,7 +33,7 @@ async function updateChangelog(lastVersion, version) {
   await git('commit', '-m', `Update CHANGELOG.md for ${version}`);
 }
 
-(async () => {
+async function main(): Promise<void> {
   await checkCleanWorkingDir();
 
   const version = process.argv[2];
@@ -80,4 +79,6 @@ async function updateChangelog(lastVersion, version) {
 
   // re-tag to include the changelog
   await git(`git tag --force v${version}`);
-})().catch(console.error);
+}
+
+main().catch(console.error);


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).

**Summarize your changes:**

Convert bump script to TypeScript, add convenience function, and avoid using `util.promisify`.