### PR TITLE
feat(maker-squirrel): support WIN_CSC_LINK and WIN_CSC_KEY_PASSWORD for certificateFile and certificatePassword

### DIFF
--- a/packages/maker/squirrel/src/MakerSquirrel.ts
+++ b/packages/maker/squirrel/src/MakerSquirrel.ts
@@ -27,13 +27,21 @@ export default class MakerSquirrel extends MakerBase<MakerSquirrelConfig> {
     const outPath = path.resolve(makeDir, `squirrel.windows/${targetArch}`);
     await this.ensureDirectory(outPath);
 
+    const config = this.config;
+    if (process.env.WIN_CSC_LINK) {
+      config.certificateFile = process.env.WIN_CSC_LINK;
+    }
+    if (process.env.WIN_CSC_KEY_PASSWORD) {
+      config.certificatePassword = process.env.WIN_CSC_KEY_PASSWORD;
+    }
+
     const winstallerConfig: ElectronWinstallerOptions = {
       name: packageJSON.name,
       title: appName,
       noMsi: true,
       exe: `${forgeConfig.packagerConfig.executableName || appName}.exe`,
       setupExe: `${appName}-${packageJSON.version} Setup.exe`,
-      ...this.config,
+      ...config,
       appDirectory: dir,
       outputDirectory: outPath,
     };

--- a/packages/maker/wix/src/Config.ts
+++ b/packages/maker/wix/src/Config.ts
@@ -59,7 +59,8 @@ export interface MakerWixConfig {
   version?: string;
   /**
    * Parameters to pass to signtool.exe. Overrides `certificateFile` and
-   * `certificatePassword`.
+   * `certificatePassword`. The environment variable `WIN_CSC_LINK` can
+   * also be used.
    */
   signWithParams?: string;
   /**
@@ -68,6 +69,7 @@ export interface MakerWixConfig {
   certificateFile?: string;
   /**
    * The password to decrypt the certificate given in `certificateFile`.
+   * The environment variable `WIN_CSC_KEY_PASSWORD` can also be used.
    */
   certificatePassword?: string;
   /**


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [ ] The changes have sufficient test coverage (if applicable).
* [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Hello,

I think it would be great to support a more secure way of providing the credentials for the Windows code signing process. I don't want to commit my credentials in the `package.json` file, and I currently don't have any other need to use a script to build the package.

In electron-builder they support the use of two environment variables (see https://www.electron.build/code-signing.html). I think that's an ok solution so I am hoping that electron-forge can also adopt the same convention. I think there is no reason to use a different name, so to make it less confusing for users I picked the same names.

I haven't actually tried to build this yet. Before I put in the time to do that, can someone let me know if this is an okay approach? Edits to this branch are allowed by maintainers, so feel free to push more commits. Thanks!
