### PR TITLE
feat(plugin-webpack): Allow each entrypoint to specify `nodeIntegration`

### DIFF
--- a/packages/plugin/webpack/src/Config.ts
+++ b/packages/plugin/webpack/src/Config.ts
@@ -33,6 +33,20 @@ export interface WebpackPluginEntryPoint {
    * preload scripts you don't need to set this.
    */
   preload?: WebpackPreloadEntryPoint;
+  /**
+   * Override the Webpack config for this renderer based on whether `nodeIntegration` for
+   * the `BrowserWindow` is enabled. Namely, for Webpack's `target` option:
+   *
+   * * When `nodeIntegration` is true, the `target` is `electron-renderer`.
+   * * When `nodeIntegration` is false, the `target` is `web`.
+   *
+   * Unfortunately, we cannot derive the value from the main process code as it can be a
+   * dynamically generated value at runtime, and Webpack processes at build-time.
+   *
+   * Defaults to `false` (as it is disabled by default in Electron \>= 5) or the value set
+   * for all entries.
+   */
+  nodeIntegration?: boolean;
 }
 
 export interface WebpackPreloadEntryPoint {
@@ -66,8 +80,8 @@ export interface WebpackPluginRendererConfig {
    */
   jsonStats?: boolean;
   /**
-   * Adjusts the Webpack config for the renderer based on whether `nodeIntegration` for the
-   * `BrowserWindow` is enabled. Namely, for Webpack's `target` option:
+   * Adjusts the Webpack config for all renderer entries based on whether `nodeIntegration`
+   * for the `BrowserWindow` is enabled. Namely, for Webpack's `target` option:
    *
    * * When `nodeIntegration` is true, the `target` is `electron-renderer`.
    * * When `nodeIntegration` is false, the `target` is `web`.

--- a/packages/plugin/webpack/test/AssetRelocatorPatch_spec.ts
+++ b/packages/plugin/webpack/test/AssetRelocatorPatch_spec.ts
@@ -161,7 +161,9 @@ describe('AssetRelocatorPatch', () => {
 
     it('builds renderer', async () => {
       const rendererConfig = await generator.getRendererConfig(config.renderer.entryPoints);
-      await asyncWebpack(rendererConfig);
+      for (const rendererEntryConfig of rendererConfig) {
+        await asyncWebpack(rendererEntryConfig);
+      }
 
       await expectOutputFileToHaveTheCorrectNativeModulePath({
         outDir: rendererOut,
@@ -216,7 +218,9 @@ describe('AssetRelocatorPatch', () => {
 
     it('builds renderer', async () => {
       const rendererConfig = await generator.getRendererConfig(config.renderer.entryPoints);
-      await asyncWebpack(rendererConfig);
+      for (const rendererEntryConfig of rendererConfig) {
+        await asyncWebpack(rendererEntryConfig);
+      }
 
       await expectOutputFileToHaveTheCorrectNativeModulePath({
         outDir: rendererOut,
@@ -239,7 +243,9 @@ describe('AssetRelocatorPatch', () => {
       generator = new WebpackConfigGenerator(config, appPath, true, 3000);
 
       const rendererConfig = await generator.getRendererConfig(config.renderer.entryPoints);
-      await asyncWebpack(rendererConfig);
+      for (const rendererEntryConfig of rendererConfig) {
+        await asyncWebpack(rendererEntryConfig);
+      }
 
       await expectOutputFileToHaveTheCorrectNativeModulePath({
         outDir: rendererOut,

--- a/packages/plugin/webpack/test/WebpackConfig_spec.ts
+++ b/packages/plugin/webpack/test/WebpackConfig_spec.ts
@@ -29,30 +29,45 @@ describe('WebpackConfigGenerator', () => {
   describe('rendererTarget', () => {
     it('is web if undefined', () => {
       const config = {
-        renderer: {},
+        renderer: {
+          entryPoints: [{ name: 'foo', js: 'foo/index.js' }],
+        },
       } as WebpackPluginConfig;
       const generator = new WebpackConfigGenerator(config, '/', false, 3000);
-      expect(generator.rendererTarget).to.equal('web');
+      expect(generator.rendererTarget(config.renderer.entryPoints[0])).to.equal('web');
     });
 
     it('is web if false', () => {
       const config = {
         renderer: {
+          entryPoints: [{ name: 'foo', js: 'foo/index.js' }],
           nodeIntegration: false,
         },
       } as WebpackPluginConfig;
       const generator = new WebpackConfigGenerator(config, '/', false, 3000);
-      expect(generator.rendererTarget).to.equal('web');
+      expect(generator.rendererTarget(config.renderer.entryPoints[0])).to.equal('web');
     });
 
     it('is electron-renderer if true', () => {
       const config = {
         renderer: {
+          entryPoints: [{ name: 'foo', js: 'foo/index.js' }],
           nodeIntegration: true,
         },
       } as WebpackPluginConfig;
       const generator = new WebpackConfigGenerator(config, '/', false, 3000);
-      expect(generator.rendererTarget).to.equal('electron-renderer');
+      expect(generator.rendererTarget(config.renderer.entryPoints[0])).to.equal('electron-renderer');
+    });
+
+    it('is web if entry nodeIntegration is false', () => {
+      const config = {
+        renderer: {
+          entryPoints: [{ name: 'foo', js: 'foo/index.js', nodeIntegration: false }],
+          nodeIntegration: true,
+        },
+      } as WebpackPluginConfig;
+      const generator = new WebpackConfigGenerator(config, '/', false, 3000);
+      expect(generator.rendererTarget(config.renderer.entryPoints[0])).to.equal('web');
     });
   });
 
@@ -411,7 +426,7 @@ describe('WebpackConfigGenerator', () => {
       const rendererWebpackConfig = await generator.getRendererConfig(config.renderer.entryPoints);
       // Our preload config plugins is an empty list while our renderer config plugins has a member
       expect(preloadWebpackConfig.name).to.equal('preload');
-      expect(rendererWebpackConfig.name).to.equal('renderer');
+      expect(rendererWebpackConfig[0].name).to.equal('renderer');
     });
   });
 
@@ -430,20 +445,20 @@ describe('WebpackConfigGenerator', () => {
       } as WebpackPluginConfig;
       const generator = new WebpackConfigGenerator(config, mockProjectDir, false, 3000);
       const webpackConfig = await generator.getRendererConfig(config.renderer.entryPoints);
-      expect(webpackConfig.target).to.deep.equal('electron-renderer');
-      expect(webpackConfig.mode).to.equal('development');
-      expect(webpackConfig.entry).to.deep.equal({
+      expect(webpackConfig[0].target).to.deep.equal('electron-renderer');
+      expect(webpackConfig[0].mode).to.equal('development');
+      expect(webpackConfig[0].entry).to.deep.equal({
         main: ['rendererScript.js'],
       });
-      expect(webpackConfig.output).to.deep.equal({
+      expect(webpackConfig[0].output).to.deep.equal({
         path: path.join(mockProjectDir, '.webpack', 'renderer'),
         filename: '[name]/index.js',
         globalObject: 'self',
         publicPath: '/',
       });
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      expect(webpackConfig.plugins!.length).to.equal(2);
-      expect(hasAssetRelocatorPatchPlugin(webpackConfig.plugins)).to.equal(true);
+      expect(webpackConfig[0].plugins!.length).to.equal(2);
+      expect(hasAssetRelocatorPatchPlugin(webpackConfig[0].plugins)).to.equal(true);
     });
 
     it('generates a development config with an HTML endpoint', async () => {
@@ -460,12 +475,12 @@ describe('WebpackConfigGenerator', () => {
       } as WebpackPluginConfig;
       const generator = new WebpackConfigGenerator(config, mockProjectDir, false, 3000);
       const webpackConfig = await generator.getRendererConfig(config.renderer.entryPoints);
-      expect(webpackConfig.entry).to.deep.equal({
+      expect(webpackConfig[0].entry).to.deep.equal({
         main: ['rendererScript.js'],
       });
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      expect(webpackConfig.plugins!.length).to.equal(3);
-      expect(hasAssetRelocatorPatchPlugin(webpackConfig.plugins)).to.equal(true);
+      expect(webpackConfig[0].plugins!.length).to.equal(3);
+      expect(hasAssetRelocatorPatchPlugin(webpackConfig[0].plugins)).to.equal(true);
     });
 
     it('generates a production config', async () => {
@@ -481,19 +496,19 @@ describe('WebpackConfigGenerator', () => {
       } as WebpackPluginConfig;
       const generator = new WebpackConfigGenerator(config, mockProjectDir, true, 3000);
       const webpackConfig = await generator.getRendererConfig(config.renderer.entryPoints);
-      expect(webpackConfig.target).to.deep.equal('web');
-      expect(webpackConfig.mode).to.equal('production');
-      expect(webpackConfig.entry).to.deep.equal({
+      expect(webpackConfig[0].target).to.deep.equal('web');
+      expect(webpackConfig[0].mode).to.equal('production');
+      expect(webpackConfig[0].entry).to.deep.equal({
         main: ['rendererScript.js'],
       });
-      expect(webpackConfig.output).to.deep.equal({
+      expect(webpackConfig[0].output).to.deep.equal({
         path: path.join(mockProjectDir, '.webpack', 'renderer'),
         filename: '[name]/index.js',
         globalObject: 'self',
       });
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      expect(webpackConfig.plugins!.length).to.equal(2);
-      expect(hasAssetRelocatorPatchPlugin(webpackConfig.plugins)).to.equal(true);
+      expect(webpackConfig[0].plugins!.length).to.equal(2);
+      expect(hasAssetRelocatorPatchPlugin(webpackConfig[0].plugins)).to.equal(true);
     });
 
     it('can override the renderer target', async () => {
@@ -512,7 +527,7 @@ describe('WebpackConfigGenerator', () => {
       } as WebpackPluginConfig;
       const generator = new WebpackConfigGenerator(config, mockProjectDir, true, 3000);
       const webpackConfig = await generator.getRendererConfig(config.renderer.entryPoints);
-      expect(webpackConfig.target).to.equal('web');
+      expect(webpackConfig[0].target).to.equal('web');
     });
 
     it('generates a config from function', async () => {

--- a/typings/webpack-dev-server/index.d.ts
+++ b/typings/webpack-dev-server/index.d.ts
@@ -2,9 +2,10 @@
 // See: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/55300#issuecomment-904636931
 declare module 'webpack-dev-server' {
   import { Server } from 'http';
-  import { Compiler } from 'webpack';
+  import { Compiler, MultiCompiler } from 'webpack';
   class WebpackDevServer {
     constructor(options: {}, compiler: Compiler);
+    constructor(options: {}, compiler: MultiCompiler);
     server: Server;
     start(): Promise<void>;
     close(): void;


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Summarize your changes:

Note that this replaces https://github.com/electron-userland/electron-forge/pull/2856 based on [this suggestion](https://github.com/electron-userland/electron-forge/pull/2856#issuecomment-1146258778).

We have multiple BrowserWindows in our project, some which use `nodeIntegration: false` and some which use `nodeIntegration: true`.

Without this change we get the error require is not defined at runtime in the BrowserWindows with nodeIntegration: false.

We didn't need to do this with older versions of `@electron-forge/plugin-webpack` that used Webpack 4 where we could simply not import any Node JS modules and just use browser-targeted modules.

`@electron-forge/plugin-webpack` only allows us to set one target for all entrypoints. This change allows overriding the `nodeIntegration` value for a specific entrypoint. e.g.

```js
  plugins: [
    [
      '@electron-forge/plugin-webpack',
      {
        mainConfig: './webpack.main.config.js',
        renderer: {
          config: './webpack.renderer.config.js',
          nodeIntegration: true, // Implies `target: 'electron-renderer'` for all entrypoints
          entryPoints: [
            {
              html: './src/app/app.html',
              js: './src/app/app.tsx',
              name: 'app'
            },
            {
              html: './src/mediaPlayer/index.html',
              js: './src/mediaPlayer/index.tsx',
              name: 'media_player',
              nodeIntegration: false
            }
          ]
        }
      ]
    ]
```

This uses Webpack's ability to pass an array of webpack configurations rather than a single configuration.
