### PR TITLE
test: re-enable native module package test

### DIFF
--- a/packages/api/core/test/slow/api_spec_slow.ts
+++ b/packages/api/core/test/slow/api_spec_slow.ts
@@ -285,10 +285,7 @@ describe('Electron Forge API', () => {
       await fs.remove(path.resolve(dir, 'out'));
     });
 
-    // FIXME(erickzhao): This test hangs on the electron-rebuild step
-    // with Electron 19. It was tested to work on Electron 18.
-    // see https://github.com/electron-userland/electron-forge/pull/2869
-    describe.skip('with prebuilt native module deps installed', () => {
+    describe('with prebuilt native module deps installed', () => {
       before(async () => {
         await installDeps(dir, ['ref-napi']);
       });


### PR DESCRIPTION
Follow up to #2870, this PR re-enables the `ref-napi` native module test that failed with the Electron 19 binary.

Fixes #2871
