### PR TITLE
refactor: add / use named exports for plugins + makers + publishers

### DIFF
--- a/packages/api/core/src/api/make.ts
+++ b/packages/api/core/src/api/make.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import { asyncOra } from '@electron-forge/async-ora';
-import MakerBase from '@electron-forge/maker-base';
+import { MakerBase } from '@electron-forge/maker-base';
 import { ForgeArch, ForgeConfig, ForgeConfigMaker, ForgeMakeResult, ForgePlatform, IForgeResolvableMaker } from '@electron-forge/shared-types';
 import { getHostArch } from '@electron/get';
 import chalk from 'chalk';

--- a/packages/api/core/test/fixture/custom-maker.ts
+++ b/packages/api/core/test/fixture/custom-maker.ts
@@ -1,4 +1,4 @@
-import MakerBase from '@electron-forge/maker-base';
+import { MakerBase } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';
 
 interface Config {

--- a/packages/maker/appx/src/MakerAppX.ts
+++ b/packages/maker/appx/src/MakerAppX.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
+import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';
 import resolveCommand from 'cross-spawn/lib/util/resolveCommand';
 import windowsStore from 'electron-windows-store';
@@ -130,4 +130,4 @@ export default class MakerAppX extends MakerBase<MakerAppXConfig> {
   }
 }
 
-export { MakerAppXConfig };
+export { MakerAppX, MakerAppXConfig };

--- a/packages/maker/base/src/Maker.ts
+++ b/packages/maker/base/src/Maker.ts
@@ -169,3 +169,5 @@ export default abstract class Maker<C> implements IForgeMaker {
     return `${noPrerelease}.0`;
   }
 }
+
+export { Maker as MakerBase };

--- a/packages/maker/base/test/ensure-output_spec.ts
+++ b/packages/maker/base/test/ensure-output_spec.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { expect } from 'chai';
 import fs from 'fs-extra';
 
-import MakerBase, { EmptyConfig } from '../src/Maker';
+import { EmptyConfig, MakerBase } from '../src/Maker';
 
 class MakerImpl extends MakerBase<EmptyConfig> {
   name = 'test';

--- a/packages/maker/base/test/support_spec.ts
+++ b/packages/maker/base/test/support_spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import MakerBase, { EmptyConfig } from '../src/Maker';
+import { EmptyConfig, MakerBase } from '../src/Maker';
 
 class MakerImpl extends MakerBase<EmptyConfig> {
   name = 'test';

--- a/packages/maker/base/test/version_spec.ts
+++ b/packages/maker/base/test/version_spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import MakerBase, { EmptyConfig } from '../src/Maker';
+import { EmptyConfig, MakerBase } from '../src/Maker';
 
 class MakerImpl extends MakerBase<EmptyConfig> {
   name = 'test';

--- a/packages/maker/deb/src/MakerDeb.ts
+++ b/packages/maker/deb/src/MakerDeb.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
+import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgeArch, ForgePlatform } from '@electron-forge/shared-types';
 
 import { MakerDebConfig } from './Config';
@@ -51,4 +51,4 @@ export default class MakerDeb extends MakerBase<MakerDebConfig> {
   }
 }
 
-export { MakerDebConfig };
+export { MakerDeb, MakerDebConfig };

--- a/packages/maker/deb/test/MakerDeb_spec.ts
+++ b/packages/maker/deb/test/MakerDeb_spec.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
+import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgeArch } from '@electron-forge/shared-types';
 import { expect } from 'chai';
 import proxyquire from 'proxyquire';

--- a/packages/maker/dmg/src/MakerDMG.ts
+++ b/packages/maker/dmg/src/MakerDMG.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
+import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';
 import fs from 'fs-extra';
 
@@ -40,4 +40,4 @@ export default class MakerDMG extends MakerBase<MakerDMGConfig> {
   }
 }
 
-export { MakerDMGConfig };
+export { MakerDMG, MakerDMGConfig };

--- a/packages/maker/dmg/test/MakerDMG_spec.ts
+++ b/packages/maker/dmg/test/MakerDMG_spec.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
+import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgeArch } from '@electron-forge/shared-types';
 import { expect } from 'chai';
 import proxyquire from 'proxyquire';

--- a/packages/maker/flatpak/src/MakerFlatpak.ts
+++ b/packages/maker/flatpak/src/MakerFlatpak.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
+import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgeArch, ForgePlatform } from '@electron-forge/shared-types';
 import fs from 'fs-extra';
 
