### PR TITLE
feat: remove preload.js from TypeScript templates

### DIFF
--- a/packages/template/typescript-webpack/package.json
+++ b/packages/template/typescript-webpack/package.json
@@ -20,6 +20,8 @@
     "fs-extra": "^10.0.0"
   },
   "devDependencies": {
-    "@electron-forge/test-utils": "6.0.0-beta.66"
+    "@electron-forge/test-utils": "6.0.0-beta.66",
+    "chai": "^4.3.3",
+    "fast-glob": "^3.2.7"
   }
 }

--- a/packages/template/typescript-webpack/src/TypeScriptWebpackTemplate.ts
+++ b/packages/template/typescript-webpack/src/TypeScriptWebpackTemplate.ts
@@ -63,6 +63,9 @@ class TypeScriptWebpackTemplate extends BaseTemplate {
       await this.copyTemplateFile(path.join(directory, 'src'), 'index.ts');
 
       await this.copyTemplateFile(path.join(directory, 'src'), 'renderer.ts');
+
+      // Remove preload.js and replace with preload.ts
+      await fs.remove(filePath('preload.js'));
       await this.copyTemplateFile(path.join(directory, 'src'), 'preload.ts');
     });
   }

--- a/packages/template/typescript-webpack/test/TypeScriptWebpackTemplate_spec.ts
+++ b/packages/template/typescript-webpack/test/TypeScriptWebpackTemplate_spec.ts
@@ -3,7 +3,6 @@ import fs from 'fs-extra';
 import glob from 'fast-glob';
 import path from 'path';
 import template from '../src/TypeScriptWebpackTemplate';
