### PR TITLE
fix(template-typescript-webpack): preload file to webpack config

### DIFF
--- a/packages/template/typescript-webpack/src/TypeScriptWebpackTemplate.ts
+++ b/packages/template/typescript-webpack/src/TypeScriptWebpackTemplate.ts
@@ -66,6 +66,9 @@ class TypeScriptWebpackTemplate extends BaseTemplate {
       await this.copyTemplateFile(path.join(directory, 'src'), 'index.ts');
 
       await this.copyTemplateFile(path.join(directory, 'src'), 'renderer.ts');
+
+      // Remove preload.js and replace with preload.ts
+      await fs.remove(filePath('preload.js'));
       await this.copyTemplateFile(path.join(directory, 'src'), 'preload.ts');
     });
   }

--- a/packages/template/typescript-webpack/src/TypeScriptWebpackTemplate.ts
+++ b/packages/template/typescript-webpack/src/TypeScriptWebpackTemplate.ts
@@ -26,6 +26,9 @@ class TypeScriptWebpackTemplate extends BaseTemplate {
                 html: './src/index.html',
                 js: './src/renderer.ts',
                 name: 'main_window',
+                preload: {
+                  js: 'preload.js',
+                },
               },
             ],
           },

--- a/packages/template/typescript-webpack/src/TypeScriptWebpackTemplate.ts
+++ b/packages/template/typescript-webpack/src/TypeScriptWebpackTemplate.ts
@@ -27,7 +27,7 @@ class TypeScriptWebpackTemplate extends BaseTemplate {
                 js: './src/renderer.ts',
                 name: 'main_window',
                 preload: {
-                  js: 'preload.js',
+                  js: './src/preload.ts',
                 },
               },
             ],


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
I added the preload script to the package.json file, so it would get compiled by Webpack. When you initialize the project it does not work, because the file is not compiled by Webpack. This change would solve this, by adding it to the compiler.

closes #2935