### PR TITLE
feat!: upgrade electron-packager@17

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -13,13 +13,13 @@ value of the environment variable is a comma-separated list of modules which sup
 feature. Known modules include:
 
 - `@electron/get:*`
+- `@electron/osx-sign`
 - `electron-forge:*` (always use this one before filing an issue)
 - `electron-installer-debian`
 - `electron-installer-dmg`
 - `electron-installer-flatpak`
 - `electron-installer-redhat`
 - `electron-installer-snap:*`
-- `electron-osx-sign`
 - `electron-packager`
 - `electron-rebuild`
 - `electron-windows-installer:main`

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "cross-spawn": "^7.0.3",
     "cross-zip": "^4.0.0",
     "debug": "^4.3.1",
-    "electron-osx-sign": "^0.5.0",
     "electron-packager": "^17.0.0",
     "electron-rebuild": "^3.2.6",
     "express": "^4.17.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "cross-zip": "^4.0.0",
     "debug": "^4.3.1",
     "electron-osx-sign": "^0.5.0",
-    "electron-packager": "^16.0.0",
+    "electron-packager": "^17.0.0",
     "electron-rebuild": "^3.2.6",
     "express": "^4.17.1",
     "express-ws": "^5.0.2",

--- a/packages/api/core/package.json
+++ b/packages/api/core/package.json
@@ -49,7 +49,7 @@
     "@malept/cross-spawn-promise": "^2.0.0",
     "chalk": "^4.0.0",
     "debug": "^4.3.1",
-    "electron-packager": "^16.0.0",
+    "electron-packager": "^17.0.0",
     "electron-rebuild": "^3.2.6",
     "fast-glob": "^3.2.7",
     "filenamify": "^4.1.0",

