### PR TITLE
Add missing Webpack targets

### DIFF
--- a/packages/template/typescript-webpack/tmpl/webpack.main.config.js
+++ b/packages/template/typescript-webpack/tmpl/webpack.main.config.js
@@ -11,4 +11,5 @@ module.exports = {
   resolve: {
     extensions: ['.js', '.ts', '.jsx', '.tsx', '.css', '.json'],
   },
+  target: "electron-main",
 };

--- a/packages/template/typescript-webpack/tmpl/webpack.renderer.config.js
+++ b/packages/template/typescript-webpack/tmpl/webpack.renderer.config.js
@@ -14,4 +14,5 @@ module.exports = {
   resolve: {
     extensions: ['.js', '.ts', '.jsx', '.tsx', '.css'],
   },
+  target: "electron-renderer",
 };

--- a/packages/template/webpack/tmpl/webpack.main.config.js
+++ b/packages/template/webpack/tmpl/webpack.main.config.js
@@ -8,4 +8,5 @@ module.exports = {
   module: {
     rules: require('./webpack.rules'),
   },
+  target: "electron-main",
 };

--- a/packages/template/webpack/tmpl/webpack.renderer.config.js
+++ b/packages/template/webpack/tmpl/webpack.renderer.config.js
@@ -10,4 +10,5 @@ module.exports = {
   module: {
     rules,
   },
+  target: "electron-renderer",
 };


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

Missing Webpack targets are added in the templates. I spent quite some time before finding this issue and I want to prevent other people from having the same experience. These targets make sure core node modules are available.
