### PR TITLE
feat: 🎸 Add packageSourceMaps option to WebpackPluginConfig

### DIFF
--- a/packages/plugin/webpack/src/Config.ts
+++ b/packages/plugin/webpack/src/Config.ts
@@ -85,12 +85,6 @@ export interface WebpackPluginConfig {
    */
   mainConfig: WebpackConfiguration | string;
   /**
-   * In the event that webpack has been configured with `devtool: sourcemap` (or any other option
-   * which results in a `.map` file being generated), this option will cause the source map files be
-   * packaged with your app. By default they are not included.
-   */
-  includeSourceMap?: boolean;
-  /**
    * Instructs webpack to emit a JSON file containing statistics about modules, the dependency
    * graph, and various other build information for the main process. This file is located in
    * `.webpack/main/stats.json`, but is not packaged with your app.
@@ -108,6 +102,12 @@ export interface WebpackPluginConfig {
    * The TCP port for web-multi-logger. Defaults to 9000.
    */
   loggerPort?: number;
+  /**
+   * In the event that webpack has been configured with `devtool: sourcemap` (or any other option
+   * which results in `.map` files being generated), this option will cause the source map files be
+   * packaged with your app. By default they are not included.
+   */
+  packageSourceMaps?: boolean;
   /**
    * Sets the [`Content-Security-Policy` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy)
    * for the Webpack development server.

--- a/packages/plugin/webpack/src/Config.ts
+++ b/packages/plugin/webpack/src/Config.ts
@@ -86,10 +86,10 @@ export interface WebpackPluginConfig {
   mainConfig: WebpackConfiguration | string;
   /**
    * In the event that webpack has been configured with `devtool: sourcemap` (or any other option
-   * which results in a `.map` file being generated), this option will cause it to not be
-   * packaged with your app.
+   * which results in a `.map` file being generated), this option will cause the source map files be
+   * packaged with your app. By default they are not included.
    */
-  ignoreSourcemap?: boolean;
+  includeSourceMap?: boolean;
   /**
    * Instructs webpack to emit a JSON file containing statistics about modules, the dependency
    * graph, and various other build information for the main process. This file is located in

--- a/packages/plugin/webpack/src/Config.ts
+++ b/packages/plugin/webpack/src/Config.ts
@@ -85,6 +85,12 @@ export interface WebpackPluginConfig {
    */
   mainConfig: WebpackConfiguration | string;
   /**
+   * In the event that webpack has been configured with `devtool: sourcemap` (or any other option
+   * which results in a `.map` file being generated), this option will cause it to not be
+   * packaged with your app.
+   */
+  ignoreSourcemap?: boolean;
+  /**
    * Instructs webpack to emit a JSON file containing statistics about modules, the dependency
    * graph, and various other build information for the main process. This file is located in
    * `.webpack/main/stats.json`, but is not packaged with your app.

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -203,7 +203,7 @@ Your packaged app may be larger than expected if you dont ignore everything othe
         return true;
       }
 
-      if (this.config.ignoreSourcemap && /[^/\\]+\.js\.map$/.test(file)) {
+      if (!this.config.includeSourceMap && /[^/\\]+\.js\.map$/.test(file)) {
         return true;
       }
 

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -203,6 +203,10 @@ Your packaged app may be larger than expected if you dont ignore everything othe
         return true;
       }
 
+      if (this.config.ignoreSourcemap && /[^/\\]+\.js\.map$/.test(file)) {
+        return true;
+      }
+
       return !/^[/\\]\.webpack($|[/\\]).*$/.test(file);
     };
     return forgeConfig;

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -203,7 +203,7 @@ Your packaged app may be larger than expected if you dont ignore everything othe
         return true;
       }
 
-      if (!this.config.includeSourceMap && /[^/\\]+\.js\.map$/.test(file)) {
+      if (!this.config.packageSourceMaps && /[^/\\]+\.js\.map$/.test(file)) {
         return true;
       }
 

--- a/packages/plugin/webpack/test/WebpackPlugin_spec.ts
+++ b/packages/plugin/webpack/test/WebpackPlugin_spec.ts
@@ -119,8 +119,8 @@ describe('WebpackPlugin', () => {
         expect(ignore(path.join('foo', 'bar', '.webpack', 'renderer', 'stats.json'))).to.equal(true);
       });
 
-      it('ignores sourcemap files', async () => {
-        const webpackConfig = { ...baseConfig, ignoreSourcemap: true };
+      it('ignores source map files by default', async () => {
+        const webpackConfig = { ...baseConfig };
         plugin = new WebpackPlugin(webpackConfig);
         const config = await plugin.resolveForgeConfig({} as ForgeConfig);
         const ignore = config.packagerConfig.ignore as IgnoreFunction;
@@ -129,6 +129,18 @@ describe('WebpackPlugin', () => {
         expect(ignore(path.join('/.webpack', 'main', 'index.js.map'))).to.equal(true);
         expect(ignore(path.join('/.webpack', 'renderer', 'main_window', 'index.js'))).to.equal(false);
         expect(ignore(path.join('/.webpack', 'renderer', 'main_window', 'index.js.map'))).to.equal(true);
+      });
+
+      it('includes source map files when specified by config', async () => {
+        const webpackConfig = { ...baseConfig, includeSourceMap: true };
+        plugin = new WebpackPlugin(webpackConfig);
+        const config = await plugin.resolveForgeConfig({} as ForgeConfig);
+        const ignore = config.packagerConfig.ignore as IgnoreFunction;
+
+        expect(ignore(path.join('/.webpack', 'main', 'index.js'))).to.equal(false);
+        expect(ignore(path.join('/.webpack', 'main', 'index.js.map'))).to.equal(false);
+        expect(ignore(path.join('/.webpack', 'renderer', 'main_window', 'index.js'))).to.equal(false);
+        expect(ignore(path.join('/.webpack', 'renderer', 'main_window', 'index.js.map'))).to.equal(false);
       });
     });
   });

--- a/packages/plugin/webpack/test/WebpackPlugin_spec.ts
+++ b/packages/plugin/webpack/test/WebpackPlugin_spec.ts
@@ -132,7 +132,7 @@ describe('WebpackPlugin', () => {
       });
 
       it('includes source map files when specified by config', async () => {
-        const webpackConfig = { ...baseConfig, includeSourceMap: true };
+        const webpackConfig = { ...baseConfig, packageSourceMaps: true };
         plugin = new WebpackPlugin(webpackConfig);
         const config = await plugin.resolveForgeConfig({} as ForgeConfig);
         const ignore = config.packagerConfig.ignore as IgnoreFunction;

--- a/packages/plugin/webpack/test/WebpackPlugin_spec.ts
+++ b/packages/plugin/webpack/test/WebpackPlugin_spec.ts
@@ -118,6 +118,18 @@ describe('WebpackPlugin', () => {
         expect(ignore(path.join('foo', 'bar', '.webpack', 'main', 'stats.json'))).to.equal(true);
         expect(ignore(path.join('foo', 'bar', '.webpack', 'renderer', 'stats.json'))).to.equal(true);
       });
+
+      it('ignores sourcemap files', async () => {
+        const webpackConfig = { ...baseConfig, ignoreSourcemap: true };
+        plugin = new WebpackPlugin(webpackConfig);
+        const config = await plugin.resolveForgeConfig({} as ForgeConfig);
+        const ignore = config.packagerConfig.ignore as IgnoreFunction;
+
+        expect(ignore(path.join('/.webpack', 'main', 'index.js'))).to.equal(false);
+        expect(ignore(path.join('/.webpack', 'main', 'index.js.map'))).to.equal(true);
+        expect(ignore(path.join('/.webpack', 'renderer', 'main_window', 'index.js'))).to.equal(false);
+        expect(ignore(path.join('/.webpack', 'renderer', 'main_window', 'index.js.map'))).to.equal(true);
+      });
     });
   });
 


### PR DESCRIPTION
Stop including source maps in a packages application by default.

Add `packageSourceMaps` to `WebpackPluginConfig` allow source maps to be included in the packaged application.

✅ Closes: #2573

<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Add a configuration option to `WebpackPluginConfig`:
```javascript
packageSourceMaps?: boolean;
```

Update the `forgeConfig.packagerConfig.ignore` function in `WebpackPlugin.resolveForgeConfig` to return `true` if the filename ends in `.js.map` unless the above configuration option is set to `true`.