### PR TITLE
feat(publisher-github): add debug support for Octokit

### DIFF
--- a/packages/publisher/github/package.json
+++ b/packages/publisher/github/package.json
@@ -7,6 +7,10 @@
   "license": "MIT",
   "main": "dist/PublisherGithub.js",
   "typings": "dist/PublisherGithub.d.ts",
+  "scripts": {
+    "test": "yarn test:base test/**/*_spec.ts",
+    "test:base": "cross-env TS_NODE_FILES=1 mocha --config ../../../.mocharc.js"
+  },
   "devDependencies": {
     "chai": "^4.3.3",
     "mocha": "^9.0.1",
@@ -24,7 +28,6 @@
     "@octokit/rest": "^18.0.11",
     "@octokit/types": "^6.1.2",
     "fs-extra": "^10.0.0",
-    "lodash": "^4.17.20",
     "mime-types": "^2.1.25"
   }
 }

--- a/packages/publisher/github/package.json
+++ b/packages/publisher/github/package.json
@@ -27,6 +27,7 @@
     "@octokit/core": "^3.2.4",
     "@octokit/rest": "^18.0.11",
     "@octokit/types": "^6.1.2",
+    "debug": "^4.3.1",
     "fs-extra": "^10.0.0",
     "mime-types": "^2.1.25"
   }

--- a/packages/publisher/github/src/util/github.ts
+++ b/packages/publisher/github/src/util/github.ts
@@ -1,5 +1,9 @@
+import debug from 'debug';
 import { Octokit } from '@octokit/rest';
 import { OctokitOptions } from '@octokit/core/dist-types/types.d';
+
+const logInfo = debug('electron-forge:publisher:github:info');
+const logDebug = debug('electron-forge:publisher:github:debug');
 
 export default class GitHub {
   private options: OctokitOptions;
@@ -11,10 +15,19 @@ export default class GitHub {
     requireAuth: boolean = false,
     options: OctokitOptions = {},
   ) {
+    const noOp = () => {};
+
     this.options = {
       ...options,
+      log: {
+        debug: logDebug.enabled ? logDebug : noOp,
+        error: console.error,
+        info: logInfo.enabled ? logInfo : noOp,
+        warn: console.warn,
+      },
       userAgent: 'Electron Forge',
     };
+
     if (authToken) {
       this.token = authToken;
     } else if (process.env.GITHUB_TOKEN) {

--- a/packages/publisher/github/src/util/github.ts
+++ b/packages/publisher/github/src/util/github.ts
@@ -1,6 +1,5 @@
 import { Octokit } from '@octokit/rest';
 import { OctokitOptions } from '@octokit/core/dist-types/types.d';
-import { merge } from 'lodash';
 
 export default class GitHub {
   private options: OctokitOptions;
@@ -12,10 +11,10 @@ export default class GitHub {
     requireAuth: boolean = false,
     options: OctokitOptions = {},
   ) {
-    this.options = merge(
-      options,
-      { headers: { 'user-agent': 'Electron Forge' } },
-    );
+    this.options = {
+      ...options,
+      userAgent: 'Electron Forge',
+    };
     if (authToken) {
       this.token = authToken;
     } else if (process.env.GITHUB_TOKEN) {

--- a/packages/publisher/github/test/github_spec.ts
+++ b/packages/publisher/github/test/github_spec.ts
@@ -1,4 +1,6 @@
 import { expect } from 'chai';
+import { Octokit } from '@octokit/rest';
+import { OctokitOptions } from '@octokit/core/dist-types/types.d';
 import proxyquire from 'proxyquire';
 import sinon, { SinonSpy } from 'sinon';
 
@@ -37,6 +39,12 @@ describe('GitHub', () => {
   });
 
   describe('getGitHub', () => {
+    function getOptions(api: Octokit): OctokitOptions {
+      const { options } = api as any;
+      delete options.log;
+      return options;
+    }
+
     it('should create a new GitHubAPI', () => {
       const gh = new GitHub();
       expect(gitHubSpy.callCount).to.equal(0);
@@ -50,7 +58,7 @@ describe('GitHub', () => {
       });
       const api = gh.getGitHub();
 
-      expect((api as any).options).to.deep.equal({
+      expect(getOptions(api)).to.deep.equal({
         auth: '1234',
         baseUrl: 'https://github.example.com:8443/enterprise',
         userAgent: 'Electron Forge',
@@ -61,14 +69,14 @@ describe('GitHub', () => {
       const gh = new GitHub('1234', true, { userAgent: 'Something' });
       const api = gh.getGitHub();
 
-      expect((api as any).options.userAgent).to.equal('Electron Forge');
+      expect(getOptions(api).userAgent).to.equal('Electron Forge');
     });
 
     it('should authenticate if a token is present', () => {
       const gh = new GitHub('token');
       const api = gh.getGitHub();
       gh.getGitHub();
-      expect((api as any).options).to.deep.equal({
+      expect(getOptions(api)).to.deep.equal({
         auth: 'token',
         userAgent: 'Electron Forge',
       });
@@ -78,7 +86,7 @@ describe('GitHub', () => {
       const gh = new GitHub();
       const api = gh.getGitHub();
       gh.getGitHub();
-      expect((api as any).options).to.deep.equal({
+      expect(getOptions(api)).to.deep.equal({
         userAgent: 'Electron Forge',
       });
     });

--- a/packages/publisher/github/test/github_spec.ts
+++ b/packages/publisher/github/test/github_spec.ts
@@ -53,17 +53,15 @@ describe('GitHub', () => {
       expect((api as any).options).to.deep.equal({
         auth: '1234',
         baseUrl: 'https://github.example.com:8443/enterprise',
-        headers: {
-          'user-agent': 'Electron Forge',
-        },
+        userAgent: 'Electron Forge',
       });
     });
 
     it('should not override the user agent', () => {
-      const gh = new GitHub('1234', true, { headers: { 'user-agent': 'Something' } });
+      const gh = new GitHub('1234', true, { userAgent: 'Something' });
       const api = gh.getGitHub();
 
-      expect((api as any).options.headers['user-agent']).to.equal('Electron Forge');
+      expect((api as any).options.userAgent).to.equal('Electron Forge');
     });
 
     it('should authenticate if a token is present', () => {
@@ -72,9 +70,7 @@ describe('GitHub', () => {
       gh.getGitHub();
       expect((api as any).options).to.deep.equal({
         auth: 'token',
-        headers: {
-          'user-agent': 'Electron Forge',
-        },
+        userAgent: 'Electron Forge',
       });
     });
 
@@ -83,9 +79,7 @@ describe('GitHub', () => {
       const api = gh.getGitHub();
       gh.getGitHub();
       expect((api as any).options).to.deep.equal({
-        headers: {
-          'user-agent': 'Electron Forge',
-        },
+        userAgent: 'Electron Forge',
       });
     });
 


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Hooks the `debug` module into [Octokit's logging mechanism](https://octokit.github.io/rest.js/v18#logging). You can enable info messages by adding `electron-forge:publisher:github:info` to the `DEBUG` environment variable, and debug messages by adding `electron-forge:publisher:github:debug` to the `DEBUG` environment variable. Please note that both will be enabled if you already have `electron-forge:*` in the `DEBUG` environment variable.

Also does some cleanup while working on the module (namely, using the `userAgent` option instead of setting a header).

Addresses #2498.
Fixes #1672.
Closes #1673.