### PR TITLE
build: update @electron/get to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@aws-sdk/lib-storage": "^3.28.0",
     "@aws-sdk/types": "^3.25.0",
     "@doyensec/electronegativity": "^1.9.1",
-    "@electron/get": "^1.9.0",
+    "@electron/get": "^2.0.0",
     "@malept/cross-spawn-promise": "^2.0.0",
     "@octokit/core": "^3.2.4",
     "@octokit/plugin-retry": "^3.0.9",

--- a/packages/api/cli/package.json
+++ b/packages/api/cli/package.json
@@ -20,7 +20,7 @@
     "@electron-forge/async-ora": "6.0.0-beta.65",
     "@electron-forge/core": "6.0.0-beta.65",
     "@electron-forge/shared-types": "6.0.0-beta.65",
-    "@electron/get": "^1.9.0",
+    "@electron/get": "^2.0.0",
     "chalk": "^4.0.0",
     "commander": "^4.1.1",
     "debug": "^4.3.1",

--- a/packages/api/core/package.json
+++ b/packages/api/core/package.json
@@ -52,7 +52,7 @@
     "@electron-forge/template-typescript": "6.0.0-beta.65",
     "@electron-forge/template-typescript-webpack": "6.0.0-beta.65",
     "@electron-forge/template-webpack": "6.0.0-beta.65",
-    "@electron/get": "^1.9.0",
+    "@electron/get": "^2.0.0",
     "@malept/cross-spawn-promise": "^2.0.0",
     "chalk": "^4.0.0",
     "debug": "^4.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1096,7 +1096,7 @@
     typescript "~4.2.4"
     winston "^2.3.1"
 
-"@electron/get@^1.6.0", "@electron/get@^1.9.0":
+"@electron/get@^1.6.0":
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/@electron/get/-/get-1.13.1.tgz#42a0aa62fd1189638bd966e23effaebb16108368"
   integrity sha512-U5vkXDZ9DwXtkPqlB45tfYnnYBN8PePp1z/XDCupnSpdrxT8/ThCv9WCwPLf9oqiSGZTkH6dx2jDUPuoXpjkcA==
@@ -1105,6 +1105,22 @@
     env-paths "^2.2.0"
     fs-extra "^8.1.0"
     got "^9.6.0"
+    progress "^2.0.3"
+    semver "^6.2.0"
+    sumchecker "^3.0.1"
+  optionalDependencies:
+    global-agent "^3.0.0"
+    global-tunnel-ng "^2.7.1"
+
+"@electron/get@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@electron/get/-/get-2.0.0.tgz#d991e68dc089fc66b521ec3ca4021515482bef91"
+  integrity sha512-d0XfNGayKLrYRqddW4f2Zdjaj71LfvZlCnUN8ojyNMr7WD8v6B+fqdCV8Etnwn/vUfFWFwMk/HtLEFZy01h4tQ==
+  dependencies:
+    debug "^4.1.1"
+    env-paths "^2.2.0"
+    fs-extra "^8.1.0"
+    got "^11.8.5"
     progress "^2.0.3"
     semver "^6.2.0"
     sumchecker "^3.0.1"


### PR DESCRIPTION
- [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Bumps @electron/get to 2.0.0. This is not marked as a breaking change, because the required version of Node for Forge is currently 14+ (@electron/get's new version requires at least 12+)