### PR TITLE
files at root of renderer ability

### DIFF
--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -66,7 +66,7 @@ export default class WebpackConfigGenerator {
 
   toEnvironmentVariable(entryPoint: WebpackPluginEntryPoint, preload = false): string {
     const suffix = preload ? '_PRELOAD_WEBPACK_ENTRY' : '_WEBPACK_ENTRY';
-    return `${entryPoint.name.toUpperCase().replace(/ /g, '_')}${suffix}`;
+    return `${this.pluginConfig.renderer.entryPoints.length === 1 && this.pluginConfig.renderer.entryPoints[0].name === '.' ? '_ROOT' : entryPoint.name.toUpperCase().replace(/ /g, '_')}${suffix}`;
   }
 
   getPreloadDefine(entryPoint: WebpackPluginEntryPoint): string {


### PR DESCRIPTION
```js
declare const _ROOT_WEBPACK_ENTRY: string;
declare const _ROOT_PRELOAD_WEBPACK_ENTRY: string;
```
forge.config
```json
// Forge Plugins
  plugins: [
    [
      '@electron-forge/plugin-webpack',
      {
        ...
        renderer: {
          ...
          entryPoints: [
            {
              name: '.',
              ...
            },
          ],
        },
      },
    ],
  ],
```
just use dot '.' for entryPoint name
