### PR TITLE
fix(docs): only load modules if package has entry point

### DIFF
--- a/tools/gen-docs.ts
+++ b/tools/gen-docs.ts
@@ -8,7 +8,7 @@ import * as typedoc from 'typedoc';
   const typedocApp = new typedoc.Application();
   typedocApp.bootstrap({
     entryPointStrategy: 'packages',
-    entryPoints: packages.map((pkg) => pkg.path),
+    entryPoints: packages.filter((pkg) => !!pkg.manifest['main']).map((pkg) => pkg.path),
     excludeExternals: true,
     excludeInternal: true,
     excludePrivate: true,

--- a/tools/gen-docs.ts
+++ b/tools/gen-docs.ts
@@ -8,7 +8,7 @@ import * as typedoc from 'typedoc';
   const typedocApp = new typedoc.Application();
   typedocApp.bootstrap({
     entryPointStrategy: 'packages',
-    entryPoints: packages.filter((pkg) => !!pkg.manifest['main']).map((pkg) => pkg.path),
+    entryPoints: packages.filter((pkg) => !!pkg.manifest.main).map((pkg) => pkg.path),
     excludeExternals: true,
     excludeInternal: true,
     excludePrivate: true,

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -7,7 +7,7 @@ const PACKAGES_DIR = path.resolve(BASE_DIR, 'packages');
 export interface Package {
   path: string;
   name: string;
-  manifest: object; // the parsed package.json
+  manifest: Record<string, unknown>; // the parsed package.json
 }
 
 export const getPackageInfo = async (): Promise<Package[]> => {


### PR DESCRIPTION
Two small fixes:
* Better type for `package.json` in our utility code
* Doesn't attempt to run TypeDoc for a package if it doesn't have a `main` entry. Removes a warning message `Warning: Could not determine the entry point for "/Users/erick.zhao/Developer/electron/forge/packages/api/cli/package.json". Package will be ignored.`