### PR TITLE
feat: 🎸 allow specifying alternative tag prefix

### DIFF
--- a/packages/publisher/github/src/Config.ts
+++ b/packages/publisher/github/src/Config.ts
@@ -39,4 +39,8 @@ export interface PublisherGitHubConfig {
    * Whether or not this release should be tagged as a draft
    */
   draft?: boolean;
+  /**
+   * Prepended to the package version to determine the release name (default "v")
+   */
+  tagPrefix?: string;
 }


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Add configuration option `tagPrefix`, that if set, overrides the default
"v" when determining the corresponding tag name for GitHub releases.

✅ Closes: #1790
