### PR TITLE
Upgrade `node-fetch`, `^2.6.0` -> `^3.1.0`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "lodash": "^4.17.20",
     "log-symbols": "^4.0.0",
     "mime-types": "^2.1.25",
-    "node-fetch": "^2.6.0",
+    "node-fetch": "^3.1.0",
     "nugget": "^2.0.1",
     "open": "^8.1.0",
     "ora": "^5.0.0",

--- a/packages/api/cli/package.json
+++ b/packages/api/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@electron-forge/cli",
-  "version": "6.0.0-beta.61",
+  "version": "6.0.0-beta.62",
   "description": "A complete tool for building modern Electron applications",
   "repository": "https://github.com/electron-userland/electron-forge",
   "author": "Samuel Attard",
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@electron-forge/async-ora": "6.0.0-beta.61",
-    "@electron-forge/core": "6.0.0-beta.61",
+    "@electron-forge/core": "6.0.0-beta.62",
     "@electron-forge/shared-types": "6.0.0-beta.61",
     "@electron/get": "^1.9.0",
     "colors": "^1.4.0",

--- a/packages/api/core/package.json
+++ b/packages/api/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@electron-forge/core",
-  "version": "6.0.0-beta.61",
+  "version": "6.0.0-beta.62",
   "description": "A complete tool for building modern Electron applications",
   "repository": "https://github.com/electron-userland/electron-forge",
   "main": "dist/api/index.js",

--- a/packages/api/core/package.json
+++ b/packages/api/core/package.json
@@ -62,7 +62,7 @@
     "fs-extra": "^10.0.0",
     "lodash": "^4.17.20",
     "log-symbols": "^4.0.0",
-    "node-fetch": "^2.6.0",
+    "node-fetch": "^3.1.0",
     "nugget": "^2.0.1",
     "resolve-package": "^1.0.1",
     "semver": "^7.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3973,6 +3973,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+data-uri-to-buffer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz#b5db46aea50f6176428ac05b73be39a57701a64b"
+  integrity sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==
+
 date-fns@^1.27.2:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
@@ -5167,6 +5172,13 @@ fd-slicer@~1.1.0:
   dependencies:
     pend "~1.2.0"
 
+fetch-blob@^3.1.2:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.1.3.tgz#a7dca4855e39d3e3c5a1da62d4ee335c37d26012"
+  integrity sha512-ax1Y5I9w+9+JiM+wdHkhBoxew+zG4AJ2SvAD1v1szpddUIiPERVGBxrMcB2ZqW0Y3PP8bOWYv2zqQq1Jp2kqUQ==
+  dependencies:
+    web-streams-polyfill "^3.0.3"
+
 fetch-mock@^9.10.7:
   version "9.11.0"
   resolved "https://registry.yarnpkg.com/fetch-mock/-/fetch-mock-9.11.0.tgz#371c6fb7d45584d2ae4a18ee6824e7ad4b637a3f"
@@ -5387,6 +5399,13 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+formdata-polyfill@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
+  dependencies:
+    fetch-blob "^3.1.2"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -7621,12 +7640,21 @@ node-dir@^0.1.17:
   dependencies:
     minimatch "^3.0.2"
 
-node-fetch@^2.6.0, node-fetch@^2.6.1:
+node-fetch@^2.6.1:
   version "2.6.5"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.5.tgz#42735537d7f080a7e5f78b6c549b7146be1742fd"
   integrity sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==
   dependencies:
     whatwg-url "^5.0.0"
+
+node-fetch@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.1.0.tgz#714f4922dc270239487654eaeeab86b8206cb52e"
+  integrity sha512-QU0WbIfMUjd5+MUzQOYhenAazakV7Irh1SGkWCsRzBwvm4fAhzEUaHMJ6QLP7gWT6WO9/oH2zhKMMGMuIrDyKw==
+  dependencies:
+    data-uri-to-buffer "^4.0.0"
+    fetch-blob "^3.1.2"
+    formdata-polyfill "^4.0.10"
 
 node-forge@^0.10.0:
   version "0.10.0"
@@ -10141,6 +10169,11 @@ wcwidth@^1.0.1:
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
+
+web-streams-polyfill@^3.0.3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz#a6b74026b38e4885869fb5c589e90b95ccfc7965"
+  integrity sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION


- [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] ~The changes are appropriately documented (if applicable).~
- [ ] ~The changes have sufficient test coverage (if applicable).~
- [ ] ~The testsuite passes successfully on my local machine (if applicable).~

**Summarize your changes:**

`whatwg-url` versions 6 and below rely on a `webidl-conversions` package,
which makes use of `SharedArrayBuffer` -
this is disabled in newer Chrome versions,
will likely soon be disabled in Electron,
and breaks cross-browser cross-desktop codebases.

![Screen Shot 2021-12-06 at 8 20 57 PM](https://user-images.githubusercontent.com/30454698/144948476-4a9dc14e-44e4-4107-966c-110f3d123a9d.png)

`node-fetch` version `3.1.0` has been upgraded to no longer rely on `whatwg-url`, instead relying on [`data-uri-to-buffer, formdata-polyfill, fetch-blob`](https://www.npmjs.com/package/node-fetch/v/3.1.0).

Main branch test suite is failing, so I'm unable to run test coverage for this change.