### PR TITLE
fix(template): add plugin:import/electron to TypeScript ESLint config

### DIFF
--- a/packages/template/typescript-webpack/package.json
+++ b/packages/template/typescript-webpack/package.json
@@ -8,7 +8,7 @@
   "main": "dist/TypeScriptWebpackTemplate.js",
   "typings": "dist/TypeScriptWebpackTemplate.d.ts",
   "scripts": {
-    "test": "echo No Tests"
+    "test": "mocha --config ../../../.mocharc.js test/**/*_spec.ts"
   },
   "engines": {
     "node": ">= 12.13.0"

--- a/packages/template/typescript-webpack/tmpl/.eslintrc.json
+++ b/packages/template/typescript-webpack/tmpl/.eslintrc.json
@@ -13,17 +13,5 @@
     "plugin:import/electron",
     "plugin:import/typescript"
   ],
-  "parser": "@typescript-eslint/parser",
-  "settings": {
-    "import/resolver": {
-      "node": {
-        "extensions": [
-          ".js",
-          ".jsx",
-          ".ts",
-          ".tsx"
-        ]
-      }
-    }
-  }
+  "parser": "@typescript-eslint/parser"
 }

--- a/packages/template/typescript-webpack/tmpl/.eslintrc.json
+++ b/packages/template/typescript-webpack/tmpl/.eslintrc.json
@@ -8,8 +8,7 @@
     "eslint:recommended",
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
-    "plugin:import/errors",
-    "plugin:import/warnings",
+    "plugin:import/recommended",
     "plugin:import/electron",
     "plugin:import/typescript"
   ],

--- a/packages/template/typescript-webpack/tmpl/.eslintrc.json
+++ b/packages/template/typescript-webpack/tmpl/.eslintrc.json
@@ -10,6 +10,7 @@
     "plugin:@typescript-eslint/recommended",
     "plugin:import/errors",
     "plugin:import/warnings",
+    "plugin:import/electron",
     "plugin:import/typescript"
   ],
   "parser": "@typescript-eslint/parser",

--- a/packages/template/typescript/tmpl/.eslintrc.json
+++ b/packages/template/typescript/tmpl/.eslintrc.json
@@ -10,6 +10,7 @@
       "plugin:@typescript-eslint/recommended",
       "plugin:import/errors",
       "plugin:import/warnings",
+      "plugin:import/electron",
       "plugin:import/typescript"
     ],
     "parser": "@typescript-eslint/parser"

--- a/packages/template/typescript/tmpl/.eslintrc.json
+++ b/packages/template/typescript/tmpl/.eslintrc.json
@@ -8,8 +8,7 @@
       "eslint:recommended",
       "plugin:@typescript-eslint/eslint-recommended",
       "plugin:@typescript-eslint/recommended",
-      "plugin:import/errors",
-      "plugin:import/warnings",
+      "plugin:import/recommended",
       "plugin:import/electron",
       "plugin:import/typescript"
     ],


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

* Add `import/electron` settings
* Update import config to use `recommended` over `errors` + `warnings`
* Remove redundant settings
* Add proper test script to the `typescript-webpack` template module

Closes #2142.