@@ -52,4 +52,4 @@ export default class MakerFlatpak extends MakerBase<MakerFlatpakConfig> {
   }
 }
 
-export { MakerFlatpak };
+export { MakerFlatpak, MakerFlatpakConfig };

--- a/packages/maker/flatpak/test/MakerFlatpak_spec.ts
+++ b/packages/maker/flatpak/test/MakerFlatpak_spec.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
+import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgeArch } from '@electron-forge/shared-types';
 import { expect } from 'chai';
 import 'chai-as-promised';

--- a/packages/maker/pkg/src/MakerPKG.ts
+++ b/packages/maker/pkg/src/MakerPKG.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
+import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';
 import { flatAsync } from '@electron/osx-sign';
 
@@ -40,4 +40,4 @@ export default class MakerPKG extends MakerBase<MakerPKGConfig> {
   }
 }
 
-export { MakerPKGConfig };
+export { MakerPKG, MakerPKGConfig };

--- a/packages/maker/pkg/test/MakerPKG_spec.ts
+++ b/packages/maker/pkg/test/MakerPKG_spec.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
+import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgeArch } from '@electron-forge/shared-types';
 import { expect } from 'chai';
 import proxyquire from 'proxyquire';

--- a/packages/maker/rpm/src/MakerRpm.ts
+++ b/packages/maker/rpm/src/MakerRpm.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
+import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgeArch, ForgePlatform } from '@electron-forge/shared-types';
 
 import { MakerRpmConfig } from './Config';
@@ -49,4 +49,4 @@ export default class MakerRpm extends MakerBase<MakerRpmConfig> {
   }
 }
 
-export { MakerRpmConfig };
+export { MakerRpm, MakerRpmConfig };

--- a/packages/maker/rpm/test/MakerRpm_spec.ts
+++ b/packages/maker/rpm/test/MakerRpm_spec.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
+import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgeArch } from '@electron-forge/shared-types';
 import { expect } from 'chai';
 import proxyquire from 'proxyquire';

--- a/packages/maker/snap/src/MakerSnap.ts
+++ b/packages/maker/snap/src/MakerSnap.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
+import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';
 
 import { MakerSnapConfig } from './Config';
@@ -34,4 +34,4 @@ export default class MakerSnap extends MakerBase<MakerSnapConfig> {
   }
 }
 
-export { MakerSnapConfig };
+export { MakerSnap, MakerSnapConfig };

--- a/packages/maker/snap/test/MakerSnap_spec.ts
+++ b/packages/maker/snap/test/MakerSnap_spec.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
+import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgeArch } from '@electron-forge/shared-types';
 import { expect } from 'chai';
 import proxyquire from 'proxyquire';

--- a/packages/maker/squirrel/src/MakerSquirrel.ts
+++ b/packages/maker/squirrel/src/MakerSquirrel.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
+import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';
 import { convertVersion, createWindowsInstaller, Options as ElectronWinstallerOptions } from 'electron-winstaller';
 import fs from 'fs-extra';
@@ -51,3 +51,5 @@ export default class MakerSquirrel extends MakerBase<MakerSquirrelConfig> {
     return artifacts;
   }
 }
+
+export { MakerSquirrel };

--- a/packages/maker/wix/src/MakerWix.ts
+++ b/packages/maker/wix/src/MakerWix.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
+import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';
 import chalk from 'chalk';
 import { MSICreator, MSICreatorOptions } from 'electron-wix-msi/lib/creator';
@@ -52,4 +52,4 @@ export default class MakerWix extends MakerBase<MakerWixConfig> {
   }
 }
 
-export { MakerWixConfig };
+export { MakerWix, MakerWixConfig };

--- a/packages/maker/zip/src/MakerZIP.ts
+++ b/packages/maker/zip/src/MakerZIP.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { promisify } from 'util';
 
-import MakerBase, { EmptyConfig, MakerOptions } from '@electron-forge/maker-base';
+import { EmptyConfig, MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';
 
 export type MakerZIPConfig = EmptyConfig;
@@ -28,3 +28,5 @@ export default class MakerZIP extends MakerBase<MakerZIPConfig> {
     return [zipPath];
   }
 }
+
+export { MakerZIP };

--- a/packages/plugin/auto-unpack-natives/src/AutoUnpackNativesPlugin.ts
+++ b/packages/plugin/auto-unpack-natives/src/AutoUnpackNativesPlugin.ts
@@ -1,4 +1,4 @@
-import PluginBase from '@electron-forge/plugin-base';
+import { PluginBase } from '@electron-forge/plugin-base';
 import { ForgeConfig, ForgeHookFn } from '@electron-forge/shared-types';
 
 import { AutoUnpackNativesConfig } from './Config';
