### PR TITLE
fix(template-webpack): only use node-loader if the .node files are in native_modules/

### DIFF
--- a/packages/template/typescript-webpack/tmpl/webpack.rules.js
+++ b/packages/template/typescript-webpack/tmpl/webpack.rules.js
@@ -1,7 +1,9 @@
 module.exports = [
   // Add support for native node modules
   {
-    test: /\.node$/,
+    // We're specifying native_modules in the test because the asset relocator loader generates a
+    // "fake" .node file which is really a cjs file.
+    test: /native_modules\/.+\.node$/,
     use: 'node-loader',
   },
   {

--- a/packages/template/webpack/tmpl/webpack.rules.js
+++ b/packages/template/webpack/tmpl/webpack.rules.js
@@ -1,7 +1,9 @@
 module.exports = [
   // Add support for native node modules
   {
-    test: /\.node$/,
+    // We're specifying native_modules in the test because the asset relocator loader generates a
+    // "fake" .node file which is really a cjs file.
+    test: /native_modules\/.+\.node$/,
     use: 'node-loader',
   },
   {


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

Apparently the asset relocator loader generates "fake" `.node` files which are actually JS files that point toward the relocated native modules in `native_modules/`. Since they're not actually native code, we can't have `node-loader` load them. To fix this, adjust the default test for the `node-loader` to only pick up `.node` modules in a `native_modules` folder. (This can be adjusted as necessary by the Electron app author).
