### PR TITLE
fix(maker-dmg): add the arch to the default dmg name

### DIFF
--- a/packages/maker/dmg/package.json
+++ b/packages/maker/dmg/package.json
@@ -7,6 +7,10 @@
   "license": "MIT",
   "main": "dist/MakerDMG.js",
   "typings": "dist/MakerDMG.d.ts",
+  "scripts": {
+    "test": "yarn test:base test/**/*_spec.ts",
+    "test:base": "cross-env TS_NODE_FILES=1 mocha --config ../../../.mocharc.js"
+  },
   "devDependencies": {
     "chai": "^4.3.3",
     "chai-as-promised": "^7.0.0",

--- a/packages/maker/dmg/src/MakerDMG.ts
+++ b/packages/maker/dmg/src/MakerDMG.ts
@@ -19,12 +19,13 @@ export default class MakerDMG extends MakerBase<MakerDMGConfig> {
     makeDir,
     appName,
     packageJSON,
+    targetArch,
   }: MakerOptions) {
     // eslint-disable-next-line global-require
     const electronDMG = require('electron-installer-dmg');
 
     const outPath = path.resolve(makeDir, `${this.config.name || appName}.dmg`);
-    const forgeDefaultOutPath = path.resolve(makeDir, `${appName}-${packageJSON.version}.dmg`);
+    const forgeDefaultOutPath = path.resolve(makeDir, `${appName}-${packageJSON.version}-${targetArch}.dmg`);
 
     await this.ensureFile(outPath);
     const dmgConfig = {

--- a/packages/maker/dmg/test/MakerDMG_spec.ts
+++ b/packages/maker/dmg/test/MakerDMG_spec.ts
@@ -67,14 +67,14 @@ describe('MakerDMG', () => {
       dir, makeDir, appName, targetArch, packageJSON,
     });
     expect(renameStub.callCount).to.equal(1);
-    expect(renameStub.firstCall.args[1]).to.include('1.2.3');
+    expect(renameStub.firstCall.args[1]).to.include(`1.2.3-${targetArch}`);
   });
 
   it('should rename the DMG file to include the version if no custom name is set', async () => {
     await (maker.make as any)({
       dir, makeDir, appName, targetArch, packageJSON,
     });
-    expect(renameStub.firstCall.args[1]).to.include('1.2.3');
+    expect(renameStub.firstCall.args[1]).to.include(`1.2.3-${targetArch}`);
   });
 
   it('should not attempt to rename the DMG file if a custom name is set', async () => {


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

As reported in Discord, publishing both arm64 and x64 DMGs are by default difficult because it's named the same despite being built for different architectures. This adds the target arch to the default DMG basename.