### PR TITLE
fix(plugin-webpack): don't show the error message if packagerConfig.ignore is a function

### DIFF
--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -185,9 +185,11 @@ export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
       forgeConfig.packagerConfig = {};
     }
     if (forgeConfig.packagerConfig.ignore) {
-      console.error(`You have set packagerConfig.ignore, the Electron Forge webpack plugin normally sets this automatically.
+      if (typeof forgeConfig.packagerConfig.ignore !== 'function') {
+        console.error(`You have set packagerConfig.ignore, the Electron Forge webpack plugin normally sets this automatically.
 
 Your packaged app may be larger than expected if you dont ignore everything other than the '.webpack' folder`.red);
+      }
       return forgeConfig;
     }
     forgeConfig.packagerConfig.ignore = (file: string) => {


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

Fixes #2017 
