### PR TITLE
fix(docs): only publish API docs on v6 tags

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,9 +1,9 @@
-name: GitHub Pages
+name: API Documentation
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - v6.**
 
 jobs:
   deploy:


### PR DESCRIPTION
As discussed in today's Ecosystem WG meeting.

cc @VerteDinde @malept @dsanders11 