### PR TITLE
fix: keep stdin unpaused after ora completes

### DIFF
--- a/packages/api/core/src/api/start.ts
+++ b/packages/api/core/src/api/start.ts
@@ -27,6 +27,7 @@ export default async ({
   inspectBrk = false,
 }: StartOptions): Promise<ElectronProcess> => {
   asyncOra.interactive = interactive;
+  asyncOra.keepStdinFlowing = true;
 
   await asyncOra('Locating Application', async () => {
     const resolvedDir = await resolveDir(dir);
@@ -131,9 +132,13 @@ export default async ({
         process.stdin.resume();
       }
       spawned.on('exit', () => {
-        if (spawned.restarted) return;
+        if (spawned.restarted) {
+          return;
+        }
 
-        if (!process.stdin.isPaused()) process.stdin.pause();
+        if (interactive && !process.stdin.isPaused()) {
+          process.stdin.pause();
+        }
       });
     } else if (interactive && !process.stdin.isPaused()) {
       process.stdin.pause();
@@ -153,6 +158,7 @@ export default async ({
         lastSpawned.emit('restarted', await forgeSpawnWrapper());
       }
     });
+    process.stdin.resume();
   }
 
   return forgeSpawnWrapper();

--- a/packages/api/core/src/api/start.ts
+++ b/packages/api/core/src/api/start.ts
@@ -27,6 +27,10 @@ export default async ({
   inspectBrk = false,
 }: StartOptions): Promise<ElectronProcess> => {
   asyncOra.interactive = interactive;
+  // Since the `start` command is meant to be long-living (i.e. run forever,
+  // until interrupted) we should enable this to keep stdin flowing after ora
+  // completes. For more context:
+  // https://github.com/electron-userland/electron-forge/issues/2319
   asyncOra.keepStdinFlowing = true;
 
   await asyncOra('Locating Application', async () => {

--- a/packages/utils/async-ora/src/ora-handler.ts
+++ b/packages/utils/async-ora/src/ora-handler.ts
@@ -30,6 +30,13 @@ export class OraImpl {
 export interface AsyncOraMethod {
   (initialOraValue: string, asyncFn: (oraImpl: OraImpl) => Promise<void>, processExitFn?: (code: number) => void): Promise<void>;
   interactive?: boolean;
+
+  /**
+   * This will keep stdin unpaused if ora inadvertently pauses it. Beware that
+   * enabling this may keep the node process alive even when there is no more
+   * work to be done, as it will forever be waiting for input on stdin.
+   */
+  keepStdinFlowing?: boolean;
 }
 
 const asyncOra: AsyncOraMethod = (initialOraValue, asyncFn, processExitFn = process.exit) => {
@@ -40,7 +47,15 @@ const asyncOra: AsyncOraMethod = (initialOraValue, asyncFn, processExitFn = proc
   return new Promise((resolve, reject) => {
     asyncFn(fnOra)
       .then(() => {
+        const wasPaused = process.stdin.isPaused();
+
+        // Note: this may pause stdin as a side-effect in certain cases
         fnOra.succeed();
+
+        if (asyncOra.keepStdinFlowing && !wasPaused && process.stdin.isPaused()) {
+          process.stdin.resume();
+        }
+
         return resolve();
       })
       .catch((err) => {

--- a/packages/utils/async-ora/src/ora-handler.ts
+++ b/packages/utils/async-ora/src/ora-handler.ts
@@ -35,6 +35,9 @@ export interface AsyncOraMethod {
    * This will keep stdin unpaused if ora inadvertently pauses it. Beware that
    * enabling this may keep the node process alive even when there is no more
    * work to be done, as it will forever be waiting for input on stdin.
+   *
+   * More context:
+   *   https://github.com/electron-userland/electron-forge/issues/2319
    */
   keepStdinFlowing?: boolean;
 }


### PR DESCRIPTION
- [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

As a side-effect of using `node:readline`, when `ora` completes it may `pause` `stdin`. Once it is in this paused state, it is impossible to truly revert to the original "unpaused" state as calling `resume` on `stdin` has its own side-effect of keeping the node process alive as long as `stdin` remains unpaused (which is different than the default, where stdin is both unpaused but will not keep the process alive).

To get around this, I added a flag on `asyncOra` that will maintain `stdin`'s unpaused state across ora's completion, but only for cases where that behavior is desirable, like the `electron-forge start` which both reads from `stdin` and is meant to stay alive "forever".

Fixes #2319.