### PR TITLE
chore: clean up unused eslint-disable directives

### DIFF
--- a/packages/api/cli/src/electron-forge-make.ts
+++ b/packages/api/cli/src/electron-forge-make.ts
@@ -8,7 +8,6 @@ import path from 'path';
 import './util/terminate';
 import workingDir from './util/working-dir';
 
-// eslint-disable-next-line import/prefer-default-export
 export async function getMakeOptions(): Promise<MakeOptions> {
   let dir = process.cwd();
   program
@@ -36,7 +35,7 @@ export async function getMakeOptions(): Promise<MakeOptions> {
   return makeOpts;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any, no-underscore-dangle
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 if (require.main === module || (global as any).__LINKED_FORGE__) {
   (async () => {
     const makeOpts = await getMakeOptions();

--- a/packages/api/cli/src/electron-forge.ts
+++ b/packages/api/cli/src/electron-forge.ts
@@ -41,7 +41,6 @@ program
   .command('publish', 'Publish the current Electron application to GitHub')
   .command('install', 'Install an Electron application from GitHub')
   .on('command:*', (commands) => {
-    // eslint-disable-next-line no-underscore-dangle
     if (!program._execs.has(commands[0])) {
       console.error();
       console.error(chalk.red(`Unknown command "${program.args.join(' ')}".`));

--- a/packages/api/cli/src/util/check-system.ts
+++ b/packages/api/cli/src/util/check-system.ts
@@ -21,8 +21,7 @@ async function checkNodeVersion(ora: OraImpl) {
   const versionSatisified = semver.satisfies(process.versions.node, engines.node);
 
   if (!versionSatisified) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    ora.warn!(`You are running Node.js version ${process.versions.node}, but Electron Forge requires Node.js ${engines.node}.`);
+    ora.warn(`You are running Node.js version ${process.versions.node}, but Electron Forge requires Node.js ${engines.node}.`);
   }
 
   return versionSatisified;
@@ -55,8 +54,7 @@ function warnIfPackageManagerIsntAKnownGoodVersion(packageManager: string, versi
   const versions = osVersions ? `${whitelistedVersions.all} || ${osVersions}` : whitelistedVersions.all;
   const versionString = version.toString();
   if (!validPackageManagerVersion(packageManager, versionString, versions, ora)) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    ora.warn!(`You are using ${packageManager}, but not a known good version.
+    ora.warn(`You are using ${packageManager}, but not a known good version.
 The known versions that work with Electron Forge are: ${versions}`);
   }
 }

--- a/packages/api/core/src/api/import.ts
+++ b/packages/api/core/src/api/import.ts
@@ -68,7 +68,6 @@ export default async ({
     throw new Error(`We couldn't find a project in: ${dir}`);
   }
 
-  // eslint-disable-next-line max-len
   if (typeof confirmImport === 'function') {
     if (!(await confirmImport())) {
       // TODO: figure out if we can just return early here
@@ -132,7 +131,6 @@ export default async ({
     if (buildToolPackages[key]) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const explanation = buildToolPackages[key]!;
-      // eslint-disable-next-line max-len
       let remove = true;
       if (typeof shouldRemoveDependency === 'function') {
         remove = await shouldRemoveDependency(key, explanation);
@@ -150,7 +148,6 @@ export default async ({
 
   const updatePackageScript = async (scriptName: string, newValue: string) => {
     if (packageJSON.scripts[scriptName] !== newValue) {
-      // eslint-disable-next-line max-len
       let update = true;
       if (typeof shouldUpdateScript === 'function') {
         update = await shouldUpdateScript(scriptName, newValue);

--- a/packages/api/core/src/api/init-scripts/find-template.ts
+++ b/packages/api/core/src/api/init-scripts/find-template.ts
@@ -38,7 +38,7 @@ export default async (dir: string, template: string): Promise<ForgeTemplate> => 
     }
   });
 
-  // eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-dynamic-require, global-require
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
   const templateModule: PossibleModule<ForgeTemplate> = require(templateModulePath);
 
   return templateModule.default || templateModule;

--- a/packages/api/core/src/api/install.ts
+++ b/packages/api/core/src/api/install.ts
@@ -29,12 +29,10 @@ export interface Asset {
   id: string;
   name: string;
   size: number;
-  // eslint-disable-next-line camelcase
   browser_download_url: string;
 }
 
 interface Release {
-  // eslint-disable-next-line camelcase
   tag_name: string;
   prerelease: boolean;
   assets: Asset[];
@@ -102,7 +100,6 @@ export default async ({ interactive = false, prerelease = false, repo, chooseAss
       if (tagB.substr(0, 1) === 'v') tagB = tagB.substr(1);
       return semver.gt(tagB, tagA) ? 1 : -1;
     });
-    // eslint-disable-next-line prefer-destructuring
     latestRelease = sortedReleases[0];
 
     searchSpinner.text = 'Searching for Releases';

--- a/packages/api/core/src/api/make.ts
+++ b/packages/api/core/src/api/make.ts
@@ -112,7 +112,6 @@ export default async ({
   for (const target of targets) {
     /* eslint-disable @typescript-eslint/no-explicit-any */
     let maker: MakerBase<any>;
-    // eslint-disable-next-line no-underscore-dangle
     if ((target as MakerBase<any>).__isElectronForgeMaker) {
       maker = target as MakerBase<any>;
       /* eslint-enable @typescript-eslint/no-explicit-any */
@@ -134,7 +133,6 @@ export default async ({
       }
 
       maker = new MakerClass(resolvableTarget.config, resolvableTarget.platforms || undefined);
-      // eslint-disable-next-line no-continue
       if (!maker.platforms.includes(actualTargetPlatform)) continue;
     }
 
@@ -192,12 +190,11 @@ export default async ({
     }
 
     targetId = 0;
-    // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/no-unused-vars
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     for (const _target of targets) {
       const maker = makers[targetId];
       targetId += 1;
 
-      // eslint-disable-next-line no-loop-func
       await asyncOra(
         `Making for target: ${chalk.green(maker.name)} - On platform: ${chalk.cyan(actualTargetPlatform)} - For arch: ${chalk.cyan(targetArch)}`,
         async () => {
@@ -234,7 +231,6 @@ export default async ({
             });
           } catch (err) {
             if (err instanceof Error) {
-              // eslint-disable-next-line no-throw-literal
               throw {
                 message: `An error occured while making for target: ${maker.name}`,
                 stack: `${err.message}\n${err.stack}`,

--- a/packages/api/core/src/api/package.ts
+++ b/packages/api/core/src/api/package.ts
@@ -180,7 +180,6 @@ export default async ({
   }
 
   if (!packageJSON.version && !packageOpts.appVersion) {
-    // eslint-disable-next-line max-len
     warn(
       interactive,
       chalk.yellow('Please set "version" or "config.forge.packagerConfig.appVersion" in your application\'s package.json so auto-updates work properly')

--- a/packages/api/core/src/api/publish.ts
+++ b/packages/api/core/src/api/publish.ts
@@ -150,7 +150,6 @@ const publish = async ({
       return (
         (forgeConfig.publishers || []).find((p: ForgeConfigPublisher) => {
           if (typeof p === 'string') return false;
-          // eslint-disable-next-line no-underscore-dangle
           if ((p as IForgePublisher).__isElectronForgePublisher) return false;
           return (p as IForgeResolvablePublisher).name === target;
         }) || { name: target }
@@ -162,7 +161,6 @@ const publish = async ({
   for (const publishTarget of publishTargets) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let publisher: PublisherBase<any>;
-    // eslint-disable-next-line no-underscore-dangle
     if ((publishTarget as IForgePublisher).__isElectronForgePublisher) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       publisher = publishTarget as PublisherBase<any>;
@@ -171,7 +169,6 @@ const publish = async ({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let PublisherClass: any;
       await asyncOra(`Resolving publish target: ${chalk.cyan(resolvablePublishTarget.name)}`, async () => {
-        // eslint-disable-line no-loop-func
         PublisherClass = requireSearch(dir, [resolvablePublishTarget.name]);
         if (!PublisherClass) {
           throw new Error(

--- a/packages/api/core/src/api/start.ts
+++ b/packages/api/core/src/api/start.ts
@@ -155,7 +155,6 @@ export default async ({
   if (interactive) {
     process.stdin.on('data', async (data) => {
       if (data.toString().trim() === 'rs' && lastSpawned) {
-        // eslint-disable-next-line no-console
         console.info(chalk.cyan('\nRestarting App\n'));
         lastSpawned.restarted = true;
         lastSpawned.kill('SIGTERM');

--- a/packages/api/core/src/util/deprecate.ts
+++ b/packages/api/core/src/util/deprecate.ts
@@ -1,4 +1,3 @@
-/* eslint "no-console": "off" */
 import chalk from 'chalk';
 import logSymbols from 'log-symbols';
 

--- a/packages/api/core/src/util/electron-executable.ts
+++ b/packages/api/core/src/util/electron-executable.ts
@@ -20,7 +20,6 @@ export function pluginCompileExists(packageJSON: PackageJSON): boolean {
   }
 
   if (Object.keys((packageJSON.dependencies as Dependencies) || {}).find(findPluginCompile)) {
-    // eslint-disable-next-line no-console
     console.warn(logSymbols.warning, chalk.yellow(`${pluginCompileName} was detected in dependencies, it should be in devDependencies`));
     return true;
   }
@@ -31,7 +30,6 @@ export function pluginCompileExists(packageJSON: PackageJSON): boolean {
 export default async function locateElectronExecutable(dir: string, packageJSON: PackageJSON): Promise<string> {
   let electronModulePath: string | undefined = await getElectronModulePath(dir, packageJSON);
   if (electronModulePath?.endsWith('electron-prebuilt-compile') && !pluginCompileExists(packageJSON)) {
-    // eslint-disable-next-line no-console
     console.warn(
       logSymbols.warning,
       chalk.yellow(
@@ -41,13 +39,11 @@ export default async function locateElectronExecutable(dir: string, packageJSON:
     electronModulePath = undefined;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-dynamic-require, global-require
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
   let electronExecPath = require(electronModulePath || path.resolve(dir, 'node_modules/electron'));
 
   if (typeof electronExecPath !== 'string') {
-    // eslint-disable-next-line no-console
     console.warn(logSymbols.warning, 'Returned Electron executable path is not a string, defaulting to a hardcoded location. Value:', electronExecPath);
-    // eslint-disable-next-line import/no-dynamic-require, global-require
     electronExecPath = require(path.resolve(dir, 'node_modules/electron'));
   }
 

--- a/packages/api/core/src/util/electron-version.ts
+++ b/packages/api/core/src/util/electron-version.ts
@@ -96,7 +96,6 @@ export async function getElectronVersion(dir: string, packageJSON: PackageJSONWi
     const electronPackageJSONPath = await getElectronPackageJSONPath(dir, packageName);
     if (electronPackageJSONPath) {
       const electronPackageJSON = await fs.readJson(electronPackageJSONPath);
-      // eslint-disable-next-line prefer-destructuring
       version = electronPackageJSON.version;
     } else {
       throw new PackageNotFoundError(packageName, dir);

--- a/packages/api/core/src/util/forge-config.ts
+++ b/packages/api/core/src/util/forge-config.ts
@@ -27,7 +27,6 @@ export type PackageJSONForInitialForgeConfig = {
 type ProxiedObject = object;
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-// eslint-disable-next-line arrow-parens
 const proxify = <T extends ProxiedObject>(buildIdentifier: string | (() => string), proxifiedObject: T, envPrefix: string): T => {
   let newObject: T = {} as any;
   if (Array.isArray(proxifiedObject)) {
@@ -51,7 +50,6 @@ const proxify = <T extends ProxiedObject>(buildIdentifier: string | (() => strin
       }
       const value = Reflect.get(target, name, receiver);
 
-      // eslint-disable-next-line no-underscore-dangle
       if (value && typeof value === 'object' && value.__isMagicBuildIdentifierMap) {
         const identifier = typeof buildIdentifier === 'function' ? buildIdentifier() : buildIdentifier;
         return value.map[identifier];
@@ -84,7 +82,6 @@ const proxify = <T extends ProxiedObject>(buildIdentifier: string | (() => strin
  * Sets sensible defaults for the `config.forge` object.
  */
 export function setInitialForgeConfig(packageJSON: PackageJSONForInitialForgeConfig): void {
-  // eslint-disable-line @typescript-eslint/no-explicit-any
   const { name = '' } = packageJSON;
 
   ((packageJSON.config.forge as ForgeConfig).makers as IForgeResolvableMaker[])[0].config.name = name.replace(/-/g, '_');
@@ -107,7 +104,7 @@ export async function forgeConfigIsValidFilePath(dir: string, forgeConfig: strin
   return typeof forgeConfig === 'string' && ((await fs.pathExists(path.resolve(dir, forgeConfig))) || fs.pathExists(path.resolve(dir, `${forgeConfig}.js`)));
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function renderConfigTemplate(dir: string, templateObj: any, obj: any): void {
   for (const [key, value] of Object.entries(obj)) {
     if (typeof value === 'object' && value !== null) {
@@ -115,7 +112,6 @@ export function renderConfigTemplate(dir: string, templateObj: any, obj: any): v
     } else if (typeof value === 'string') {
       obj[key] = template(value)(templateObj);
       if (obj[key].startsWith('require:')) {
-        // eslint-disable-next-line global-require, import/no-dynamic-require
         obj[key] = require(path.resolve(dir, obj[key].substr(8)));
       }
     }
@@ -136,10 +132,9 @@ export default async (dir: string): Promise<ForgeConfig> => {
 
   if (await forgeConfigIsValidFilePath(dir, forgeConfig)) {
     try {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require, import/no-dynamic-require
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
       forgeConfig = require(path.resolve(dir, forgeConfig as string)) as ForgeConfig;
     } catch (err) {
-      // eslint-disable-next-line no-console
       console.error(`Failed to load: ${path.resolve(dir, forgeConfig as string)}`);
       throw err;
     }

--- a/packages/api/core/src/util/is-installed.ts
+++ b/packages/api/core/src/util/is-installed.ts
@@ -1,4 +1,3 @@
-/* eslint "global-require": "off", "import/no-dynamic-require": "off" */
 export default function isInstalled(pkg: string): boolean {
   try {
     require(pkg);

--- a/packages/api/core/src/util/messages.ts
+++ b/packages/api/core/src/util/messages.ts
@@ -1,4 +1,3 @@
-/* eslint "no-console": "off" */
 export function info(interactive: boolean, message: string): void {
   if (interactive) {
     console.info(message);

--- a/packages/api/core/src/util/plugin-interface.ts
+++ b/packages/api/core/src/util/plugin-interface.ts
@@ -14,7 +14,6 @@ export default class PluginInterface implements IForgePluginInterface {
 
   constructor(dir: string, forgeConfig: ForgeConfig) {
     this.plugins = forgeConfig.plugins.map((plugin) => {
-      // eslint-disable-next-line no-underscore-dangle
       if ((plugin as IForgePlugin).__isElectronForgePlugin) {
         return plugin;
       }

--- a/packages/api/core/src/util/require-search.ts
+++ b/packages/api/core/src/util/require-search.ts
@@ -18,7 +18,6 @@ export function requireSearchRaw<T>(relativeTo: string, paths: string[]): T | nu
   for (const testPath of testPaths) {
     try {
       d('testing', testPath);
-      // eslint-disable-next-line global-require, import/no-dynamic-require
       return require(testPath);
     } catch (err) {
       if (err instanceof Error) {
@@ -38,7 +37,6 @@ export type PossibleModule<T> = {
   default?: T;
 } & T;
 
-// eslint-disable-next-line arrow-parens
 export default <T>(relativeTo: string, paths: string[]): T | null => {
   const result = requireSearchRaw<PossibleModule<T>>(relativeTo, paths);
   return typeof result === 'object' && result && result.default ? result.default : (result as T | null);

--- a/packages/api/core/src/util/upgrade-forge-config.ts
+++ b/packages/api/core/src/util/upgrade-forge-config.ts
@@ -161,9 +161,7 @@ export default function upgradeForgeConfig(forge5Config: Forge5Config): ForgeCon
 export function updateUpgradedForgeDevDeps(packageJSON: ForgePackageJSON, devDeps: string[]): string[] {
   const forgeConfig = packageJSON.config.forge;
   devDeps = devDeps.filter((dep) => !dep.startsWith('@electron-forge/maker-'));
-  // eslint-disable-next-line max-len
   devDeps = devDeps.concat((forgeConfig.makers as IForgeResolvableMaker[]).map((maker: IForgeResolvableMaker) => siblingDep(path.basename(maker.name))));
-  // eslint-disable-next-line max-len
   devDeps = devDeps.concat(
     (forgeConfig.publishers as IForgeResolvablePublisher[]).map((publisher: IForgeResolvablePublisher) => siblingDep(path.basename(publisher.name)))
   );

--- a/packages/api/core/src/util/yarn-or-npm.ts
+++ b/packages/api/core/src/util/yarn-or-npm.ts
@@ -11,7 +11,6 @@ const safeYarnOrNpm = (): string => {
       return process.env.NODE_INSTALLER;
     default:
       if (process.env.NODE_INSTALLER) {
-        // eslint-disable-next-line no-console
         console.warn(logSymbols.warning, chalk.yellow(`Unknown NODE_INSTALLER, using detected installer ${system}`));
       }
       return system;
@@ -20,7 +19,6 @@ const safeYarnOrNpm = (): string => {
 
 export default safeYarnOrNpm;
 
-// eslint-disable-next-line max-len
 export const yarnOrNpmSpawn = (args?: CrossSpawnArgs, opts?: CrossSpawnOptions): Promise<string> => spawn(safeYarnOrNpm(), args, opts);
 
 export const hasYarn = (): boolean => safeYarnOrNpm() === 'yarn';

--- a/packages/api/core/test/fast/electron-executable_spec.ts
+++ b/packages/api/core/test/fast/electron-executable_spec.ts
@@ -27,8 +27,6 @@ describe('locateElectronExecutable', () => {
     };
 
     await expect(locateElectronExecutable(appFixture, packageJSON)).to.eventually.equal('execPath');
-
-    // eslint-disable-next-line no-console, no-unused-expressions
     expect(console.warn).to.not.have.been.called;
   });
 
@@ -42,8 +40,6 @@ describe('locateElectronExecutable', () => {
     };
 
     await expect(locateElectronExecutable(appFixture, packageJSON)).to.eventually.equal('execPath');
-
-    // eslint-disable-next-line no-console, no-unused-expressions
     expect(console.warn).to.have.been.calledOnce;
   });
 
@@ -54,8 +50,6 @@ describe('locateElectronExecutable', () => {
     const compileFixture = path.join(fixtureDir, 'prebuilt-compile');
 
     await expect(locateElectronExecutable(compileFixture, packageJSON)).to.eventually.be.rejected;
-
-    // eslint-disable-next-line no-console, no-unused-expressions
     expect(console.warn).to.have.been.calledOnce;
   });
 
@@ -68,10 +62,7 @@ describe('locateElectronExecutable', () => {
     };
 
     const compileFixture = path.join(fixtureDir, 'prebuilt-compile');
-    // eslint-disable-next-line no-unused-expressions
     await expect(locateElectronExecutable(compileFixture, packageJSON)).to.eventually.be.rejected;
-
-    // eslint-disable-next-line no-console, no-unused-expressions
     expect(console.warn).to.not.have.been.called;
   });
 });
@@ -101,8 +92,6 @@ describe('pluginCompileExists', () => {
     };
 
     expect(pluginCompileExists(packageJSON)).to.equal(true);
-
-    // eslint-disable-next-line no-console, no-unused-expressions
     expect(console.warn).to.not.have.been.called;
   });
 
@@ -113,8 +102,6 @@ describe('pluginCompileExists', () => {
     };
 
     expect(pluginCompileExists(packageJSON)).to.equal(true);
-
-    // eslint-disable-next-line no-console, no-unused-expressions
     expect(console.warn).to.have.been.calledOnce;
   });
 });

--- a/packages/api/core/test/fast/publish_spec.ts
+++ b/packages/api/core/test/fast/publish_spec.ts
@@ -30,7 +30,6 @@ describe('publish', () => {
     voidStub = stub();
     nowhereStub = stub();
     publishers = ['@electron-forge/publisher-test'];
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const fakePublisher = (stub: SinonStub, name = 'default') =>
       class _FakePublisher {
         private publish: SinonStub;

--- a/packages/api/core/test/slow/api_spec_slow.ts
+++ b/packages/api/core/test/slow/api_spec_slow.ts
@@ -274,7 +274,6 @@ describe('Electron Forge API', () => {
 
     it('can make from custom outDir without errors', async () => {
       await updatePackageJSON(dir, async (packageJSON) => {
-        // eslint-disable-next-line node/no-missing-require
         packageJSON.config.forge.makers = [{ name: require.resolve('@electron-forge/maker-zip') } as IForgeResolvableMaker];
       });
 
@@ -317,7 +316,6 @@ describe('Electron Forge API', () => {
       it('should have deleted the forge config from the packaged app', async () => {
         const cleanPackageJSON = await readMetadata({
           src: path.resolve(dir, 'out', `Test-App-${process.platform}-${process.arch}`),
-          // eslint-disable-next-line no-console
           logger: console.error,
         });
         expect(cleanPackageJSON).to.not.have.nested.property('config.forge');
@@ -386,7 +384,6 @@ describe('Electron Forge API', () => {
 
           for (const optionsFetcher of options) {
             if (shouldPass) {
-              // eslint-disable-next-line no-loop-func
               it(`successfully makes for config: ${JSON.stringify(optionsFetcher())}`, async () => {
                 const outputs = await forge.make(optionsFetcher());
                 for (const outputResult of outputs) {
@@ -469,7 +466,6 @@ describe('Electron Forge API', () => {
           await expect(
             forge.make({
               dir,
-              // eslint-disable-next-line node/no-missing-require
               overrideTargets: [require.resolve('@electron-forge/maker-zip'), require.resolve('@electron-forge/maker-dmg')],
               platform: 'mas',
             })

--- a/packages/api/core/test/slow/api_spec_slow.ts
+++ b/packages/api/core/test/slow/api_spec_slow.ts
@@ -274,6 +274,7 @@ describe('Electron Forge API', () => {
 
     it('can make from custom outDir without errors', async () => {
       await updatePackageJSON(dir, async (packageJSON) => {
+        // eslint-disable-next-line node/no-missing-require
         packageJSON.config.forge.makers = [{ name: require.resolve('@electron-forge/maker-zip') } as IForgeResolvableMaker];
       });
 
@@ -466,6 +467,7 @@ describe('Electron Forge API', () => {
           await expect(
             forge.make({
               dir,
+              // eslint-disable-next-line node/no-missing-require
               overrideTargets: [require.resolve('@electron-forge/maker-zip'), require.resolve('@electron-forge/maker-dmg')],
               platform: 'mas',
             })

--- a/packages/api/core/test/slow/install_spec_slow.ts
+++ b/packages/api/core/test/slow/install_spec_slow.ts
@@ -92,7 +92,6 @@ describe('install', () => {
     );
   });
 
-  // eslint-disable-next-line no-nested-ternary
   const compatSuffix = process.platform === 'darwin' ? 'dmg' : process.platform === 'win32' ? 'exe' : 'deb';
 
   it('should download a release if there is a single compatible asset', async () => {

--- a/packages/maker/appx/src/Config.ts
+++ b/packages/maker/appx/src/Config.ts
@@ -1,5 +1,4 @@
 // TODO: Upstream this to electron-windows-store
-// eslint-disable-next-line import/prefer-default-export
 export interface MakerAppXConfig {
   containerVirtualization?: boolean;
   flatten?: boolean;

--- a/packages/maker/appx/src/MakerAppX.ts
+++ b/packages/maker/appx/src/MakerAppX.ts
@@ -26,8 +26,8 @@ async function findSdkTool(exe: string) {
       }
       const topDir = path.dirname(testPath);
       for (const subVersion of await fs.readdir(topDir)) {
-        if (!(await fs.stat(path.resolve(topDir, subVersion))).isDirectory()) continue; // eslint-disable-line max-len, no-continue
-        if (subVersion.substr(0, 2) !== '10') continue; // eslint-disable-line no-continue
+        if (!(await fs.stat(path.resolve(topDir, subVersion))).isDirectory()) continue;
+        if (subVersion.substr(0, 2) !== '10') continue;
 
         testExe = path.resolve(topDir, subVersion, 'x64', 'makecert.exe');
         if (await fs.pathExists(testExe)) {

--- a/packages/maker/base/src/Maker.ts
+++ b/packages/maker/base/src/Maker.ts
@@ -150,7 +150,6 @@ export default abstract class Maker<C> implements IForgeMaker {
    */
   isInstalled(module: string): boolean {
     try {
-      // eslint-disable-next-line global-require, import/no-dynamic-require
       require(module);
       return true;
     } catch (e) {

--- a/packages/maker/deb/src/MakerDeb.ts
+++ b/packages/maker/deb/src/MakerDeb.ts
@@ -31,6 +31,7 @@ export default class MakerDeb extends MakerBase<MakerDebConfig> {
   }
 
   async make({ dir, makeDir, targetArch }: MakerOptions): Promise<string[]> {
+    // eslint-disable-next-line node/no-missing-require
     const installer = require('electron-installer-debian');
 
     const outDir = path.resolve(makeDir, 'deb', targetArch);

--- a/packages/maker/deb/src/MakerDeb.ts
+++ b/packages/maker/deb/src/MakerDeb.ts
@@ -31,7 +31,6 @@ export default class MakerDeb extends MakerBase<MakerDebConfig> {
   }
 
   async make({ dir, makeDir, targetArch }: MakerOptions): Promise<string[]> {
-    // eslint-disable-next-line global-require, import/no-unresolved, node/no-missing-require
     const installer = require('electron-installer-debian');
 
     const outDir = path.resolve(makeDir, 'deb', targetArch);

--- a/packages/maker/dmg/src/MakerDMG.ts
+++ b/packages/maker/dmg/src/MakerDMG.ts
@@ -15,7 +15,6 @@ export default class MakerDMG extends MakerBase<MakerDMGConfig> {
   }
 
   async make({ dir, makeDir, appName, packageJSON, targetArch }: MakerOptions): Promise<string[]> {
-    // eslint-disable-next-line global-require
     const electronDMG = require('electron-installer-dmg');
 
     const outPath = path.resolve(makeDir, `${this.config.name || appName}.dmg`);

--- a/packages/maker/flatpak/src/MakerFlatpak.ts
+++ b/packages/maker/flatpak/src/MakerFlatpak.ts
@@ -32,7 +32,6 @@ export default class MakerFlatpak extends MakerBase<MakerFlatpakConfig> {
   }
 
   async make({ dir, makeDir, targetArch }: MakerOptions): Promise<string[]> {
-    // eslint-disable-next-line global-require, import/no-unresolved, node/no-missing-require
     const installer = require('@malept/electron-installer-flatpak');
 
     const arch = flatpakArch(targetArch);

--- a/packages/maker/flatpak/src/MakerFlatpak.ts
+++ b/packages/maker/flatpak/src/MakerFlatpak.ts
@@ -32,6 +32,7 @@ export default class MakerFlatpak extends MakerBase<MakerFlatpakConfig> {
   }
 
   async make({ dir, makeDir, targetArch }: MakerOptions): Promise<string[]> {
+    // eslint-disable-next-line node/no-missing-require
     const installer = require('@malept/electron-installer-flatpak');
 
     const arch = flatpakArch(targetArch);

--- a/packages/maker/pkg/src/Config.ts
+++ b/packages/maker/pkg/src/Config.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/prefer-default-export
 export interface MakerPKGConfig {
   /**
    * Name of certificate to use when signing.

--- a/packages/maker/rpm/src/MakerRpm.ts
+++ b/packages/maker/rpm/src/MakerRpm.ts
@@ -31,6 +31,7 @@ export default class MakerRpm extends MakerBase<MakerRpmConfig> {
   }
 
   async make({ dir, makeDir, targetArch }: MakerOptions): Promise<string[]> {
+    // eslint-disable-next-line node/no-missing-require
     const installer = require('electron-installer-redhat');
 
     const outDir = path.resolve(makeDir, 'rpm', targetArch);

--- a/packages/maker/rpm/src/MakerRpm.ts
+++ b/packages/maker/rpm/src/MakerRpm.ts
@@ -31,7 +31,6 @@ export default class MakerRpm extends MakerBase<MakerRpmConfig> {
   }
 
   async make({ dir, makeDir, targetArch }: MakerOptions): Promise<string[]> {
-    // eslint-disable-next-line global-require, import/no-unresolved, node/no-missing-require
     const installer = require('electron-installer-redhat');
 
     const outDir = path.resolve(makeDir, 'rpm', targetArch);

--- a/packages/maker/snap/src/Config.ts
+++ b/packages/maker/snap/src/Config.ts
@@ -1,4 +1,3 @@
 import { Options, SnapcraftConfig } from 'electron-installer-snap';
 
-// eslint-disable-next-line import/prefer-default-export
 export type MakerSnapConfig = Omit<Options, 'arch' | 'dest' | 'src'> & SnapcraftConfig;

--- a/packages/maker/snap/src/MakerSnap.ts
+++ b/packages/maker/snap/src/MakerSnap.ts
@@ -16,7 +16,6 @@ export default class MakerSnap extends MakerBase<MakerSnapConfig> {
   }
 
   async make({ dir, makeDir, targetArch }: MakerOptions): Promise<string[]> {
-    // eslint-disable-next-line global-require
     const installer = require('electron-installer-snap');
 
     const outPath = path.resolve(makeDir, 'snap', targetArch);

--- a/packages/maker/wix/src/MakerWix.ts
+++ b/packages/maker/wix/src/MakerWix.ts
@@ -25,7 +25,6 @@ export default class MakerWix extends MakerBase<MakerWixConfig> {
 
     let { version } = packageJSON;
     if (version.includes('-')) {
-      // eslint-disable-next-line no-console
       console.warn(
         logSymbols.warning,
         chalk.yellow('WARNING: WiX distributables do not handle prerelease information in the app version, removing it from the MSI')

--- a/packages/maker/zip/src/MakerZIP.ts
+++ b/packages/maker/zip/src/MakerZIP.ts
@@ -16,7 +16,6 @@ export default class MakerZIP extends MakerBase<MakerZIPConfig> {
   }
 
   async make({ dir, makeDir, appName, packageJSON, targetArch, targetPlatform }: MakerOptions): Promise<string[]> {
-    // eslint-disable-next-line global-require
     const { zip } = require('cross-zip');
 
     const zipDir = ['darwin', 'mas'].includes(targetPlatform) ? path.resolve(dir, `${appName}.app`) : dir;

--- a/packages/plugin/auto-unpack-natives/src/Config.ts
+++ b/packages/plugin/auto-unpack-natives/src/Config.ts
@@ -1,4 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-empty-interface, import/prefer-default-export
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface AutoUnpackNativesConfig {
   // No configuration options
 }

--- a/packages/plugin/compile/src/Config.ts
+++ b/packages/plugin/compile/src/Config.ts
@@ -1,2 +1,2 @@
-// eslint-disable-next-line @typescript-eslint/no-empty-interface, import/prefer-default-export
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface CompilePluginConfig {}

--- a/packages/plugin/compile/src/lib/compile-hook.ts
+++ b/packages/plugin/compile/src/lib/compile-hook.ts
@@ -1,15 +1,13 @@
-/* eslint "no-console": "off" */
 import { asyncOra } from '@electron-forge/async-ora';
 import { ForgeConfig } from '@electron-forge/shared-types';
 import fs from 'fs-extra';
 import path from 'path';
 
-// eslint-disable-next-line import/prefer-default-export
 export const createCompileHook =
   (originalDir: string) =>
   async (_config: ForgeConfig, buildPath: string): Promise<void> => {
     await asyncOra('Compiling Application', async () => {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-dynamic-require, global-require
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
       const compileCLI = require(path.resolve(originalDir, 'node_modules/electron-compile/lib/cli.js'));
 
       async function compileAndShim(appDir: string) {

--- a/packages/plugin/local-electron/src/Config.ts
+++ b/packages/plugin/local-electron/src/Config.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/prefer-default-export
 export interface LocalElectronPluginConfig {
   /**
    * Whether or not the plugin is enabled.

--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -41,7 +41,7 @@ export default class WebpackConfigGenerator {
   async resolveConfig(config: Configuration | ConfigurationFactory | string): Promise<Configuration> {
     const rawConfig =
       typeof config === 'string'
-        ? // eslint-disable-next-line import/no-dynamic-require, global-require, @typescript-eslint/no-var-requires
+        ? // eslint-disable-next-line @typescript-eslint/no-var-requires
           (require(path.resolve(this.projectDir, config)) as Configuration | ConfigurationFactory)
         : config;
 

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -1,4 +1,3 @@
-/* eslint "no-console": "off" */
 import { asyncOra } from '@electron-forge/async-ora';
 import PluginBase from '@electron-forge/plugin-base';
 import { ElectronProcess, ForgeArch, ForgeConfig, ForgeHookFn, ForgePlatform } from '@electron-forge/shared-types';
@@ -112,7 +111,6 @@ export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
     await fs.writeJson(jsonStatsFilename, jsonStats, { spaces: 2 });
   }
 
-  // eslint-disable-next-line max-len
   private runWebpack = async (options: Configuration[], isRenderer = false): Promise<webpack.MultiStats | undefined> =>
     new Promise((resolve, reject) => {
       webpack(options).run(async (err, stats) => {
@@ -143,13 +141,10 @@ export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
   };
 
   get configGenerator(): WebpackConfigGenerator {
-    // eslint-disable-next-line no-underscore-dangle
     if (!this._configGenerator) {
-      // eslint-disable-next-line no-underscore-dangle
       this._configGenerator = new WebpackConfigGenerator(this.config, this.projectDir, this.isProd, this.port);
     }
 
-    // eslint-disable-next-line no-underscore-dangle
     return this._configGenerator;
   }
 

--- a/packages/plugin/webpack/test/WebpackConfig_spec.ts
+++ b/packages/plugin/webpack/test/WebpackConfig_spec.ts
@@ -121,7 +121,6 @@ describe('WebpackConfigGenerator', () => {
       const generator = new WebpackConfigGenerator(config, '/', true, 3000);
       const defines = generator.getDefines(false);
 
-      // eslint-disable-next-line no-template-curly-in-string
       expect(defines.HELLO_WEBPACK_ENTRY).to.equal("`file://${require('path').resolve(__dirname, '..', '.', 'hello', 'index.js')}`");
     });
 

--- a/packages/publisher/base/src/Publisher.ts
+++ b/packages/publisher/base/src/Publisher.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ForgePlatform, ForgeConfig, ForgeMakeResult, IForgePublisher } from '@electron-forge/shared-types';
 
 export interface PublisherOptions {

--- a/packages/publisher/base/test/Publisher_spec.ts
+++ b/packages/publisher/base/test/Publisher_spec.ts
@@ -17,7 +17,7 @@ describe('Publisher', () => {
   it('__isElectronForgePublisher should not be settable', () => {
     const publisher = new PublisherImpl(null);
     expect(() => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-underscore-dangle
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (publisher as any).__isElectronForgePublisher = false;
     }).to.throw();
     expect(() => {

--- a/packages/publisher/electron-release-server/src/Config.ts
+++ b/packages/publisher/electron-release-server/src/Config.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/prefer-default-export
 export interface PublisherERSConfig {
   /**
    * The base URL of your instance of ERS.

--- a/packages/publisher/electron-release-server/src/PublisherERS.ts
+++ b/packages/publisher/electron-release-server/src/PublisherERS.ts
@@ -69,7 +69,6 @@ export default class PublisherERS extends PublisherBase<PublisherERSConfig> {
       })
     ).json();
 
-    // eslint-disable-next-line max-len
     const authFetch = (apiPath: string, options?: RequestInit) =>
       fetchAndCheckStatus(api(apiPath), { ...(options || {}), headers: { ...(options || {}).headers, Authorization: `Bearer ${token}` } });
 
@@ -86,7 +85,6 @@ export default class PublisherERS extends PublisherBase<PublisherERSConfig> {
 
       let channel = 'stable';
       if (config.channel) {
-        // eslint-disable-next-line prefer-destructuring
         channel = config.channel;
       } else if (packageJSON.version.includes('beta')) {
         channel = 'beta';

--- a/packages/publisher/electron-release-server/test/PublisherERS_spec.ts
+++ b/packages/publisher/electron-release-server/test/PublisherERS_spec.ts
@@ -6,6 +6,7 @@ import { stub } from 'sinon';
 
 describe('PublisherERS', () => {
   let fetch: typeof fetchMock;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let PublisherERS: any;
 
   beforeEach(() => {

--- a/packages/publisher/github/src/PublisherGithub.ts
+++ b/packages/publisher/github/src/PublisherGithub.ts
@@ -11,12 +11,10 @@ import NoReleaseError from './util/no-release-error';
 import { PublisherGitHubConfig } from './Config';
 
 interface GitHubRelease {
-  // eslint-disable-next-line camelcase
   tag_name: string;
   assets: {
     name: string;
   }[];
-  // eslint-disable-next-line camelcase
   upload_url: string;
 }
 

--- a/packages/publisher/github/src/util/github.ts
+++ b/packages/publisher/github/src/util/github.ts
@@ -20,9 +20,9 @@ export default class GitHub {
       ...options,
       log: {
         debug: logDebug.enabled ? logDebug : noOp,
-        error: console.error, // eslint-disable-line no-console
+        error: console.error,
         info: logInfo.enabled ? logInfo : noOp,
-        warn: console.warn, // eslint-disable-line no-console
+        warn: console.warn,
       },
       userAgent: 'Electron Forge',
     };

--- a/packages/publisher/nucleus/src/Config.ts
+++ b/packages/publisher/nucleus/src/Config.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/prefer-default-export
 export interface PublisherNucleusConfig {
   /**
    * Hostname (with https?://) of your instance of Nucleus

--- a/packages/publisher/nucleus/src/PublisherNucleus.ts
+++ b/packages/publisher/nucleus/src/PublisherNucleus.ts
@@ -46,7 +46,6 @@ export default class PublisherNucleus extends PublisherBase<PublisherNucleusConf
         let artifactIdx = 0;
         for (const artifactPath of makeResult.artifacts) {
           // Skip the RELEASES file, it is automatically generated on the server
-          // eslint-disable-next-line no-continue
           if (path.basename(artifactPath).toLowerCase() === 'releases') continue;
           data.append(`file${artifactIdx}`, fs.createReadStream(artifactPath));
           artifactIdx += 1;

--- a/packages/publisher/s3/src/Config.ts
+++ b/packages/publisher/s3/src/Config.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/prefer-default-export
 export interface PublisherS3Config {
   /**
    * Your AWS Access Key ID

--- a/packages/publisher/snapcraft/src/Config.ts
+++ b/packages/publisher/snapcraft/src/Config.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/prefer-default-export
 export interface PublisherSnapcraftConfig {
   /**
    * A comma-separated list of channels to release to

--- a/packages/template/base/src/BaseTemplate.ts
+++ b/packages/template/base/src/BaseTemplate.ts
@@ -66,7 +66,6 @@ export class BaseTemplate implements ForgeTemplate {
   async initializePackageJSON(directory: string): Promise<void> {
     await asyncOra('Initializing NPM Module', async () => {
       const packageJSON = await fs.readJson(path.resolve(__dirname, '../tmpl/package.json'));
-      // eslint-disable-next-line no-multi-assign
       packageJSON.productName = packageJSON.name = path.basename(directory).toLowerCase();
       packageJSON.author = await determineAuthor(directory);
 

--- a/packages/template/base/test/determine-author_spec.ts
+++ b/packages/template/base/test/determine-author_spec.ts
@@ -8,7 +8,6 @@ describe('determineAuthor', () => {
   let determineAuthor: (dir: string) => Promise<PackagePerson>;
   let returnGitUsername = true;
   let returnGitEmail = true;
-  // eslint-disable-next-line max-len
   const fakeSpawn = async (cmd: string, args: string[], _options: { cwd: string }): Promise<string> => {
     if (args.includes('user.name')) {
       if (returnGitUsername) {

--- a/packages/template/base/tmpl/index.js
+++ b/packages/template/base/tmpl/index.js
@@ -2,7 +2,6 @@ const { app, BrowserWindow } = require('electron');
 const path = require('path');
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
-// eslint-disable-next-line global-require
 if (require('electron-squirrel-startup')) {
   app.quit();
 }

--- a/packages/template/typescript-webpack/tmpl/index.ts
+++ b/packages/template/typescript-webpack/tmpl/index.ts
@@ -7,7 +7,6 @@ declare const MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY: string;
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (require('electron-squirrel-startup')) {
-  // eslint-disable-line global-require
   app.quit();
 }
 

--- a/packages/utils/async-ora/src/ora-handler.ts
+++ b/packages/utils/async-ora/src/ora-handler.ts
@@ -1,9 +1,7 @@
-/* eslint "no-console": "off" */
 import chalk from 'chalk';
 import ora from './ora';
 
 export class OraImpl {
-  // eslint-disable-next-line no-empty-function, no-useless-constructor
   constructor(public text: string = '') {}
 
   succeed(_symbol?: string): OraImpl {

--- a/packages/utils/async-ora/src/ora.ts
+++ b/packages/utils/async-ora/src/ora.ts
@@ -1,4 +1,3 @@
-/* eslint "no-console": "off" */
 import chalk from 'chalk';
 import debug from 'debug';
 import 'log-symbols';

--- a/packages/utils/async-ora/test/ora-handler_spec.ts
+++ b/packages/utils/async-ora/test/ora-handler_spec.ts
@@ -91,7 +91,7 @@ describe('asyncOra', () => {
 
   it('should succeed the ora if the async fn passes', async () => {
     await asyncOra('random text', async () => {
-      // eslint-disable-next-line no-console, no-constant-condition
+      // eslint-disable-next-line no-constant-condition
       if (2 + 2 === 5) console.error('Big brother is at it again');
     });
     expect(currentOra).to.not.equal(undefined);
@@ -107,7 +107,6 @@ describe('asyncOra', () => {
     await asyncOra(
       'this is gonna end badly',
       async () => {
-        // eslint-disable-next-line no-throw-literal
         throw { message: 'Not an error', stack: 'No Stack - Not an error' };
       },
       () => {
@@ -141,7 +140,7 @@ describe('asyncOra', () => {
     await asyncOra(
       'this is dodge',
       async () => {
-        throw 42; // eslint-disable-line no-throw-literal
+        throw 42;
       },
       processExitSpy
     );

--- a/packages/utils/test-utils/src/index.ts
+++ b/packages/utils/test-utils/src/index.ts
@@ -32,9 +32,7 @@ export async function expectLintToPass(dir: string): Promise<void> {
     await runNPM(dir, 'run', 'lint');
   } catch (err) {
     if (err instanceof ExitError) {
-      // eslint-disable-next-line no-console
       console.error('STDOUT:', err.stdout.toString());
-      // eslint-disable-next-line no-console
       console.error('STDERR:', err.stderr.toString());
     }
     throw err;

--- a/packages/utils/types/src/index.ts
+++ b/packages/utils/types/src/index.ts
@@ -1,5 +1,4 @@
 import { ChildProcess } from 'child_process';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { ArchOption, Options, TargetPlatform } from 'electron-packager';
 import { RebuildOptions } from 'electron-rebuild';
 

--- a/packages/utils/web-multi-logger/src/Log.ts
+++ b/packages/utils/web-multi-logger/src/Log.ts
@@ -1,4 +1,3 @@
 export default class Log {
-  // eslint-disable-next-line no-empty-function, no-useless-constructor
   constructor(public line: string, public timestamp: Date) {}
 }

--- a/tools/bump.ts
+++ b/tools/bump.ts
@@ -27,7 +27,7 @@ async function checkCleanWorkingDir(): Promise<void> {
 async function updateChangelog(lastVersion: string, version: string): Promise<void> {
   await run('yarn', ['changelog', `--tag=v${lastVersion}..v${version}`, '--exclude=build,chore,ci,docs,refactor,style,test']);
 
-  require('../ci/fix-changelog'); // eslint-disable-line global-require
+  require('../ci/fix-changelog');
 
   await git('add', 'CHANGELOG.md');
   await git('commit', '-m', `Update CHANGELOG.md for ${version}`);

--- a/tools/test-globber.ts
+++ b/tools/test-globber.ts
@@ -1,4 +1,3 @@
-/* eslint "global-require": "off", "import/no-dynamic-require": "off" */
 import glob from 'fast-glob';
 import minimist from 'minimist';
 import * as path from 'path';


### PR DESCRIPTION
This removes a bunch of old unused `// eslint-disable` calls that might have been needed for previous iterations of our ESLint config, but no longer.

I hunted these down with the `--report-unused-disable-directives` flag. 