### PR TITLE
fix(plugin-webpack): validate that the correct entry point is used

### DIFF
--- a/packages/plugin/webpack/package.json
+++ b/packages/plugin/webpack/package.json
@@ -8,7 +8,7 @@
   "main": "dist/WebpackPlugin.js",
   "typings": "dist/WebpackPlugin.d.ts",
   "scripts": {
-    "test": "xvfb-maybe mocha --config ../../../.mocharc.js test/**/*_spec.ts test/**/**/*_spec.ts"
+    "test": "xvfb-maybe mocha --config ../../../.mocharc.js test/**/*_spec.ts"
   },
   "devDependencies": {
     "@malept/cross-spawn-promise": "^2.0.0",

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -27,8 +27,10 @@ export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
 
   private isProd = false;
 
+  // The root of the Electron app
   private projectDir!: string;
 
+  // Where the Webpack output is generated. Usually `$projectDir/.webpack`
   private baseDir!: string;
 
   private _configGenerator!: WebpackConfigGenerator;
@@ -208,6 +210,13 @@ Your packaged app may be larger than expected if you dont ignore everything othe
 
   packageAfterCopy = async (_forgeConfig: ForgeConfig, buildPath: string): Promise<void> => {
     const pj = await fs.readJson(path.resolve(this.projectDir, 'package.json'));
+
+    if (!pj.main?.endsWith('.webpack/main')) {
+      throw new Error(`Electron Forge is configured to use the Webpack plugin. The plugin expects the
+"main" entry point in "package.json" to be ".webpack/main" (where the plugin outputs
+the generated files). Instead, it is ${JSON.stringify(pj.main)}`);
+    }
+
     if (pj.config) {
       delete pj.config.forge;
     }

--- a/packages/plugin/webpack/test/WebpackPlugin_spec.ts
+++ b/packages/plugin/webpack/test/WebpackPlugin_spec.ts
@@ -42,7 +42,7 @@ describe('WebpackPlugin', () => {
     });
 
     it('should remove config.forge from package.json', async () => {
-      const packageJSON = { config: { forge: 'config.js' } };
+      const packageJSON = { main: './.webpack/main', config: { forge: 'config.js' } };
       await fs.writeJson(packageJSONPath, packageJSON);
       await plugin.packageAfterCopy({} as ForgeConfig, packagedPath);
       expect(await fs.pathExists(packagedPackageJSONPath)).to.equal(true);
@@ -50,11 +50,23 @@ describe('WebpackPlugin', () => {
     });
 
     it('should succeed if there is no config.forge', async () => {
-      const packageJSON = { name: 'test' };
+      const packageJSON = { main: '.webpack/main' };
       await fs.writeJson(packageJSONPath, packageJSON);
       await plugin.packageAfterCopy({} as ForgeConfig, packagedPath);
       expect(await fs.pathExists(packagedPackageJSONPath)).to.equal(true);
       expect(await fs.readJson(packagedPackageJSONPath)).to.not.have.property('config');
+    });
+
+    it('should fail if there is no main key in package.json', async () => {
+      const packageJSON = {};
+      await fs.writeJson(packageJSONPath, packageJSON);
+      await expect(plugin.packageAfterCopy({} as ForgeConfig, packagedPath)).to.eventually.be.rejectedWith(/entry point/);
+    });
+
+    it('should fail if main in package.json does not end with .webpack/main', async () => {
+      const packageJSON = { main: 'src/main.js' };
+      await fs.writeJson(packageJSONPath, packageJSON);
+      await expect(plugin.packageAfterCopy({} as ForgeConfig, packagedPath)).to.eventually.be.rejectedWith(/entry point/);
     });
 
     after(async () => {


### PR DESCRIPTION
- [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Addresses #2519 