### PR TITLE
feat(plugin-webpack): allow specifing a seperate webpack config for your preload

### DIFF
--- a/packages/plugin/webpack/src/Config.ts
+++ b/packages/plugin/webpack/src/Config.ts
@@ -45,6 +45,11 @@ export interface WebpackPreloadEntryPoint {
    * entry files into your application.
    */
   prefixedEntries?: string[];
+  /**
+   * The optional webpack config for your preload process, defaults to the 
+   * renderer webpack config if blank
+   */
+  config?: WebpackConfiguration | string;
 }
 
 export interface WebpackPluginRendererConfig {

--- a/packages/plugin/webpack/src/Config.ts
+++ b/packages/plugin/webpack/src/Config.ts
@@ -46,7 +46,7 @@ export interface WebpackPreloadEntryPoint {
    */
   prefixedEntries?: string[];
   /**
-   * The optional webpack config for your preload process, defaults to the 
+   * The optional webpack config for your preload process, defaults to the
    * renderer webpack config if blank
    */
   config?: WebpackConfiguration | string;

--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -142,7 +142,7 @@ export default class WebpackConfigGenerator {
   }
 
   async getPreloadRendererConfig(parentPoint: WebpackPluginEntryPoint, entryPoint: WebpackPreloadEntryPoint): Promise<Configuration> {
-    const rendererConfig = this.resolveConfig(this.pluginConfig.renderer.config);
+    const rendererConfig = this.resolveConfig(entryPoint.config || this.pluginConfig.renderer.config);
     const prefixedEntries = entryPoint.prefixedEntries || [];
 
     return webpackMerge(

--- a/packages/plugin/webpack/test/WebpackConfig_spec.ts
+++ b/packages/plugin/webpack/test/WebpackConfig_spec.ts
@@ -5,7 +5,6 @@ import path from 'path';
 import WebpackConfigGenerator from '../src/WebpackConfig';
 import { WebpackPluginConfig, WebpackPluginEntryPoint } from '../src/Config';
 import AssetRelocatorPatch from '../src/util/AssetRelocatorPatch';
-import { at } from 'lodash';
 
 const mockProjectDir = process.platform === 'win32' ? 'C:\\path' : '/path';
 
@@ -349,9 +348,9 @@ describe('WebpackConfigGenerator', () => {
                 js: 'preload.js',
                 config: {
                   name: 'preload',
-                  target: 'electron-preload', 
+                  target: 'electron-preload',
                   entry: 'preload',
-                }
+                },
               },
             },
           ],
@@ -368,7 +367,7 @@ describe('WebpackConfigGenerator', () => {
       // Our preload config plugins is an empty list while our renderer config plugins has a member
       expect(preloadWebpackConfig.name).to.equal('preload');
       expect(rendererWebpackConfig.name).to.equal('renderer');
-    })
+    });
   });
 
   describe('getRendererConfig', () => {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Allows you to specify a seperate webpack config for the preload process. This is 100% necessary in order to use react refresh see: 
https://github.com/electron-userland/electron-forge/issues/1936 
https://github.com/pmmmwh/react-refresh-webpack-plugin/issues/263

There is a pr open for this currently but the author appears to have abandoned it. This is blocking me so lets get this fixed. I am happy to write documentation for it if needed. 