### PR TITLE
ci: upgrade slow tests to ubuntu-20.04 environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
     needs: dependabolt
     strategy:
       matrix:
-        os: [windows-latest, macOS-latest, ubuntu-18.04]
+        os: [windows-latest, macOS-latest, ubuntu-20.04]
     steps:
       - name: Fix git checkout line endings
         run: git config --global core.autocrlf input


### PR DESCRIPTION
The older 18.04 environment is deprecated by GitHub Actions.