### PR TITLE
fix(docs): avoid generating Typescript utility types

### DIFF
--- a/tools/gen-docs.ts
+++ b/tools/gen-docs.ts
@@ -13,7 +13,7 @@ import * as typedoc from 'typedoc';
     excludeInternal: true,
     excludePrivate: true,
     excludeProtected: true,
-    externalPattern: ['**/node_modules/@types/node/**'],
+    externalPattern: ['**/node_modules/@types/node/**', '**/node_modules/typescript/**'],
     hideGenerator: true,
     includeVersion: true,
     name: 'Electron Forge',


### PR DESCRIPTION
Adds `'**/node_modules/typescript/**'` to the settings for TypeDoc so we don't export internal TypeScript utility types like `Record` or `Omit`.