@@ -34,4 +34,4 @@ export default class AutoUnpackNativesPlugin extends PluginBase<AutoUnpackNative
   };
 }
 
-export { AutoUnpackNativesConfig };
+export { AutoUnpackNativesPlugin, AutoUnpackNativesConfig };

--- a/packages/plugin/base/src/Plugin.ts
+++ b/packages/plugin/base/src/Plugin.ts
@@ -28,3 +28,5 @@ export default abstract class Plugin<C> implements IForgePlugin {
     return false;
   }
 }
+
+export { Plugin as PluginBase };

--- a/packages/plugin/compile/src/CompilePlugin.ts
+++ b/packages/plugin/compile/src/CompilePlugin.ts
@@ -1,12 +1,12 @@
 import * as path from 'path';
 
-import PluginBase, { StartOptions } from '@electron-forge/plugin-base';
+import { PluginBase, StartOptions } from '@electron-forge/plugin-base';
 import { ForgeHookFn } from '@electron-forge/shared-types';
 
 import { CompilePluginConfig } from './Config';
 import { createCompileHook } from './lib/compile-hook';
 
-export default class LocalElectronPlugin extends PluginBase<CompilePluginConfig> {
+export default class CompileElectronPlugin extends PluginBase<CompilePluginConfig> {
   name = 'electron-compile';
 
   private dir!: string;
@@ -35,4 +35,4 @@ export default class LocalElectronPlugin extends PluginBase<CompilePluginConfig>
   }
 }
 
-export { CompilePluginConfig };
+export { CompileElectronPlugin, CompilePluginConfig };

--- a/packages/plugin/electronegativity/src/ElectronegativityPlugin.ts
+++ b/packages/plugin/electronegativity/src/ElectronegativityPlugin.ts
@@ -1,5 +1,5 @@
 import runElectronegativity from '@doyensec/electronegativity';
-import PluginBase from '@electron-forge/plugin-base';
+import { PluginBase } from '@electron-forge/plugin-base';
 import { ForgeConfig, ForgeHookFn } from '@electron-forge/shared-types';
 
 // To be more precise, postPackage options we care about.
@@ -78,3 +78,5 @@ export default class ElectronegativityPlugin extends PluginBase<Electronegativit
     );
   };
 }
+
+export { ElectronegativityPlugin };

--- a/packages/plugin/local-electron/src/LocalElectronPlugin.ts
+++ b/packages/plugin/local-electron/src/LocalElectronPlugin.ts
@@ -1,4 +1,4 @@
-import PluginBase from '@electron-forge/plugin-base';
+import { PluginBase } from '@electron-forge/plugin-base';
 import { ForgeConfig, ForgeHookFn } from '@electron-forge/shared-types';
 import fs from 'fs-extra';
 
@@ -62,4 +62,4 @@ export default class LocalElectronPlugin extends PluginBase<LocalElectronPluginC
   };
 }
 
-export { LocalElectronPluginConfig };
+export { LocalElectronPlugin, LocalElectronPluginConfig };

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 import { asyncOra } from '@electron-forge/async-ora';
 import { utils } from '@electron-forge/core';
-import PluginBase from '@electron-forge/plugin-base';
+import { PluginBase } from '@electron-forge/plugin-base';
 import { ElectronProcess, ForgeArch, ForgeConfig, ForgeHookFn, ForgePlatform } from '@electron-forge/shared-types';
 import Logger, { Tab } from '@electron-forge/web-multi-logger';
 import chalk from 'chalk';
