### PR TITLE
feat!(maker-pkg): upgrade to `@electron/osx-sign`

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@aws-sdk/types": "^3.25.0",
     "@doyensec/electronegativity": "^1.9.1",
     "@electron/get": "^2.0.0",
+    "@electron/osx-sign": "^1.0.1",
     "@malept/cross-spawn-promise": "^2.0.0",
     "@octokit/core": "^3.2.4",
     "@octokit/plugin-retry": "^3.0.9",

--- a/packages/maker/pkg/package.json
+++ b/packages/maker/pkg/package.json
@@ -20,6 +20,6 @@
   "dependencies": {
     "@electron-forge/maker-base": "6.0.0-beta.67",
     "@electron-forge/shared-types": "6.0.0-beta.67",
-    "electron-osx-sign": "^0.5.0"
+    "@electron/osx-sign": "^1.0.1"
   }
 }

--- a/packages/maker/pkg/src/Config.ts
+++ b/packages/maker/pkg/src/Config.ts
@@ -12,7 +12,7 @@ export interface MakerPKGConfig {
    *
    * Default: `true`.
    */
-  'identity-validation'?: boolean;
+  identityValidation?: boolean;
   /**
    * Path to install the bundle. Default to `/Applications`.
    */

--- a/packages/maker/pkg/src/MakerPKG.ts
+++ b/packages/maker/pkg/src/MakerPKG.ts
@@ -30,7 +30,7 @@ export default class MakerPKG extends MakerBase<MakerPKGConfig> {
       app: path.resolve(dir, `${appName}.app`),
       pkg: outPath,
       platform: targetPlatform,
-    };should pass through correct default
+    };
     await flatAsync(pkgConfig);
 
     return [outPath];

--- a/packages/maker/pkg/src/MakerPKG.ts
+++ b/packages/maker/pkg/src/MakerPKG.ts
@@ -1,11 +1,9 @@
 import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';
-import { flatAsync } from '@electron/osx-sign';
+import { buildPkg } from '@electron/osx-sign';
 
 import path from 'path';
 import { MakerPKGConfig } from './Config';
