### PR TITLE
fix: renderer should not compile native modules

### DIFF
--- a/packages/template/typescript-webpack/tmpl/webpack.main.config.js
+++ b/packages/template/typescript-webpack/tmpl/webpack.main.config.js
@@ -6,7 +6,25 @@ module.exports = {
   entry: './src/index.ts',
   // Put your normal webpack config below here
   module: {
-    rules: require('./webpack.rules'),
+    rules: require('./webpack.rules').concat(
+      // Add support for native node modules
+      {
+        // We're specifying native_modules in the test because the asset relocator loader generates a
+        // "fake" .node file which is really a cjs file.
+        test: /native_modules\/.+\.node$/,
+        use: 'node-loader',
+      },
+      {
+        test: /\.(m?js|node)$/,
+        parser: { amd: false },
+        use: {
+          loader: '@vercel/webpack-asset-relocator-loader',
+          options: {
+            outputAssetBase: 'native_modules',
+          },
+        },
+      }
+    ),
   },
   resolve: {
     extensions: ['.js', '.ts', '.jsx', '.tsx', '.css', '.json'],

--- a/packages/template/typescript-webpack/tmpl/webpack.rules.js
+++ b/packages/template/typescript-webpack/tmpl/webpack.rules.js
@@ -1,21 +1,4 @@
 module.exports = [
-  // Add support for native node modules
-  {
-    // We're specifying native_modules in the test because the asset relocator loader generates a
-    // "fake" .node file which is really a cjs file.
-    test: /native_modules\/.+\.node$/,
-    use: 'node-loader',
-  },
-  {
-    test: /\.(m?js|node)$/,
-    parser: { amd: false },
-    use: {
-      loader: '@vercel/webpack-asset-relocator-loader',
-      options: {
-        outputAssetBase: 'native_modules',
-      },
-    },
-  },
   {
     test: /\.tsx?$/,
     exclude: /(node_modules|\.webpack)/,

--- a/packages/template/webpack/tmpl/webpack.main.config.js
+++ b/packages/template/webpack/tmpl/webpack.main.config.js
@@ -6,6 +6,24 @@ module.exports = {
   entry: './src/main.js',
   // Put your normal webpack config below here
   module: {
-    rules: require('./webpack.rules'),
+    rules: require('./webpack.rules').concat(
+      // Add support for native node modules
+      {
+        // We're specifying native_modules in the test because the asset relocator loader generates a
+        // "fake" .node file which is really a cjs file.
+        test: /native_modules\/.+\.node$/,
+        use: 'node-loader',
+      },
+      {
+        test: /\.(m?js|node)$/,
+        parser: { amd: false },
+        use: {
+          loader: '@vercel/webpack-asset-relocator-loader',
+          options: {
+            outputAssetBase: 'native_modules',
+          },
+        },
+      }
+    ),
   },
 };

--- a/packages/template/webpack/tmpl/webpack.rules.js
+++ b/packages/template/webpack/tmpl/webpack.rules.js
@@ -1,21 +1,4 @@
 module.exports = [
-  // Add support for native node modules
-  {
-    // We're specifying native_modules in the test because the asset relocator loader generates a
-    // "fake" .node file which is really a cjs file.
-    test: /native_modules\/.+\.node$/,
-    use: 'node-loader',
-  },
-  {
-    test: /\.(m?js|node)$/,
-    parser: { amd: false },
-    use: {
-      loader: '@vercel/webpack-asset-relocator-loader',
-      options: {
-        outputAssetBase: 'native_modules',
-      },
-    },
-  },
   // Put your webpack loader rules in this array.  This is where you would put
   // your ts-loader configuration for instance:
   /**


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [ ] The testsuite passes successfully on my local machine (if applicable).

Now in webpack template, `main` and `renderer` both use the same webpack rules which include native module compile rule as below:
```js
  // Add support for native node modules
  {
    // We're specifying native_modules in the test because the asset relocator loader generates a
    // "fake" .node file which is really a cjs file.
    test: /native_modules\/.+\.node$/,
    use: 'node-loader',
  },
  {
    test: /\.(m?js|node)$/,
    parser: { amd: false },
    use: {
      loader: '@vercel/webpack-asset-relocator-loader',
      options: {
        outputAssetBase: 'native_modules',
      },
    },
  },
```

`renderer` actually don't neet that, and it will cause error sometimes.

For example, in preload file import some js files or some node_module library:

```js
// preload.js
import './test.js';
```

It matched the regexp: `/\.(m?js|node)$/`, `@vercel/webpack-asset-relocator-loader` will handle it and compile it include such code:

```js
...
/************************************************************************/
/******/ 	/* webpack/runtime/compat */
/******/ 	
/******/ 	if (typeof __webpack_require__ !== 'undefined') __webpack_require__.ab = __dirname + "/native_modules/";
/******/ 	
/************************************************************************/
...
```

In renderer there is no `__dirname` and it will cause `__dirname is not defined` error:

![image](https://user-images.githubusercontent.com/6689073/177788374-4b222587-8f71-4e1b-87e1-3102ac2fb310.png)

So I updated the webpack template, move native module compile rules to `webpack.main.js`, It worked.

