### PR TITLE
fix(plugin-webpack): fix deprecation warnings for dev-server@4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "sudo-prompt": "^9.1.1",
     "username": "^5.1.0",
     "webpack": "^5.37.0",
-    "webpack-dev-server": "^4.0.0-rc.0",
+    "webpack-dev-server": "^4.0.0",
     "webpack-merge": "^5.7.3",
     "which": "^2.0.2",
     "xterm": "^4.9.0",

--- a/packages/plugin/webpack/package.json
+++ b/packages/plugin/webpack/package.json
@@ -31,7 +31,7 @@
     "global": "^4.3.2",
     "html-webpack-plugin": "^5.3.1",
     "webpack": "^5.37.0",
-    "webpack-dev-server": "^4.0.0-rc.0",
+    "webpack-dev-server": "^4.0.0",
     "webpack-merge": "^5.7.3"
   }
 }

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -303,7 +303,7 @@ Your packaged app may be larger than expected if you dont ignore everything othe
 
       const compiler = webpack(config);
       const webpackDevServer = new WebpackDevServer(this.devServerOptions(), compiler);
-      await webpackDevServer.start(this.port);
+      await webpackDevServer.start();
       this.servers.push(webpackDevServer.server);
     });
 

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -302,9 +302,9 @@ Your packaged app may be larger than expected if you dont ignore everything othe
       config.plugins.push(pluginLogs);
 
       const compiler = webpack(config);
-      const webpackDevServer = new WebpackDevServer(compiler, this.devServerOptions());
-      const server = await webpackDevServer.listen(this.port);
-      this.servers.push(server);
+      const webpackDevServer = new WebpackDevServer(this.devServerOptions(), compiler);
+      await webpackDevServer.start(this.port);
+      this.servers.push(webpackDevServer.server);
     });
 
     await asyncOra('Compiling Preload Scripts', async () => {

--- a/typings/webpack-dev-server/index.d.ts
+++ b/typings/webpack-dev-server/index.d.ts
@@ -3,8 +3,9 @@ declare module 'webpack-dev-server' {
   import { Server } from 'http';
   import { Compiler } from 'webpack';
   class WebpackDevServer {
-    constructor(compiler: Compiler, options?: {})
-    listen(port?: number, hostname?: string): Promise<Server>
+    constructor(options: {}, compilter: Compiler)
+    server: Server;
+    start(): Promise<void>
     close(): void
   }
   export default WebpackDevServer;

--- a/typings/webpack-dev-server/index.d.ts
+++ b/typings/webpack-dev-server/index.d.ts
@@ -3,7 +3,7 @@ declare module 'webpack-dev-server' {
   import { Server } from 'http';
   import { Compiler } from 'webpack';
   class WebpackDevServer {
-    constructor(options: {}, compilter: Compiler)
+    constructor(options: {}, compiler: Compiler)
     server: Server;
     start(): Promise<void>
     close(): void

--- a/yarn.lock
+++ b/yarn.lock
@@ -5512,11 +5512,6 @@ ipaddr.js@^2.0.1:
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-2.0.1.tgz#eca256a7a877e917aeb368b0a7497ddf42ef81c0"
   integrity sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==
 
-is-absolute-url@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/is-absolute-url/-/is-absolute-url-3.0.3.tgz#96c6a22b6a23929b11ea0afb1836c36ad4a5d698"
-  integrity sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==
-
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
@@ -6127,11 +6122,6 @@ keyv@^4.0.0:
   integrity sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==
   dependencies:
     json-buffer "3.0.1"
-
-killable@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892"
-  integrity sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg==
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -9832,14 +9822,15 @@ webpack-dev-middleware@^5.0.0:
     range-parser "^1.2.1"
     schema-utils "^3.0.0"
 
-webpack-dev-server@^4.0.0-rc.0:
-  version "4.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.0.0-rc.0.tgz#56099f1e1e877d15a1fc28a928f38bbc600e33da"
-  integrity sha512-9S+MywBN/ecr8AbXNVUnmbFji8UTtzLR6M5Dgy6sB5Ti/73UgHn8TMhLaSBZBkY/cmSmWHDSwUXFs8lOeARpOw==
+webpack-dev-server@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.0.0.tgz#fb4906e91182154bba54a66e6e06f84c1e3c0a80"
+  integrity sha512-ya5cjoBSf3LqrshZn2HMaRZQx8YRNBE+tx+CQNFGaLLHrvs4Y1aik0sl5SFhLz2cW1O9/NtyaZhthc+8UiuvkQ==
   dependencies:
     ansi-html "^0.0.7"
     bonjour "^3.5.0"
     chokidar "^3.5.1"
+    colorette "^1.2.2"
     compression "^1.7.4"
     connect-history-api-fallback "^1.6.0"
     del "^6.0.0"
@@ -9849,8 +9840,6 @@ webpack-dev-server@^4.0.0-rc.0:
     http-proxy-middleware "^2.0.0"
     internal-ip "^6.2.0"
     ipaddr.js "^2.0.1"
-    is-absolute-url "^3.0.3"
-    killable "^1.0.1"
     open "^8.0.9"
     p-retry "^4.5.0"
     portfinder "^1.0.28"
@@ -9862,7 +9851,7 @@ webpack-dev-server@^4.0.0-rc.0:
     strip-ansi "^7.0.0"
     url "^0.11.0"
     webpack-dev-middleware "^5.0.0"
-    ws "^7.5.3"
+    ws "^8.1.0"
 
 webpack-merge@^5.7.3:
   version "5.8.0"
@@ -10045,10 +10034,15 @@ write-file-atomic@^3.0.0:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
-ws@^7.4.6, ws@^7.5.3:
+ws@^7.4.6:
   version "7.5.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.3.tgz#160835b63c7d97bfab418fc1b8a9fced2ac01a74"
   integrity sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==
+
+ws@^8.1.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.2.0.tgz#0b738cd484bfc9303421914b11bb4011e07615bb"
+  integrity sha512-uYhVJ/m9oXwEI04iIVmgLmugh2qrZihkywG9y5FfZV2ATeLIzHf93qs+tUNqlttbQK957/VX3mtwAS+UfIwA4g==
 
 xml2js@0.4.19:
   version "0.4.19"


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

It looks like between `webpack-dev-server` 4.0.0-rc.0 and 4.0.0, they added some API deprecations/breakage. This updates all that based on the [migration docs](https://github.com/webpack/webpack-dev-server/blob/v4.0.0/migration-v4.md).

Fixes #2456 
