### PR TITLE
feat!: improve forge configuration DX

### DIFF
--- a/packages/api/core/src/api/package.ts
+++ b/packages/api/core/src/api/package.ts
@@ -122,7 +122,7 @@ export default async ({
       done();
     },
     async (buildPath, electronVersion, pPlatform, pArch, done) => {
-      await rebuildHook(buildPath, electronVersion, pPlatform, pArch, forgeConfig.electronRebuildConfig);
+      await rebuildHook(buildPath, electronVersion, pPlatform, pArch, forgeConfig.rebuildConfig);
       packagerSpinner = ora('Packaging Application').start();
       done();
     },

--- a/packages/api/core/src/api/publish.ts
+++ b/packages/api/core/src/api/publish.ts
@@ -36,7 +36,7 @@ export interface PublishOptions {
    * The publish targets, by default pulled from forge config, set this prop to
    * override that list
    */
-  publishTargets?: ForgeConfigPublisher[];
+  publishTargets?: ForgeConfigPublisher[] | string[];
   /**
    * Options object to passed through to make()
    */

--- a/packages/api/core/src/api/start.ts
+++ b/packages/api/core/src/api/start.ts
@@ -51,7 +51,7 @@ export default async ({
   const platform = process.env.npm_config_platform || process.platform;
   const arch = process.env.npm_config_arch || process.arch;
 
-  await rebuild(dir, await getElectronVersion(dir, packageJSON), platform as ForgePlatform, arch as ForgeArch, forgeConfig.electronRebuildConfig);
+  await rebuild(dir, await getElectronVersion(dir, packageJSON), platform as ForgePlatform, arch as ForgeArch, forgeConfig.rebuildConfig);
 
   await runHook(forgeConfig, 'generateAssets', platform, arch);
 

--- a/packages/api/core/src/util/forge-config.ts
+++ b/packages/api/core/src/util/forge-config.ts
@@ -142,7 +142,7 @@ export default async (dir: string): Promise<ForgeConfig> => {
     throw new Error('Expected packageJSON.config.forge to be an object or point to a requirable JS file');
   }
   const defaultForgeConfig = {
-    electronRebuildConfig: {},
+    rebuildConfig: {},
     packagerConfig: {},
     makers: [],
     publishers: [],

--- a/packages/api/core/src/util/plugin-interface.ts
+++ b/packages/api/core/src/util/plugin-interface.ts
@@ -7,6 +7,10 @@ import requireSearch from './require-search';
 
 const d = debug('electron-forge:plugins');
 
+function isForgePlugin(plugin: IForgePlugin | unknown): plugin is IForgePlugin {
+  return (plugin as IForgePlugin).__isElectronForgePlugin;
+}
+
 export default class PluginInterface implements IForgePluginInterface {
   private plugins: IForgePlugin[];
 
@@ -14,23 +18,24 @@ export default class PluginInterface implements IForgePluginInterface {
 
   constructor(dir: string, forgeConfig: ForgeConfig) {
     this.plugins = forgeConfig.plugins.map((plugin) => {
-      if ((plugin as IForgePlugin).__isElectronForgePlugin) {
+      if (isForgePlugin(plugin)) {
         return plugin;
       }
 
-      if (Array.isArray(plugin)) {
-        const [pluginName, opts = {}] = plugin;
+      if (typeof plugin === 'object' && 'name' in plugin && 'config' in plugin) {
+        const { name: pluginName, config: opts } = plugin;
         if (typeof pluginName !== 'string') {
           throw new Error(`Expected plugin[0] to be a string but found ${pluginName}`);
         }
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const Plugin = requireSearch<any>(dir, [pluginName]);
         if (!Plugin) {
-          throw new Error(`Could not find module with name: ${plugin[0]}. Make sure it's listed in the devDependencies of your package.json`);
+          throw new Error(`Could not find module with name: ${pluginName}. Make sure it's listed in the devDependencies of your package.json`);
         }
         return new Plugin(opts);
       }
-      throw new Error(`Expected plugin to either be a plugin instance or [string, object] but found ${plugin}`);
+
+      throw new Error(`Expected plugin to either be a plugin instance or a { name, config } object but found ${plugin}`);
     });
     // TODO: fix hack
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/api/core/src/util/upgrade-forge-config.ts
+++ b/packages/api/core/src/util/upgrade-forge-config.ts
@@ -150,7 +150,7 @@ export default function upgradeForgeConfig(forge5Config: Forge5Config): ForgeCon
     forgeConfig.packagerConfig = forge5Config.electronPackagerConfig;
   }
   if (forge5Config.electronRebuildConfig) {
-    forgeConfig.electronRebuildConfig = forge5Config.electronRebuildConfig;
+    forgeConfig.rebuildConfig = forge5Config.electronRebuildConfig;
   }
   forgeConfig.makers = generateForgeMakerConfig(forge5Config);
   forgeConfig.publishers = generateForgePublisherConfig(forge5Config);

--- a/packages/api/core/test/fast/forge-config_spec.ts
+++ b/packages/api/core/test/fast/forge-config_spec.ts
@@ -11,7 +11,7 @@ import findConfig, {
 
 const defaults = {
   packagerConfig: {},
-  electronRebuildConfig: {},
+  rebuildConfig: {},
   makers: [],
   publishers: [],
   plugins: [],
@@ -220,12 +220,15 @@ describe('forge-config', () => {
         config: {
           forge: {
             makers: [
-              {
-                name: '@electron-forge/maker-test',
-                config: {
-                  name: 'will be overwritten',
-                },
-              },
+              // {
+              //   name: '@electron-forge/maker-test',
+              //   config: {
+              //     name: 'will be overwritten',
+              //   },
+              // },
+              // new MakerZip({
+              //   name: 'will be overwritten',
+              // }),
             ],
           },
         },

--- a/packages/api/core/test/fast/forge-config_spec.ts
+++ b/packages/api/core/test/fast/forge-config_spec.ts
@@ -220,15 +220,12 @@ describe('forge-config', () => {
         config: {
           forge: {
             makers: [
-              // {
-              //   name: '@electron-forge/maker-test',
-              //   config: {
-              //     name: 'will be overwritten',
-              //   },
-              // },
-              // new MakerZip({
-              //   name: 'will be overwritten',
-              // }),
+              {
+                name: '@electron-forge/maker-test',
+                config: {
+                  name: 'will be overwritten',
+                },
+              },
             ],
           },
         },

--- a/packages/api/core/test/fast/publish_spec.ts
+++ b/packages/api/core/test/fast/publish_spec.ts
@@ -29,7 +29,7 @@ describe('publish', () => {
     publisherSpy = stub();
     voidStub = stub();
     nowhereStub = stub();
-    publishers = ['@electron-forge/publisher-test'];
+    publishers = [{ name: '@electron-forge/publisher-test' }];
     const fakePublisher = (stub: SinonStub, name = 'default') =>
       class _FakePublisher {
         private publish: SinonStub;

--- a/packages/api/core/test/fast/read-package-json_spec.ts
+++ b/packages/api/core/test/fast/read-package-json_spec.ts
@@ -6,7 +6,7 @@ import { readRawPackageJson, readMutatedPackageJson } from '../../src/util/read-
 
 const emptyForgeConfig: Partial<ForgeConfig> = {
   packagerConfig: {},
-  electronRebuildConfig: {},
+  rebuildConfig: {},
   makers: [],
   publishers: [],
   plugins: [],

--- a/packages/api/core/test/fast/upgrade-forge-config_spec.ts
+++ b/packages/api/core/test/fast/upgrade-forge-config_spec.ts
@@ -23,7 +23,7 @@ describe('upgradeForgeConfig', () => {
     const oldConfig = { electronRebuildConfig: { ...rebuildConfig } };
 
     const newConfig = upgradeForgeConfig(oldConfig);
-    expect(newConfig.electronRebuildConfig).to.deep.equal(rebuildConfig);
+    expect(newConfig.rebuildConfig).to.deep.equal(rebuildConfig);
   });
 
   it('converts maker config', () => {
@@ -116,7 +116,7 @@ describe('updateUpgradedForgeDevDeps', () => {
     config: {
       forge: {
         packagerConfig: {},
-        electronRebuildConfig: {},
+        rebuildConfig: {},
         makers: [],
         publishers: [],
         plugins: [],

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -161,7 +161,7 @@ export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
             await utils.getElectronVersion(this.projectDir, await fs.readJson(path.join(this.projectDir, 'package.json'))),
             platform,
             arch,
-            config.electronRebuildConfig
+            config.rebuildConfig
           );
           await this.compileMain();
           await this.compileRenderers();

--- a/packages/utils/types/src/index.ts
+++ b/packages/utils/types/src/index.ts
@@ -1,5 +1,5 @@
 import { ChildProcess } from 'child_process';
-import { ArchOption, Options, TargetPlatform } from 'electron-packager';
+import { ArchOption, Options as ElectronPackagerOptions, TargetPlatform } from 'electron-packager';
 import { RebuildOptions } from 'electron-rebuild';
 
 export type ElectronProcess = ChildProcess & { restarted: boolean };
@@ -9,13 +9,18 @@ export type ForgeArch = ArchOption;
 // Why: hooks have any number/kind of args/return values
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export type ForgeHookFn = (forgeConfig: ForgeConfig, ...args: any[]) => Promise<any>;
-export type ForgeConfigPublisher = IForgeResolvablePublisher | IForgePublisher | string;
+export type ForgeConfigPublisher = IForgeResolvablePublisher | IForgePublisher;
+export type ForgeConfigMaker = IForgeResolvableMaker | IForgeMaker;
+export type ForgeConfigPlugin = IForgeResolvablePlugin | IForgePlugin;
 export interface IForgePluginInterface {
   triggerHook(hookName: string, hookArgs: any[]): Promise<void>;
   triggerMutatingHook<T>(hookName: string, item: T): Promise<any>;
   overrideStartLogic(opts: StartOptions): Promise<StartResult>;
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
+
+export type ForgeRebuildOptions = Omit<RebuildOptions, 'buildPath' | 'electronVersion' | 'arch'>;
+export type ForgePackagerOptions = Omit<ElectronPackagerOptions, 'dir' | 'arch' | 'platform' | 'out' | 'electronVersion'>;
 export interface ForgeConfig {
   /**
    * A string to uniquely identify artifacts of this build, will be appended
@@ -34,10 +39,10 @@ export interface ForgeConfig {
   /**
    * An array of Forge plugins or a tuple consisting of [pluginName, pluginOptions]
    */
-  plugins: (IForgePlugin | [string, Record<string, unknown>])[];
-  electronRebuildConfig: Partial<RebuildOptions>;
-  packagerConfig: Partial<Options>;
-  makers: (IForgeResolvableMaker | IForgeMaker)[];
+  plugins: ForgeConfigPlugin[];
+  rebuildConfig: ForgeRebuildOptions;
+  packagerConfig: ForgePackagerOptions;
+  makers: ForgeConfigMaker[];
   publishers: ForgeConfigPublisher[];
 }
 export interface ForgeMakeResult {
@@ -57,6 +62,11 @@ export interface ForgeMakeResult {
    * The arch this make run was for
    */
   arch: ForgeArch;
+}
+
+export interface IForgeResolvablePlugin {
+  name: string;
+  config?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 export interface IForgePlugin {


### PR DESCRIPTION
Couple of breaking changes to improve DX
* Plugins now follow the same syntax as makers/publishers
* Better type safety of the core make/publish APIs
* Renamed electronRebuildConfig to rebuildConfig
* Fixed types for packagerConfig and rebuildConfig to appropriately Omit certain forge provided keys

With better types we can do some work to allow `forge.config.ts` and a completely type-safe config 🪄 