### PR TITLE
feat(plugin-webpack): Allow entrypoints to specify webpack `target`

### DIFF
--- a/packages/plugin/webpack/src/Config.ts
+++ b/packages/plugin/webpack/src/Config.ts
@@ -32,6 +32,10 @@ export interface WebpackPluginEntryPoint {
    * preload scripts you don't need to set this.
    */
   preload?: WebpackPreloadEntryPoint;
+  /**
+   * Override the `target` for this entry point
+   */
+  target?: WebpackConfiguration['target'];
 }
 
 export interface WebpackPreloadEntryPoint {

--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -164,46 +164,52 @@ export default class WebpackConfigGenerator {
     );
   }
 
-  async getRendererConfig(entryPoints: WebpackPluginEntryPoint[]): Promise<Configuration> {
+  async getRendererConfig(entryPoints: WebpackPluginEntryPoint[]): Promise<Configuration[]> {
     const rendererConfig = this.resolveConfig(this.pluginConfig.renderer.config);
-    const entry: webpack.Entry = {};
-    for (const entryPoint of entryPoints) {
-      const prefixedEntries = entryPoint.prefixedEntries || [];
-      entry[entryPoint.name] = prefixedEntries.concat([entryPoint.js]);
-    }
-
     const defines = this.getDefines(false);
-    const plugins = entryPoints
-      .filter((entryPoint) => Boolean(entryPoint.html))
-      .map(
-        (entryPoint) =>
-          new HtmlWebpackPlugin({
-            title: entryPoint.name,
-            template: entryPoint.html,
-            filename: `${entryPoint.name}/index.html`,
-            chunks: [entryPoint.name].concat(entryPoint.additionalChunks || []),
-          }) as WebpackPluginInstance
-      )
-      .concat([new webpack.DefinePlugin(defines), new AssetRelocatorPatch(this.isProd, !!this.pluginConfig.renderer.nodeIntegration)]);
-    return webpackMerge(
-      {
-        entry,
-        devtool: this.rendererSourceMapOption,
-        target: this.rendererTarget,
-        mode: this.mode,
-        output: {
-          path: path.resolve(this.webpackDir, 'renderer'),
-          filename: '[name]/index.js',
-          globalObject: 'self',
-          ...(this.isProd ? {} : { publicPath: '/' }),
+
+    return entryPoints.map((entryPoint) => {
+      const config = webpackMerge(
+        {
+          entry: {
+            [entryPoint.name]: (entryPoint.prefixedEntries || []).concat([entryPoint.js]),
+          },
+          target: this.rendererTarget,
+          devtool: this.rendererSourceMapOption,
+          mode: this.mode,
+          output: {
+            path: path.resolve(this.webpackDir, 'renderer'),
+            filename: '[name]/index.js',
+            globalObject: 'self',
+            ...(this.isProd ? {} : { publicPath: '/' }),
+          },
+          node: {
+            __dirname: false,
+            __filename: false,
+          },
+          plugins: [
+            ...(entryPoint.html
+              ? [
+                  new HtmlWebpackPlugin({
+                    title: entryPoint.name,
+                    template: entryPoint.html,
+                    filename: `${entryPoint.name}/index.html`,
+                    chunks: [entryPoint.name].concat(entryPoint.additionalChunks || []),
+                  }) as WebpackPluginInstance,
+                ]
+              : []),
+            new webpack.DefinePlugin(defines),
+            new AssetRelocatorPatch(this.isProd, !!this.pluginConfig.renderer.nodeIntegration),
+          ],
         },
-        node: {
-          __dirname: false,
-          __filename: false,
-        },
-        plugins,
-      },
-      rendererConfig || {}
-    );
+        rendererConfig || {}
+      );
+
+      if (entryPoint.target) {
+        config.target = entryPoint.target;
+      }
+
+      return config;
+    });
   }
 }

--- a/packages/plugin/webpack/test/AssetRelocatorPatch_spec.ts
+++ b/packages/plugin/webpack/test/AssetRelocatorPatch_spec.ts
@@ -161,7 +161,9 @@ describe('AssetRelocatorPatch', () => {
 
     it('builds renderer', async () => {
       const rendererConfig = await generator.getRendererConfig(config.renderer.entryPoints);
-      await asyncWebpack(rendererConfig);
+      for (const rendererEntryConfig of rendererConfig) {
+        await asyncWebpack(rendererEntryConfig);
+      }
 
       await expectOutputFileToHaveTheCorrectNativeModulePath({
         outDir: rendererOut,
@@ -216,7 +218,9 @@ describe('AssetRelocatorPatch', () => {
 
     it('builds renderer', async () => {
       const rendererConfig = await generator.getRendererConfig(config.renderer.entryPoints);
-      await asyncWebpack(rendererConfig);
+      for (const rendererEntryConfig of rendererConfig) {
+        await asyncWebpack(rendererEntryConfig);
+      }
 
       await expectOutputFileToHaveTheCorrectNativeModulePath({
         outDir: rendererOut,
@@ -239,7 +243,9 @@ describe('AssetRelocatorPatch', () => {
       generator = new WebpackConfigGenerator(config, appPath, true, 3000);
 
       const rendererConfig = await generator.getRendererConfig(config.renderer.entryPoints);
-      await asyncWebpack(rendererConfig);
+      for (const rendererEntryConfig of rendererConfig) {
+        await asyncWebpack(rendererEntryConfig);
+      }
 
       await expectOutputFileToHaveTheCorrectNativeModulePath({
         outDir: rendererOut,

--- a/packages/plugin/webpack/test/WebpackConfig_spec.ts
+++ b/packages/plugin/webpack/test/WebpackConfig_spec.ts
@@ -366,7 +366,7 @@ describe('WebpackConfigGenerator', () => {
       const rendererWebpackConfig = await generator.getRendererConfig(config.renderer.entryPoints);
       // Our preload config plugins is an empty list while our renderer config plugins has a member
       expect(preloadWebpackConfig.name).to.equal('preload');
-      expect(rendererWebpackConfig.name).to.equal('renderer');
+      expect(rendererWebpackConfig[0].name).to.equal('renderer');
     });
   });
 
@@ -385,20 +385,20 @@ describe('WebpackConfigGenerator', () => {
       } as WebpackPluginConfig;
       const generator = new WebpackConfigGenerator(config, mockProjectDir, false, 3000);
       const webpackConfig = await generator.getRendererConfig(config.renderer.entryPoints);
-      expect(webpackConfig.target).to.deep.equal('electron-renderer');
-      expect(webpackConfig.mode).to.equal('development');
-      expect(webpackConfig.entry).to.deep.equal({
+      expect(webpackConfig[0].target).to.deep.equal('electron-renderer');
+      expect(webpackConfig[0].mode).to.equal('development');
+      expect(webpackConfig[0].entry).to.deep.equal({
         main: ['rendererScript.js'],
       });
-      expect(webpackConfig.output).to.deep.equal({
+      expect(webpackConfig[0].output).to.deep.equal({
         path: path.join(mockProjectDir, '.webpack', 'renderer'),
         filename: '[name]/index.js',
         globalObject: 'self',
         publicPath: '/',
       });
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      expect(webpackConfig.plugins!.length).to.equal(2);
-      expect(hasAssetRelocatorPatchPlugin(webpackConfig.plugins)).to.equal(true);
+      expect(webpackConfig[0].plugins!.length).to.equal(2);
+      expect(hasAssetRelocatorPatchPlugin(webpackConfig[0].plugins)).to.equal(true);
     });
 
     it('generates a development config with an HTML endpoint', async () => {
@@ -415,12 +415,12 @@ describe('WebpackConfigGenerator', () => {
       } as WebpackPluginConfig;
       const generator = new WebpackConfigGenerator(config, mockProjectDir, false, 3000);
       const webpackConfig = await generator.getRendererConfig(config.renderer.entryPoints);
-      expect(webpackConfig.entry).to.deep.equal({
+      expect(webpackConfig[0].entry).to.deep.equal({
         main: ['rendererScript.js'],
       });
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      expect(webpackConfig.plugins!.length).to.equal(3);
-      expect(hasAssetRelocatorPatchPlugin(webpackConfig.plugins)).to.equal(true);
+      expect(webpackConfig[0].plugins!.length).to.equal(3);
+      expect(hasAssetRelocatorPatchPlugin(webpackConfig[0].plugins)).to.equal(true);
     });
 
     it('generates a production config', async () => {
@@ -436,19 +436,19 @@ describe('WebpackConfigGenerator', () => {
       } as WebpackPluginConfig;
       const generator = new WebpackConfigGenerator(config, mockProjectDir, true, 3000);
       const webpackConfig = await generator.getRendererConfig(config.renderer.entryPoints);
-      expect(webpackConfig.target).to.deep.equal('web');
-      expect(webpackConfig.mode).to.equal('production');
-      expect(webpackConfig.entry).to.deep.equal({
+      expect(webpackConfig[0].target).to.deep.equal('web');
+      expect(webpackConfig[0].mode).to.equal('production');
+      expect(webpackConfig[0].entry).to.deep.equal({
         main: ['rendererScript.js'],
       });
-      expect(webpackConfig.output).to.deep.equal({
+      expect(webpackConfig[0].output).to.deep.equal({
         path: path.join(mockProjectDir, '.webpack', 'renderer'),
         filename: '[name]/index.js',
         globalObject: 'self',
       });
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      expect(webpackConfig.plugins!.length).to.equal(2);
-      expect(hasAssetRelocatorPatchPlugin(webpackConfig.plugins)).to.equal(true);
+      expect(webpackConfig[0].plugins!.length).to.equal(2);
+      expect(hasAssetRelocatorPatchPlugin(webpackConfig[0].plugins)).to.equal(true);
     });
 
     it('can override the renderer target', async () => {
@@ -467,7 +467,7 @@ describe('WebpackConfigGenerator', () => {
       } as WebpackPluginConfig;
       const generator = new WebpackConfigGenerator(config, mockProjectDir, true, 3000);
       const webpackConfig = await generator.getRendererConfig(config.renderer.entryPoints);
-      expect(webpackConfig.target).to.equal('web');
+      expect(webpackConfig[0].target).to.equal('web');
     });
   });
 });

--- a/typings/webpack-dev-server/index.d.ts
+++ b/typings/webpack-dev-server/index.d.ts
@@ -2,9 +2,10 @@
 // See: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/55300#issuecomment-904636931
 declare module 'webpack-dev-server' {
   import { Server } from 'http';
-  import { Compiler } from 'webpack';
+  import { Compiler, MultiCompiler } from 'webpack';
   class WebpackDevServer {
     constructor(options: {}, compiler: Compiler);
+    constructor(options: {}, compiler: MultiCompiler);
     server: Server;
     start(): Promise<void>;
     close(): void;


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

We have multiple `BrowserWindow`s in our project, some which use `nodeIntegration: false` and some which use `nodeIntegration: true`. 

Without this change we get the error `require is not defined` at runtime in the `BrowserWindow`s with `nodeIntegration: false`.

We didn't need to do this with older versions of `@electron-forge/plugin-webpack` that used Webpack 4 where we could simply not import any Node JS modules and just use browser-targeted modules.

`@electron-forge/plugin-webpack` only allows us to set one target for _all_ entrypoints. This change allows overriding the target for a specific entrypoint. e.g.

```js
  plugins: [
    [
      '@electron-forge/plugin-webpack',
      {
        nodeIntegration: true, // Implies `target: 'electron-renderer'` for all entrypoints
        mainConfig: './webpack.main.config.js',
        renderer: {
          config: './webpack.renderer.config.js',
          entryPoints: [
            {
              html: './src/app/app.html',
              js: './src/app/app.tsx',
              name: 'app'
            },
            {
              html: './src/mediaPlayer/index.html',
              js: './src/mediaPlayer/index.tsx',
              name: 'media_player',
              target: 'web' // This is new
            }
          ]
        }
      ]
    ]
```

This uses Webpack's ability to pass an array of webpack configurations rather than a single configuration.
