### PR TITLE
docs: additional typedoc improvements

### DIFF
--- a/packages/maker/base/src/Maker.ts
+++ b/packages/maker/base/src/Maker.ts
@@ -46,6 +46,7 @@ export default abstract class Maker<C> implements IForgeMaker {
 
   public requiredExternalBinaries: string[] = [];
 
+  /** @internal */
   __isElectronForgeMaker!: true;
 
   constructor(private configFetcher: C | ((arch: ForgeArch) => C) = {} as C, protected providedPlatforms?: ForgePlatform[]) {

--- a/packages/plugin/base/src/Plugin.ts
+++ b/packages/plugin/base/src/Plugin.ts
@@ -5,6 +5,7 @@ export { StartOptions };
 export default abstract class Plugin<C> implements IForgePlugin {
   public abstract name: string;
 
+  /** @internal */
   __isElectronForgePlugin!: true;
 
   constructor(public config: C) {

--- a/packages/publisher/base/src/Publisher.ts
+++ b/packages/publisher/base/src/Publisher.ts
@@ -22,6 +22,7 @@ export default abstract class Publisher<C> implements IForgePublisher {
 
   public defaultPlatforms?: ForgePlatform[];
 
+  /** @internal */
   __isElectronForgePublisher!: true;
 
   constructor(public config: C, protected providedPlatforms?: ForgePlatform[]) {

--- a/packages/utils/types/src/index.ts
+++ b/packages/utils/types/src/index.ts
@@ -60,6 +60,7 @@ export interface ForgeMakeResult {
 }
 
 export interface IForgePlugin {
+  /** @internal */
   __isElectronForgePlugin: boolean;
   name: string;
 
@@ -76,6 +77,7 @@ export interface IForgeResolvableMaker {
 }
 
 export interface IForgeMaker {
+  /** @internal */
   __isElectronForgeMaker: boolean;
   readonly platforms?: ForgePlatform[];
 }
@@ -87,6 +89,7 @@ export interface IForgeResolvablePublisher {
 }
 
 export interface IForgePublisher {
+  /** @internal */
   __isElectronForgePublisher: boolean;
   readonly platforms?: ForgePlatform[];
 }

--- a/tools/gen-docs.ts
+++ b/tools/gen-docs.ts
@@ -10,10 +10,13 @@ import * as typedoc from 'typedoc';
     entryPointStrategy: 'packages',
     entryPoints: packages.map((pkg) => pkg.path),
     excludeExternals: true,
+    excludeInternal: true,
     excludePrivate: true,
     excludeProtected: true,
-    hideGenerator: true,
     externalPattern: ['**/node_modules/@types/node/**'],
+    hideGenerator: true,
+    includeVersion: true,
+    name: 'Electron Forge',
     plugin: ['typedoc-plugin-rename-defaults', 'typedoc-plugin-missing-exports'],
   });
 


### PR DESCRIPTION
Makes the API docs a _bit_ better by tweaking the settings.

* The site name is prettier and contains the version now.
* Any class members with the `@internal` comment is now ignored.

See preview: https://astounding-pegasus-a7d11f.netlify.app/