@@ -398,4 +398,4 @@ the generated files). Instead, it is ${JSON.stringify(pj.main)}`);
   }
 }
 
-export { WebpackPluginConfig };
+export { WebpackPlugin, WebpackPluginConfig };

--- a/packages/publisher/base/src/Publisher.ts
+++ b/packages/publisher/base/src/Publisher.ts
@@ -56,3 +56,5 @@ export default abstract class Publisher<C> implements IForgePublisher {
     throw new Error(`Publisher ${this.name} did not implement the publish method`);
   }
 }
+
+export { Publisher as PublisherBase };

--- a/packages/publisher/bitbucket/src/PublisherBitbucket.ts
+++ b/packages/publisher/bitbucket/src/PublisherBitbucket.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import { asyncOra } from '@electron-forge/async-ora';
-import PublisherBase, { PublisherOptions } from '@electron-forge/publisher-base';
+import { PublisherBase, PublisherOptions } from '@electron-forge/publisher-base';
 import FormData from 'form-data';
 import fs from 'fs-extra';
 import fetch from 'node-fetch';
@@ -84,4 +84,4 @@ export default class PublisherBitbucket extends PublisherBase<PublisherBitbucket
   }
 }
 
-export { PublisherBitbucketConfig };
+export { PublisherBitbucket, PublisherBitbucketConfig };

--- a/packages/publisher/electron-release-server/src/PublisherERS.ts
+++ b/packages/publisher/electron-release-server/src/PublisherERS.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import { asyncOra } from '@electron-forge/async-ora';
-import PublisherBase, { PublisherOptions } from '@electron-forge/publisher-base';
+import { PublisherBase, PublisherOptions } from '@electron-forge/publisher-base';
 import { ForgeArch, ForgePlatform } from '@electron-forge/shared-types';
 import debug from 'debug';
 import FormData from 'form-data';
@@ -156,4 +156,4 @@ export default class PublisherERS extends PublisherBase<PublisherERSConfig> {
   }
 }
 
-export { PublisherERSConfig };
+export { PublisherERS, PublisherERSConfig };

--- a/packages/publisher/github/src/PublisherGithub.ts
+++ b/packages/publisher/github/src/PublisherGithub.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import { asyncOra } from '@electron-forge/async-ora';
-import PublisherBase, { PublisherOptions } from '@electron-forge/publisher-base';
+import { PublisherBase, PublisherOptions } from '@electron-forge/publisher-base';
 import { ForgeMakeResult } from '@electron-forge/shared-types';
 import { GetResponseDataTypeFromEndpointMethod } from '@octokit/types';
 import fs from 'fs-extra';
@@ -131,4 +131,4 @@ export default class PublisherGithub extends PublisherBase<PublisherGitHubConfig
   }
 }
 
-export { PublisherGitHubConfig };
+export { PublisherGithub, PublisherGitHubConfig };

--- a/packages/publisher/nucleus/src/PublisherNucleus.ts
+++ b/packages/publisher/nucleus/src/PublisherNucleus.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { asyncOra } from '@electron-forge/async-ora';
-import PublisherBase, { PublisherOptions } from '@electron-forge/publisher-base';
+import { PublisherBase, PublisherOptions } from '@electron-forge/publisher-base';
 import debug from 'debug';
 import FormData from 'form-data';
 import fetch from 'node-fetch';
@@ -68,4 +68,4 @@ export default class PublisherNucleus extends PublisherBase<PublisherNucleusConf
   }
 }
 
-export { PublisherNucleusConfig };
+export { PublisherNucleus, PublisherNucleusConfig };

--- a/packages/publisher/s3/src/PublisherS3.ts
+++ b/packages/publisher/s3/src/PublisherS3.ts
@@ -5,7 +5,7 @@ import { S3Client } from '@aws-sdk/client-s3';
 import { Progress, Upload } from '@aws-sdk/lib-storage';
 import { Credentials } from '@aws-sdk/types';
 import { asyncOra } from '@electron-forge/async-ora';
-import PublisherBase, { PublisherOptions } from '@electron-forge/publisher-base';
+import { PublisherBase, PublisherOptions } from '@electron-forge/publisher-base';
 import debug from 'debug';
 
 import { PublisherS3Config } from './Config';
@@ -101,4 +101,4 @@ export default class PublisherS3 extends PublisherBase<PublisherS3Config> {
   }
 }
 
-export { PublisherS3Config };
+export { PublisherS3, PublisherS3Config };

--- a/packages/publisher/snapcraft/src/PublisherSnapcraft.ts
+++ b/packages/publisher/snapcraft/src/PublisherSnapcraft.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import { asyncOra } from '@electron-forge/async-ora';
-import PublisherBase, { PublisherOptions } from '@electron-forge/publisher-base';
+import { PublisherBase, PublisherOptions } from '@electron-forge/publisher-base';
 import fs from 'fs-extra';
 
 import { PublisherSnapcraftConfig } from './Config';
@@ -41,4 +41,4 @@ export default class PublisherSnapcraft extends PublisherBase<PublisherSnapcraft
   }
 }
 
-export { PublisherSnapcraftConfig };
+export { PublisherSnapcraft, PublisherSnapcraftConfig };


### PR DESCRIPTION
This is a small usability thing, importing a named import is a lot easier than a default export and this enforces consistent naming so that we can more easily read code supplied in bug reports.