--- a/packages/api/core/src/api/import.ts
+++ b/packages/api/core/src/api/import.ts
@@ -115,6 +115,7 @@ export default async ({
   const keys = Object.keys(packageJSON.dependencies).concat(Object.keys(packageJSON.devDependencies));
   const buildToolPackages: Record<string, string | undefined> = {
     '@electron/get': 'already uses this module as a transitive dependency',
+    '@electron/osx-sign': 'already uses this module as a transitive dependency',
     'electron-builder': 'provides mostly equivalent functionality',
     'electron-download': 'already uses this module as a transitive dependency',
     'electron-forge': 'replaced with @electron-forge/cli',
@@ -122,7 +123,6 @@ export default async ({
     'electron-installer-dmg': 'already uses this module as a transitive dependency',
     'electron-installer-flatpak': 'already uses this module as a transitive dependency',
     'electron-installer-redhat': 'already uses this module as a transitive dependency',
-    'electron-osx-sign': 'already uses this module as a transitive dependency',
     'electron-packager': 'already uses this module as a transitive dependency',
     'electron-winstaller': 'already uses this module as a transitive dependency',
   };

--- a/packages/plugin/webpack/package.json
+++ b/packages/plugin/webpack/package.json
@@ -14,7 +14,7 @@
     "@malept/cross-spawn-promise": "^2.0.0",
     "@types/node": "^18.0.3",
     "chai": "^4.3.3",
-    "electron-packager": "^16.0.0",
+    "electron-packager": "^17.0.0",
     "mocha": "^9.0.1",
     "sinon": "^13.0.1",
     "which": "^2.0.2",

--- a/packages/utils/types/package.json
+++ b/packages/utils/types/package.json
@@ -9,7 +9,7 @@
   "typings": "dist/index.d.ts",
   "dependencies": {
     "@electron-forge/async-ora": "6.0.0-beta.67",
-    "electron-packager": "^16.0.0",
+    "electron-packager": "^17.0.0",
     "electron-rebuild": "^3.2.6",
     "ora": "^5.0.0"
   },

--- a/tools/update-dependencies.js
+++ b/tools/update-dependencies.js
@@ -9,7 +9,6 @@ const DO_NOT_UPGRADE = [
   '@typescript-eslint/eslint-plugin', // special case
   'chalk', // Requires ESM
   'commander', // TODO: convert to yargs
-  'electron-osx-sign', // Requires Electron Packager's dependency to also be upgraded
   'eslint-plugin-mocha', // Requires Node 14
   'find-up', // Requires ESM
   'log-symbols', // Requires ESM

--- a/yarn.lock
+++ b/yarn.lock
@@ -2777,19 +2777,6 @@ browserslist@^4.14.5, browserslist@^4.17.5:
     node-releases "^2.0.1"
     picocolors "^1.0.0"
 
-buffer-alloc-unsafe@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
-  integrity sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==
-
-buffer-alloc@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.2.0.tgz#890dd90d923a873e08e10e5fd51a57e5b7cce0ec"
-  integrity sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==
-  dependencies:
-    buffer-alloc-unsafe "^1.1.0"
-    buffer-fill "^1.0.0"
-
 buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
@@ -2799,11 +2786,6 @@ buffer-equal@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-equal/-/buffer-equal-1.0.0.tgz#59616b498304d556abd466966b22eeda3eca5fbe"
   integrity sha512-tcBWO2Dl4e7Asr9hTGcpVrCe+F7DubpmqWCTbj4FHLmjqO2hIaC383acQubWtRJhdceqs5uBHs6Es+Sk//RKiQ==
-
-buffer-fill@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
-  integrity sha1-+PeLdniYiO858gXNY39o5wISKyw=
 
 buffer-from@^1.0.0:
   version "1.1.2"
@@ -3459,7 +3441,7 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.6.8, debug@^2.6.9:
+debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -3850,18 +3832,6 @@ electron-notarize@^1.1.1:
   dependencies:
     debug "^4.1.1"
     fs-extra "^9.0.1"
-
-electron-osx-sign@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/electron-osx-sign/-/electron-osx-sign-0.5.0.tgz#fc258c5e896859904bbe3d01da06902c04b51c3a"
-  integrity sha512-icoRLHzFz/qxzDh/N4Pi2z4yVHurlsCAYQvsCSG7fCedJ4UJXBS6PoQyGH71IfcqKupcKeK7HX/NkyfG+v6vlQ==
-  dependencies:
-    bluebird "^3.5.0"
-    compare-version "^0.1.2"
-    debug "^2.6.8"
-    isbinaryfile "^3.0.2"
-    minimist "^1.2.0"
-    plist "^3.0.1"
 
 electron-packager@^17.0.0:
   version "17.0.0"
@@ -5966,13 +5936,6 @@ isarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
-isbinaryfile@^3.0.2:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-3.0.3.tgz#5d6def3edebf6e8ca8cae9c30183a804b5f8be80"
-  integrity sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==
-  dependencies:
-    buffer-alloc "^1.2.0"
-
 isbinaryfile@^4.0.8:
   version "4.0.10"
   resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-4.0.10.tgz#0c5b5e30c2557a2f06febd37b7322946aaee42b3"
@@ -7568,7 +7531,7 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-plist@^3.0.0, plist@^3.0.1:
+plist@^3.0.0:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/plist/-/plist-3.0.5.tgz#2cbeb52d10e3cdccccf0c11a63a85d830970a987"
   integrity sha512-83vX4eYdQp3vP9SxuYgEM/G/pJQqLUz/V/xzPrzruLs7fz7jxGQ1msZ/mg1nwZxUSuOp4sb+/bEIbRrbzZRxDA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1096,6 +1096,18 @@
     typescript "~4.2.4"
     winston "^2.3.1"
 
+"@electron/asar@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@electron/asar/-/asar-3.2.1.tgz#c4143896f3dd43b59a80a9c9068d76f77efb62ea"
+  integrity sha512-hE2cQMZ5+4o7+6T2lUaVbxIzrOjZZfX7dB02xuapyYFJZEAiWTelq6J3mMoxzd0iONDvYLPVKecB5tyjIoVDVA==
+  dependencies:
+    chromium-pickle-js "^0.2.0"
+    commander "^5.0.0"
+    glob "^7.1.6"
+    minimatch "^3.0.4"
+  optionalDependencies:
+    "@types/glob" "^7.1.1"
+
 "@electron/get@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@electron/get/-/get-2.0.0.tgz#d991e68dc089fc66b521ec3ca4021515482bef91"
@@ -1124,13 +1136,13 @@
     minimist "^1.2.6"
     plist "^3.0.5"
 
-"@electron/universal@^1.2.1":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@electron/universal/-/universal-1.3.0.tgz#5854e41cf5bac03f4a78b9282358661fd0a66d4e"
-  integrity sha512-6SAIlMZZRj1qpe3z3qhMWf3fmqhAdzferiQ5kpspCI9sH1GjkzRXY0RLaz0ktHtYonOj9XMpXNkhDy7QQagQEg==
+"@electron/universal@^1.3.2":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@electron/universal/-/universal-1.3.3.tgz#f22088dce7f2e808130fd1bbcd43925246adfa59"
+  integrity sha512-79yc61D5QWaQpia+sLQbIIi5iVoV4y9HtgOTlE0fYT0xoyg+ChwndBl4a0Q7yJfDsqq+/nLEPE655F0bTpDiCg==
   dependencies:
+    "@electron/asar" "^3.2.1"
     "@malept/cross-spawn-promise" "^1.1.0"
-    asar "^3.1.0"
     debug "^4.3.1"
     dir-compare "^2.4.0"
     fs-extra "^9.0.1"
@@ -2543,7 +2555,7 @@ asar@^2.0.1:
   optionalDependencies:
     "@types/glob" "^7.1.1"
 
-asar@^3.0.0, asar@^3.0.3, asar@^3.1.0:
+asar@^3.0.0, asar@^3.0.3:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/asar/-/asar-3.1.0.tgz#70b0509449fe3daccc63beb4d3c7d2e24d3c6473"
   integrity sha512-vyxPxP5arcAqN4F/ebHd/HhwnAiZtwhglvdmc7BR2f0ywbVNTOpSeyhLDbGXtE/y58hv1oC75TaNIXutnsOZsQ==
@@ -3851,18 +3863,18 @@ electron-osx-sign@^0.5.0:
     minimist "^1.2.0"
     plist "^3.0.1"
 
-electron-packager@^16.0.0:
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/electron-packager/-/electron-packager-16.0.0.tgz#2eb7f14114e06b545207496ef66b10c24b7c8ba1"
-  integrity sha512-7Ey4UUaHg3FYhA7ktsAvCWP8srp9+iPljGdeJBsNaZBakU6HWhvRC+Pc7LWXGCgAVIN5BQsUwR3xrCbFno91VA==
+electron-packager@^17.0.0:
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/electron-packager/-/electron-packager-17.0.0.tgz#09e86734da51049de08b14cee8fc6b2d424efeec"
+  integrity sha512-dDy/gMR7Zl9t5AOFNIDjX+7T0d6GEifh1o/ciDUUf/fnHpVVNjDG92HsWgToGN/H9CZi5NEdlHWUQ49Wj7TN5g==
   dependencies:
+    "@electron/asar" "^3.2.1"
     "@electron/get" "^2.0.0"
-    "@electron/universal" "^1.2.1"
-    asar "^3.1.0"
+    "@electron/osx-sign" "^1.0.1"
+    "@electron/universal" "^1.3.2"
     cross-spawn-windows-exe "^1.2.0"
     debug "^4.0.1"
     electron-notarize "^1.1.1"
-    electron-osx-sign "^0.5.0"
     extract-zip "^2.0.0"
     filenamify "^4.1.0"
     fs-extra "^10.1.0"


### PR DESCRIPTION
This PR upgrades our usage of Electron Packager to v17. The biggest change here is that we end up using `@electron/osx-sign` rather than `electron-osx-sign`.

Should be accompanied with a docs change as well.