### PR TITLE
ci(fast): use windows-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     needs: dependabolt
     strategy:
       matrix:
-        os: [windows-2019, macOS-latest, ubuntu-latest]
+        os: [windows-latest, macOS-latest, ubuntu-latest]
     steps:
       - name: Fix git checkout line endings
         run: git config --global core.autocrlf input
@@ -42,6 +42,13 @@ jobs:
         with:
           node-version: 12.x
           cache: yarn
+      - name: Install latest NPM on Windows
+        if: matrix.os == 'windows-latest'
+        # See https://github.com/actions/virtual-environments/issues/4856#issuecomment-1043256330
+        # and https://github.com/actions/setup-node/issues/411#issuecomment-1051084491
+        run: |
+          npm install -g npm@8.3.1
+          npm install -g npm@latest
       - name: Install bolt
         shell: bash
         run: |


### PR DESCRIPTION
- [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes have sufficient test coverage (if applicable).

**Summarize your changes:**

Use `windows-latest` (currently 2022) instead of `windows-2019`. Needs a very recent version of `node-gyp`.