-import assert from 'assert';
 import { expect } from 'chai';
 
 describe('TypeScriptWebpackTemplate', () => {
@@ -37,11 +36,8 @@ describe('TypeScriptWebpackTemplate', () => {
   });
 
   it('should ensure js source files from base template are removed', async () => {
-      const jsFiles = await glob(path.join(dir, 'src', '**', '*.js'));
-      expect(jsFiles.length).to.equal(
-        0,
-        `The following unexpected js files were found in the src/ folder: ${JSON.stringify(jsFiles)}`
-      );
+    const jsFiles = await glob(path.join(dir, 'src', '**', '*.js'));
+    expect(jsFiles.length).to.equal(0, `The following unexpected js files were found in the src/ folder: ${JSON.stringify(jsFiles)}`);
   });
 
   describe('lint', () => {

--- a/packages/template/typescript-webpack/test/TypeScriptWebpackTemplate_spec.ts
+++ b/packages/template/typescript-webpack/test/TypeScriptWebpackTemplate_spec.ts
@@ -1,7 +1,10 @@
 import * as testUtils from '@electron-forge/test-utils';
 import fs from 'fs-extra';
+import glob from 'fast-glob';
 import path from 'path';
 import template from '../src/TypeScriptWebpackTemplate';
+import assert from 'assert';
+import { expect } from 'chai';
 
 describe('TypeScriptWebpackTemplate', () => {
   let dir: string;
@@ -31,6 +34,14 @@ describe('TypeScriptWebpackTemplate', () => {
         await testUtils.expectProjectPathExists(dir, filename, 'file');
       });
     }
+  });
+
+  it('should ensure js source files from base template are removed', async () => {
+      const jsFiles = await glob(path.join(dir, 'src', '**', '*.js'));
+      expect(jsFiles.length).to.equal(
+        0,
+        `The following unexpected js files were found in the src/ folder: ${JSON.stringify(jsFiles)}`
+      );
   });
 
   describe('lint', () => {

--- a/packages/template/typescript/package.json
+++ b/packages/template/typescript/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@electron-forge/test-utils": "6.0.0-beta.66",
-    "chai": "^4.3.3"
+    "chai": "^4.3.3",
+    "fast-glob": "^3.2.7"
   }
 }

--- a/packages/template/typescript/src/TypeScriptTemplate.ts
+++ b/packages/template/typescript/src/TypeScriptTemplate.ts
@@ -33,6 +33,8 @@ class TypeScriptTemplate extends BaseTemplate {
       await fs.remove(filePath('index.js'));
       await this.copyTemplateFile(path.join(directory, 'src'), 'index.ts');
 
+      // Remove preload.js and replace with preload.ts
+      await fs.remove(filePath('preload.js'));
       await this.copyTemplateFile(path.join(directory, 'src'), 'preload.ts');
     });
   }

--- a/packages/template/typescript/test/TypeScriptTemplate_spec.ts
+++ b/packages/template/typescript/test/TypeScriptTemplate_spec.ts
@@ -17,12 +17,7 @@ describe('TypeScriptTemplate', () => {
   });
 
   context('template files are copied to project', () => {
-    const expectedFiles = [
-      '.eslintrc.json',
-      'tsconfig.json',
-      path.join('src', 'index.ts'),
-      path.join('src', 'preload.ts'),
-    ];
+    const expectedFiles = ['.eslintrc.json', 'tsconfig.json', path.join('src', 'index.ts'), path.join('src', 'preload.ts')];
     for (const filename of expectedFiles) {
       it(`${filename} should exist`, async () => {
         await testUtils.expectProjectPathExists(dir, filename, 'file');
@@ -31,11 +26,8 @@ describe('TypeScriptTemplate', () => {
   });
 
   it('should ensure js source files from base template are removed', async () => {
-      const jsFiles = await glob(path.join(dir, 'src', '**', '*.js'));
-      expect(jsFiles.length).to.equal(
-        0,
-        `The following unexpected js files were found in the src/ folder: ${JSON.stringify(jsFiles)}`
-      );
+    const jsFiles = await glob(path.join(dir, 'src', '**', '*.js'));
+    expect(jsFiles.length).to.equal(0, `The following unexpected js files were found in the src/ folder: ${JSON.stringify(jsFiles)}`);
   });
 
   describe('lint', () => {

--- a/packages/template/typescript/test/TypeScriptTemplate_spec.ts
+++ b/packages/template/typescript/test/TypeScriptTemplate_spec.ts
@@ -1,6 +1,7 @@
 import * as testUtils from '@electron-forge/test-utils';
 import { expect } from 'chai';
 import fs from 'fs-extra';
+import glob from 'fast-glob';
 import path from 'path';
 import template from '../src/TypeScriptTemplate';
 
@@ -16,7 +17,12 @@ describe('TypeScriptTemplate', () => {
   });
 
   context('template files are copied to project', () => {
-    const expectedFiles = ['.eslintrc.json', 'tsconfig.json', path.join('src', 'preload.ts')];
+    const expectedFiles = [
+      '.eslintrc.json',
+      'tsconfig.json',
+      path.join('src', 'index.ts'),
+      path.join('src', 'preload.ts'),
+    ];
     for (const filename of expectedFiles) {
       it(`${filename} should exist`, async () => {
         await testUtils.expectProjectPathExists(dir, filename, 'file');
@@ -24,10 +30,12 @@ describe('TypeScriptTemplate', () => {
     }
   });
 
-  it('should convert the main process file to typescript', async () => {
-    await testUtils.expectProjectPathNotExists(dir, path.join('src', 'index.js'), 'file');
-    await testUtils.expectProjectPathExists(dir, path.join('src', 'index.ts'), 'file');
-    expect((await fs.readFile(path.join(dir, 'src', 'index.ts'))).toString()).to.match(/import\b.*\bBrowserWindow\b/);
+  it('should ensure js source files from base template are removed', async () => {
+      const jsFiles = await glob(path.join(dir, 'src', '**', '*.js'));
+      expect(jsFiles.length).to.equal(
+        0,
+        `The following unexpected js files were found in the src/ folder: ${JSON.stringify(jsFiles)}`
+      );
   });
 
   describe('lint', () => {


### PR DESCRIPTION
- [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

When `preload` was added to the Forge templates, the TypeScript templates actually ended up with both a `preload.js` and a `preload.ts` because the base template adds `preload.js` and the TypeScript template adds a `preload.ts`. This PR modifies the TS templates to remove the `preload.js` just like it already removes the `index.js`.

I also modified the template tests to verify that no js files end up in the `src/` folder after the TypeScript templates are applied. That way if any other new files are added in the future, the tests will automatically verify that only the TypeScript versions are applied.