### PR TITLE
fix: escape file names for `make` step

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "express": "^4.17.1",
     "express-ws": "^5.0.2",
     "fast-glob": "^3.2.7",
+    "filenamify": "^4.1.0",
     "find-up": "^5.0.0",
     "form-data": "^4.0.0",
     "fs-extra": "^10.0.0",

--- a/packages/api/core/package.json
+++ b/packages/api/core/package.json
@@ -58,6 +58,7 @@
     "electron-packager": "^15.4.0",
     "electron-rebuild": "^3.2.6",
     "fast-glob": "^3.2.7",
+    "filenamify": "^4.1.0",
     "find-up": "^5.0.0",
     "fs-extra": "^10.0.0",
     "lodash": "^4.17.20",

--- a/packages/api/core/src/api/make.ts
+++ b/packages/api/core/src/api/make.ts
@@ -5,6 +5,7 @@ import { IForgeResolvableMaker, ForgeConfig, ForgeArch, ForgePlatform, ForgeMake
 import MakerBase from '@electron-forge/maker-base';
 import fs from 'fs-extra';
 import path from 'path';
+import filenamify from 'filenamify';
 
 import getForgeConfig from '../util/forge-config';
 import { runHook, runMutatingHook } from '../util/hook';
@@ -178,7 +179,7 @@ export default async ({
   info(interactive, `Making for the following targets: ${chalk.cyan(`${targets.map((_t, i) => makers[i].name).join(', ')}`)}`);
 
   const packageJSON = await readMutatedPackageJson(dir, forgeConfig);
-  const appName = forgeConfig.packagerConfig.name || packageJSON.productName || packageJSON.name;
+  const appName = filenamify(forgeConfig.packagerConfig.name || packageJSON.productName || packageJSON.name, { replacement: '-' });
   const outputs: ForgeMakeResult[] = [];
 
   await runHook(forgeConfig, 'preMake');


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [ ] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
- [ ] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