-
-type flatAsyncOptions = Parameters<typeof flatAsync>[0];
 
 export default class MakerPKG extends MakerBase<MakerPKGConfig> {
   name = 'pkg';
@@ -25,13 +23,13 @@ export default class MakerPKG extends MakerBase<MakerPKGConfig> {
 
     await this.ensureFile(outPath);
 
-    const pkgConfig: flatAsyncOptions = {
+    const pkgConfig = {
       ...this.config,
       app: path.resolve(dir, `${appName}.app`),
       pkg: outPath,
       platform: targetPlatform,
     };
-    await flatAsync(pkgConfig);
+    await buildPkg(pkgConfig);
 
     return [outPath];
   }

--- a/packages/maker/pkg/src/MakerPKG.ts
+++ b/packages/maker/pkg/src/MakerPKG.ts
@@ -18,7 +18,7 @@ export default class MakerPKG extends MakerBase<MakerPKGConfig> {
 
   async make({ dir, makeDir, appName, packageJSON, targetPlatform }: MakerOptions): Promise<string[]> {
     if (!this.isValidTargetPlatform(targetPlatform)) {
-      throw new Error(`The pkg maker only supports targeting "mas" and "darwin" builds. You provided "${targetPlatform}."`);
+      throw new Error(`The pkg maker only supports targeting "mas" and "darwin" builds. You provided "${targetPlatform}".`);
     }
 
     const outPath = path.resolve(makeDir, `${appName}-${packageJSON.version}.pkg`);
@@ -30,7 +30,7 @@ export default class MakerPKG extends MakerBase<MakerPKGConfig> {
       app: path.resolve(dir, `${appName}.app`),
       pkg: outPath,
       platform: targetPlatform,
-    };
+    };should pass through correct default
     await flatAsync(pkgConfig);
 
     return [outPath];

--- a/packages/maker/pkg/src/MakerPKG.ts
+++ b/packages/maker/pkg/src/MakerPKG.ts
@@ -1,6 +1,6 @@
 import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';
-import { buildPkg } from '@electron/osx-sign';
+import { flatAsync } from '@electron/osx-sign';
 
 import path from 'path';
 import { MakerPKGConfig } from './Config';
@@ -29,7 +29,7 @@ export default class MakerPKG extends MakerBase<MakerPKGConfig> {
       pkg: outPath,
       platform: targetPlatform,
     };
-    await buildPkg(pkgConfig);
+    await flatAsync(pkgConfig);
 
     return [outPath];
   }

--- a/packages/maker/pkg/test/MakerPKG_spec.ts
+++ b/packages/maker/pkg/test/MakerPKG_spec.ts
@@ -19,7 +19,7 @@ class MakerImpl extends MakerBase<MakerPKGConfig> {
 describe('MakerPKG', () => {
   let MakerDMG: typeof MakerImpl;
   let ensureFileStub: SinonStub;
-  let eosStub: SinonStub;
+  let osxSignStub: SinonStub;
   let renameStub: SinonStub;
   let config: MakerPKGConfig;
   let maker: MakerImpl;
@@ -33,7 +33,7 @@ describe('MakerPKG', () => {
 
   beforeEach(() => {
     ensureFileStub = stub().returns(Promise.resolve());
-    eosStub = stub();
+    osxSignStub = stub();
     renameStub = stub().returns(Promise.resolve());
     config = {};
 
@@ -42,8 +42,8 @@ describe('MakerPKG', () => {
       .noCallThru()
       .load('../src/MakerPKG', {
         '../../util/ensure-output': { ensureFile: ensureFileStub },
-        'electron-osx-sign': {
-          flatAsync: eosStub,
+        '@electron/osx-sign': {
+          flatAsync: osxSignStub,
         },
         'fs-extra': {
           rename: renameStub,
@@ -66,7 +66,7 @@ describe('MakerPKG', () => {
       targetArch,
       targetPlatform: 'mas',
     });
-    const opts = eosStub.firstCall.args[0];
+    const opts = osxSignStub.firstCall.args[0];
     expect(opts).to.deep.equal({
       app: path.resolve(`${dir}/My Test App.app`),
       pkg: path.resolve(`${dir.substr(0, dir.length - 4)}/make/My Test App-1.2.3.pkg`),
@@ -84,6 +84,6 @@ describe('MakerPKG', () => {
         targetArch,
         targetPlatform: 'win32',
       })
-    ).to.eventually.be.rejectedWith('The pkg maker only supports targetting "mas" and "darwin" builds.  You provided "win32"');
+    ).to.eventually.be.rejectedWith('The pkg maker only supports targeting "mas" and "darwin" builds. You provided "win32".');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1112,6 +1112,18 @@
     global-agent "^3.0.0"
     global-tunnel-ng "^2.7.1"
 
+"@electron/osx-sign@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@electron/osx-sign/-/osx-sign-1.0.1.tgz#ab4fceded7fed9f2f18c25650f46c1e3a6f17054"
+  integrity sha512-WkUcva+qkt809bI6uxxEG/uOWfl8HAw0m8aPijpKmGMIpZ1CWWB808YG6aY3wckUO86xZdmiOsUJTM4keLhY8A==
+  dependencies:
+    compare-version "^0.1.2"
+    debug "^4.3.4"
+    fs-extra "^10.0.0"
+    isbinaryfile "^4.0.8"
+    minimist "^1.2.6"
+    plist "^3.0.5"
+
 "@electron/universal@^1.2.1":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@electron/universal/-/universal-1.3.0.tgz#5854e41cf5bac03f4a78b9282358661fd0a66d4e"
@@ -3462,6 +3474,13 @@ debug@^3.1.0, debug@^3.1.1, debug@^3.2.7:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
 
 debuglog@^1.0.1:
   version "1.0.1"
@@ -5942,6 +5961,11 @@ isbinaryfile@^3.0.2:
   dependencies:
     buffer-alloc "^1.2.0"
 
+isbinaryfile@^4.0.8:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-4.0.10.tgz#0c5b5e30c2557a2f06febd37b7322946aaee42b3"
+  integrity sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -7540,7 +7564,7 @@ plist@^3.0.0, plist@^3.0.1:
     base64-js "^1.5.1"
     xmlbuilder "^9.0.7"
 
-plist@^3.0.4:
+plist@^3.0.4, plist@^3.0.5:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/plist/-/plist-3.0.6.tgz#7cfb68a856a7834bca6dbfe3218eb9c7740145d3"
   integrity sha512-WiIVYyrp8TD4w8yCvyeIr+lkmrGRd5u0VbRnU+tP/aRLxP/YadJUYOMZJ/6hIa3oUyVCsycXvtNRgd5XBJIbiA==


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Swaps out the old `electron-osx-sign` package for the newer `@electron/osx-sign` one. Closes #2957

Breaking change: `identity-validation` flag is camelCased to `identityValidation` now.
