### PR TITLE
feat(plugin-webpack): support webpack configuration from sync/async function

### DIFF
--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -38,7 +38,7 @@ export default class WebpackConfigGenerator {
       const result = require(path.resolve(this.projectDir, config));
 
       if (typeof result === 'function') {
-        return (await result()) as Configuration;
+        return (await Promise.resolve(result())) as Configuration;
       }
 
       return result as Configuration;

--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -35,10 +35,10 @@ export default class WebpackConfigGenerator {
   async resolveConfig(config: Configuration | string): Promise<Configuration> {
     if (typeof config === 'string') {
       // eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-dynamic-require, global-require
-      const result = require(path.resolve(this.projectDir, config)) as Configuration;
+      const result = require(path.resolve(this.projectDir, config));
 
       if (typeof result === 'function') {
-        return await (result as () => Promise<Configuration>)();
+        return (await result()) as Configuration;
       }
 
       return result as Configuration;

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -249,7 +249,7 @@ the generated files). Instead, it is ${JSON.stringify(pj.main)}`);
       tab = logger.createTab('Main Process');
     }
     await asyncOra('Compiling Main Process Code', async () => {
-      const mainConfig = this.configGenerator.getMainConfig();
+      const mainConfig = await this.configGenerator.getMainConfig();
       await new Promise((resolve, reject) => {
         const compiler = webpack(mainConfig);
         const [onceResolve, onceReject] = once(resolve, reject);

--- a/packages/plugin/webpack/test/AssetRelocatorPatch_spec.ts
+++ b/packages/plugin/webpack/test/AssetRelocatorPatch_spec.ts
@@ -130,7 +130,7 @@ describe('AssetRelocatorPatch', () => {
     const generator = new WebpackConfigGenerator(config, appPath, false, 3000);
 
     it('builds main', async () => {
-      await asyncWebpack(generator.getMainConfig());
+      await asyncWebpack(await generator.getMainConfig());
 
       await expectOutputFileToHaveTheCorrectNativeModulePath({
         outDir: mainOut,
@@ -184,7 +184,7 @@ describe('AssetRelocatorPatch', () => {
     let generator = new WebpackConfigGenerator(config, appPath, true, 3000);
 
     it('builds main', async () => {
-      const mainConfig = generator.getMainConfig();
+      const mainConfig = await generator.getMainConfig();
       await asyncWebpack(mainConfig);
 
       await expectOutputFileToHaveTheCorrectNativeModulePath({

--- a/packages/plugin/webpack/test/WebpackConfig_spec.ts
+++ b/packages/plugin/webpack/test/WebpackConfig_spec.ts
@@ -154,12 +154,13 @@ describe('WebpackConfigGenerator', () => {
   });
 
   describe('getMainConfig', () => {
-    it('fails when there is no mainConfig.entry', () => {
+    it('fails when there is no mainConfig.entry', async () => {
       const config = {
         mainConfig: {},
       } as WebpackPluginConfig;
       const generator = new WebpackConfigGenerator(config, '/', false, 3000);
-      expect(() => generator.getMainConfig()).to.throw('Required option "mainConfig.entry" has not been defined');
+      const result = await generator.getMainConfig();
+      expect(() => result).to.throw('Required option "mainConfig.entry" has not been defined');
     });
 
     it('generates a development config', async () => {

--- a/packages/plugin/webpack/test/WebpackConfig_spec.ts
+++ b/packages/plugin/webpack/test/WebpackConfig_spec.ts
@@ -154,13 +154,12 @@ describe('WebpackConfigGenerator', () => {
   });
 
   describe('getMainConfig', () => {
-    it('fails when there is no mainConfig.entry', async () => {
+    it('fails when there is no mainConfig.entry', () => {
       const config = {
         mainConfig: {},
       } as WebpackPluginConfig;
       const generator = new WebpackConfigGenerator(config, '/', false, 3000);
-      const result = await generator.getMainConfig();
-      expect(() => result).to.throw('Required option "mainConfig.entry" has not been defined');
+      expect(generator.getMainConfig()).to.eventually.throw('Required option "mainConfig.entry" has not been defined');
     });
 
     it('generates a development config', async () => {

--- a/packages/plugin/webpack/test/WebpackConfig_spec.ts
+++ b/packages/plugin/webpack/test/WebpackConfig_spec.ts
@@ -245,6 +245,32 @@ describe('WebpackConfigGenerator', () => {
       const webpackConfig = await generator.getMainConfig();
       expect(webpackConfig.entry).to.equal(path.resolve(baseDir, 'foo/main.js'));
     });
+
+    it('generates a config from a requirable file w/ sync function return', async () => {
+      const config = {
+        mainConfig: 'mainConfig.sync.js',
+        renderer: {
+          entryPoints: [] as WebpackPluginEntryPoint[],
+        },
+      } as WebpackPluginConfig;
+      const baseDir = path.resolve(__dirname, 'fixtures/main_config_external');
+      const generator = new WebpackConfigGenerator(config, baseDir, true, 3000);
+      const webpackConfig = await generator.getMainConfig();
+      expect(webpackConfig.entry).to.equal(path.resolve(baseDir, 'foo/main.js'));
+    });
+
+    it('generates a config from a requirable file w/ async function return', async () => {
+      const config = {
+        mainConfig: 'mainConfig.async.js',
+        renderer: {
+          entryPoints: [] as WebpackPluginEntryPoint[],
+        },
+      } as WebpackPluginConfig;
+      const baseDir = path.resolve(__dirname, 'fixtures/main_config_external');
+      const generator = new WebpackConfigGenerator(config, baseDir, true, 3000);
+      const webpackConfig = await generator.getMainConfig();
+      expect(webpackConfig.entry).to.equal(path.resolve(baseDir, 'foo/main.js'));
+    });
   });
 
   describe('getPreloadRendererConfig', () => {

--- a/packages/plugin/webpack/test/fixtures/main_config_external/mainConfig.async.js
+++ b/packages/plugin/webpack/test/fixtures/main_config_external/mainConfig.async.js
@@ -1,0 +1,3 @@
+module.exports = async () => ({
+  entry: './foo/main.js',
+});

--- a/packages/plugin/webpack/test/fixtures/main_config_external/mainConfig.sync.js
+++ b/packages/plugin/webpack/test/fixtures/main_config_external/mainConfig.sync.js
@@ -1,0 +1,3 @@
+module.exports = () => ({
+  entry: './foo/main.js',
+});


### PR DESCRIPTION
- [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

* support [webpack configuration from sync/async function returns](https://webpack.js.org/configuration/configuration-types/)

it should fix #2461 
