### PR TITLE
build: configure import/order eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,7 +24,8 @@
         "groups": ["builtin", "external", "internal", "parent", "sibling", "index", "object", "type"],
         "newlines-between": "always",
         "alphabetize": {
-          "order": "asc"
+          "order": "asc",
+          "caseInsensitive": true
         }
       }
     ],
@@ -32,7 +33,8 @@
       "error",
       {
         "ignoreDeclarationSort": true,
-        "allowSeparatedGroups": true
+        "allowSeparatedGroups": true,
+        "ignoreCase": true
       }
     ]
   },

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,10 +28,13 @@
         }
       }
     ],
-    "sort-imports": ["error", {
-      "ignoreDeclarationSort": true,
-      "allowSeparatedGroups": true
-    }]
+    "sort-imports": [
+      "error",
+      {
+        "ignoreDeclarationSort": true,
+        "allowSeparatedGroups": true
+      }
+    ]
   },
   "overrides": [
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["mocha"],
+  "plugins": ["mocha", "import"],
   "env": {
     "mocha": true
   },
@@ -17,7 +17,21 @@
         "vars": "all"
       }
     ],
-    "mocha/no-exclusive-tests": "error"
+    "mocha/no-exclusive-tests": "error",
+    "import/order": [
+      "error",
+      {
+        "groups": ["builtin", "external", "internal", "parent", "sibling", "index", "object", "type"],
+        "newlines-between": "always",
+        "alphabetize": {
+          "order": "asc"
+        }
+      }
+    ],
+    "sort-imports": ["error", {
+      "ignoreDeclarationSort": true,
+      "allowSeparatedGroups": true
+    }]
   },
   "overrides": [
     {

--- a/ci/fix-changelog.js
+++ b/ci/fix-changelog.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+
 const prettier = require('prettier');
 
 const changelogPath = path.resolve(__dirname, '..', 'CHANGELOG.md');

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "cross-env": "^7.0.2",
     "electron-installer-common": "^0.10.2",
     "eslint": "^8.0.1",
-    "eslint-plugin-import": "^2.24.2",
+    "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-mocha": "^9.0.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.0.0",

--- a/packages/api/cli/src/electron-forge-import.ts
+++ b/packages/api/cli/src/electron-forge-import.ts
@@ -1,8 +1,8 @@
-import { api } from '@electron-forge/core';
-
-import fs from 'fs-extra';
-import program from 'commander';
 import path from 'path';
+
+import { api } from '@electron-forge/core';
+import program from 'commander';
+import fs from 'fs-extra';
 
 import './util/terminate';
 import workingDir from './util/working-dir';

--- a/packages/api/cli/src/electron-forge-init.ts
+++ b/packages/api/cli/src/electron-forge-init.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { InitOptions, api } from '@electron-forge/core';
+import { api, InitOptions } from '@electron-forge/core';
 import program from 'commander';
 import fs from 'fs-extra';
 

--- a/packages/api/cli/src/electron-forge-init.ts
+++ b/packages/api/cli/src/electron-forge-init.ts
@@ -1,8 +1,8 @@
-import { api, InitOptions } from '@electron-forge/core';
-
-import fs from 'fs-extra';
-import program from 'commander';
 import path from 'path';
+
+import { InitOptions, api } from '@electron-forge/core';
+import program from 'commander';
+import fs from 'fs-extra';
 
 import './util/terminate';
 import workingDir from './util/working-dir';

--- a/packages/api/cli/src/electron-forge-make.ts
+++ b/packages/api/cli/src/electron-forge-make.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { MakeOptions, api } from '@electron-forge/core';
+import { api, MakeOptions } from '@electron-forge/core';
 import { initializeProxy } from '@electron/get';
 import program from 'commander';
 import fs from 'fs-extra';

--- a/packages/api/cli/src/electron-forge-make.ts
+++ b/packages/api/cli/src/electron-forge-make.ts
@@ -1,9 +1,9 @@
-import { api, MakeOptions } from '@electron-forge/core';
+import path from 'path';
 
-import fs from 'fs-extra';
+import { MakeOptions, api } from '@electron-forge/core';
 import { initializeProxy } from '@electron/get';
 import program from 'commander';
-import path from 'path';
+import fs from 'fs-extra';
 
 import './util/terminate';
 import workingDir from './util/working-dir';

--- a/packages/api/cli/src/electron-forge-package.ts
+++ b/packages/api/cli/src/electron-forge-package.ts
@@ -1,9 +1,9 @@
-import { api, PackageOptions } from '@electron-forge/core';
+import path from 'path';
 
-import fs from 'fs-extra';
+import { PackageOptions, api } from '@electron-forge/core';
 import { initializeProxy } from '@electron/get';
 import program from 'commander';
-import path from 'path';
+import fs from 'fs-extra';
 
 import './util/terminate';
 import workingDir from './util/working-dir';

--- a/packages/api/cli/src/electron-forge-package.ts
+++ b/packages/api/cli/src/electron-forge-package.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { PackageOptions, api } from '@electron-forge/core';
+import { api, PackageOptions } from '@electron-forge/core';
 import { initializeProxy } from '@electron/get';
 import program from 'commander';
 import fs from 'fs-extra';

--- a/packages/api/cli/src/electron-forge-publish.ts
+++ b/packages/api/cli/src/electron-forge-publish.ts
@@ -1,13 +1,13 @@
-import { api, PublishOptions } from '@electron-forge/core';
-
-import fs from 'fs-extra';
-import { initializeProxy } from '@electron/get';
-import program from 'commander';
 import path from 'path';
 
+import { PublishOptions, api } from '@electron-forge/core';
+import { initializeProxy } from '@electron/get';
+import program from 'commander';
+import fs from 'fs-extra';
+
 import './util/terminate';
-import workingDir from './util/working-dir';
 import { getMakeOptions } from './electron-forge-make';
+import workingDir from './util/working-dir';
 
 (async () => {
   let dir = process.cwd();

--- a/packages/api/cli/src/electron-forge-publish.ts
+++ b/packages/api/cli/src/electron-forge-publish.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { PublishOptions, api } from '@electron-forge/core';
+import { api, PublishOptions } from '@electron-forge/core';
 import { initializeProxy } from '@electron/get';
 import program from 'commander';
 import fs from 'fs-extra';

--- a/packages/api/cli/src/electron-forge-start.ts
+++ b/packages/api/cli/src/electron-forge-start.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { StartOptions, api } from '@electron-forge/core';
+import { api, StartOptions } from '@electron-forge/core';
 import { ElectronProcess } from '@electron-forge/shared-types';
 import program from 'commander';
 import fs from 'fs-extra';

--- a/packages/api/cli/src/electron-forge-start.ts
+++ b/packages/api/cli/src/electron-forge-start.ts
@@ -1,8 +1,9 @@
-import { api, StartOptions } from '@electron-forge/core';
-import { ElectronProcess } from '@electron-forge/shared-types';
-import fs from 'fs-extra';
 import path from 'path';
+
+import { StartOptions, api } from '@electron-forge/core';
+import { ElectronProcess } from '@electron-forge/shared-types';
 import program from 'commander';
+import fs from 'fs-extra';
 
 import './util/terminate';
 import workingDir from './util/working-dir';

--- a/packages/api/cli/src/util/check-system.ts
+++ b/packages/api/cli/src/util/check-system.ts
@@ -1,12 +1,12 @@
 import { exec } from 'child_process';
-import debug from 'debug';
-import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
-import semver from 'semver';
 
-import { utils as forgeUtils } from '@electron-forge/core';
 import { OraImpl } from '@electron-forge/async-ora';
+import { utils as forgeUtils } from '@electron-forge/core';
+import debug from 'debug';
+import fs from 'fs-extra';
+import semver from 'semver';
 
 const d = debug('electron-forge:check-system');
 

--- a/packages/api/cli/src/util/working-dir.ts
+++ b/packages/api/cli/src/util/working-dir.ts
@@ -1,5 +1,6 @@
-import fs from 'fs-extra';
 import path from 'path';
+
+import fs from 'fs-extra';
 
 export default function workingDir(dir: string, cwd: string, checkExisting = true): string {
   let finalDir = dir;

--- a/packages/api/cli/test/cli_spec.ts
+++ b/packages/api/cli/test/cli_spec.ts
@@ -1,7 +1,8 @@
+import path from 'path';
+
+import { spawn } from '@malept/cross-spawn-promise';
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import path from 'path';
-import { spawn } from '@malept/cross-spawn-promise';
 
 chai.use(chaiAsPromised);
 

--- a/packages/api/core/src/api/import.ts
+++ b/packages/api/core/src/api/import.ts
@@ -1,20 +1,21 @@
+import path from 'path';
+
 import { asyncOra } from '@electron-forge/async-ora';
 import baseTemplate from '@electron-forge/template-base';
 import chalk from 'chalk';
 import debug from 'debug';
 import fs from 'fs-extra';
 import { merge } from 'lodash';
-import path from 'path';
-
-import initGit from './init-scripts/init-git';
-import { deps, devDeps, exactDevDeps } from './init-scripts/init-npm';
 
 import { updateElectronDependency } from '../util/electron-version';
 import { setInitialForgeConfig } from '../util/forge-config';
-import { info, warn } from '../util/messages';
 import installDepList, { DepType, DepVersionRestriction } from '../util/install-dependencies';
+import { info, warn } from '../util/messages';
 import { readRawPackageJson } from '../util/read-package-json';
 import upgradeForgeConfig, { updateUpgradedForgeDevDeps } from '../util/upgrade-forge-config';
+
+import initGit from './init-scripts/init-git';
+import { deps, devDeps, exactDevDeps } from './init-scripts/init-npm';
 
 const d = debug('electron-forge:import');
 

--- a/packages/api/core/src/api/index.ts
+++ b/packages/api/core/src/api/index.ts
@@ -1,13 +1,13 @@
 import { ElectronProcess, ForgeMakeResult } from '@electron-forge/shared-types';
 
+import ForgeUtils from '../util';
+
 import _import, { ImportOptions } from './import';
 import init, { InitOptions } from './init';
 import make, { MakeOptions } from './make';
 import _package, { PackageOptions } from './package';
 import publish, { PublishOptions } from './publish';
 import start, { StartOptions } from './start';
-
-import ForgeUtils from '../util';
 
 export class ForgeAPI {
   /**

--- a/packages/api/core/src/api/init-scripts/find-template.ts
+++ b/packages/api/core/src/api/init-scripts/find-template.ts
@@ -1,8 +1,8 @@
 import { asyncOra } from '@electron-forge/async-ora';
+import { ForgeTemplate } from '@electron-forge/shared-types';
 import debug from 'debug';
 import resolvePackage from 'resolve-package';
 
-import { ForgeTemplate } from '@electron-forge/shared-types';
 import { PossibleModule } from '../../util/require-search';
 
 const d = debug('electron-forge:init:find-template');

--- a/packages/api/core/src/api/init-scripts/init-git.ts
+++ b/packages/api/core/src/api/init-scripts/init-git.ts
@@ -1,5 +1,6 @@
-import { asyncOra } from '@electron-forge/async-ora';
 import { exec } from 'child_process';
+
+import { asyncOra } from '@electron-forge/async-ora';
 import debug from 'debug';
 
 const d = debug('electron-forge:init:git');

--- a/packages/api/core/src/api/init-scripts/init-npm.ts
+++ b/packages/api/core/src/api/init-scripts/init-npm.ts
@@ -1,7 +1,8 @@
+import path from 'path';
+
 import { asyncOra } from '@electron-forge/async-ora';
 import debug from 'debug';
 import fs from 'fs-extra';
-import path from 'path';
 
 import installDepList, { DepType, DepVersionRestriction } from '../../util/install-dependencies';
 

--- a/packages/api/core/src/api/init.ts
+++ b/packages/api/core/src/api/init.ts
@@ -1,17 +1,19 @@
-import { asyncOra } from '@electron-forge/async-ora';
-import debug from 'debug';
-import { ForgeTemplate } from '@electron-forge/shared-types';
-import fs from 'fs-extra';
 import path from 'path';
+
+import { asyncOra } from '@electron-forge/async-ora';
+import { ForgeTemplate } from '@electron-forge/shared-types';
+import debug from 'debug';
+import fs from 'fs-extra';
 import semver from 'semver';
+
+import { setInitialForgeConfig } from '../util/forge-config';
+import installDepList, { DepType } from '../util/install-dependencies';
+import { readRawPackageJson } from '../util/read-package-json';
 
 import findTemplate from './init-scripts/find-template';
 import initDirectory from './init-scripts/init-directory';
 import initGit from './init-scripts/init-git';
 import initNPM from './init-scripts/init-npm';
-import installDepList, { DepType } from '../util/install-dependencies';
-import { readRawPackageJson } from '../util/read-package-json';
-import { setInitialForgeConfig } from '../util/forge-config';
 
 const d = debug('electron-forge:init');
 

--- a/packages/api/core/src/api/make.ts
+++ b/packages/api/core/src/api/make.ts
@@ -1,21 +1,22 @@
-import { asyncOra } from '@electron-forge/async-ora';
-import chalk from 'chalk';
-import { getHostArch } from '@electron/get';
-import { IForgeResolvableMaker, ForgeConfig, ForgeArch, ForgePlatform, ForgeMakeResult, ForgeConfigMaker } from '@electron-forge/shared-types';
-import MakerBase from '@electron-forge/maker-base';
-import fs from 'fs-extra';
 import path from 'path';
-import filenamify from 'filenamify';
 
+import { asyncOra } from '@electron-forge/async-ora';
+import MakerBase from '@electron-forge/maker-base';
+import { ForgeArch, ForgeConfig, ForgeConfigMaker, ForgeMakeResult, ForgePlatform, IForgeResolvableMaker } from '@electron-forge/shared-types';
+import { getHostArch } from '@electron/get';
+import chalk from 'chalk';
+import filenamify from 'filenamify';
+import fs from 'fs-extra';
+
+import { getElectronVersion } from '../util/electron-version';
 import getForgeConfig from '../util/forge-config';
 import { runHook, runMutatingHook } from '../util/hook';
 import { info, warn } from '../util/messages';
+import getCurrentOutDir from '../util/out-dir';
 import parseArchs from '../util/parse-archs';
 import { readMutatedPackageJson } from '../util/read-package-json';
-import resolveDir from '../util/resolve-dir';
-import getCurrentOutDir from '../util/out-dir';
-import { getElectronVersion } from '../util/electron-version';
 import requireSearch from '../util/require-search';
+import resolveDir from '../util/resolve-dir';
 
 import packager from './package';
 

--- a/packages/api/core/src/api/package.ts
+++ b/packages/api/core/src/api/package.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { promisify } from 'util';
 
-import { OraImpl, fakeOra, ora as realOra } from '@electron-forge/async-ora';
+import { fakeOra, OraImpl, ora as realOra } from '@electron-forge/async-ora';
 import { ForgeArch, ForgePlatform } from '@electron-forge/shared-types';
 import { getHostArch } from '@electron/get';
 import chalk from 'chalk';

--- a/packages/api/core/src/api/package.ts
+++ b/packages/api/core/src/api/package.ts
@@ -1,23 +1,24 @@
-import { ora as realOra, fakeOra, OraImpl } from '@electron-forge/async-ora';
-import { ForgeArch, ForgePlatform } from '@electron-forge/shared-types';
-import chalk from 'chalk';
-import debug from 'debug';
-import fs from 'fs-extra';
-import { getHostArch } from '@electron/get';
-import glob from 'fast-glob';
-import packager, { HookFunction } from 'electron-packager';
 import path from 'path';
 import { promisify } from 'util';
 
+import { OraImpl, fakeOra, ora as realOra } from '@electron-forge/async-ora';
+import { ForgeArch, ForgePlatform } from '@electron-forge/shared-types';
+import { getHostArch } from '@electron/get';
+import chalk from 'chalk';
+import debug from 'debug';
+import packager, { HookFunction } from 'electron-packager';
+import glob from 'fast-glob';
+import fs from 'fs-extra';
+
+import { getElectronVersion } from '../util/electron-version';
 import getForgeConfig from '../util/forge-config';
 import { runHook } from '../util/hook';
 import { warn } from '../util/messages';
+import getCurrentOutDir from '../util/out-dir';
 import { readMutatedPackageJson } from '../util/read-package-json';
 import rebuildHook from '../util/rebuild';
 import requireSearch from '../util/require-search';
 import resolveDir from '../util/resolve-dir';
-import getCurrentOutDir from '../util/out-dir';
-import { getElectronVersion } from '../util/electron-version';
 
 const d = debug('electron-forge:packager');
 

--- a/packages/api/core/src/api/publish.ts
+++ b/packages/api/core/src/api/publish.ts
@@ -1,25 +1,25 @@
+import path from 'path';
+
 import { asyncOra } from '@electron-forge/async-ora';
+import PublisherBase from '@electron-forge/publisher-base';
 import {
-  IForgeResolvablePublisher,
-  IForgePublisher,
   ForgeConfigPublisher,
   ForgeMakeResult,
+  IForgePublisher,
+  IForgeResolvablePublisher,
   // ForgePlatform,
 } from '@electron-forge/shared-types';
-import PublisherBase from '@electron-forge/publisher-base';
-
 import chalk from 'chalk';
 import debug from 'debug';
 import fs from 'fs-extra';
-import path from 'path';
 
 import getForgeConfig from '../util/forge-config';
-import resolveDir from '../util/resolve-dir';
-import PublishState from '../util/publish-state';
 import getCurrentOutDir from '../util/out-dir';
+import PublishState from '../util/publish-state';
+import requireSearch from '../util/require-search';
+import resolveDir from '../util/resolve-dir';
 
 import make, { MakeOptions } from './make';
-import requireSearch from '../util/require-search';
 
 const d = debug('electron-forge:publish');
 

--- a/packages/api/core/src/api/start.ts
+++ b/packages/api/core/src/api/start.ts
@@ -1,16 +1,17 @@
+import { SpawnOptions, spawn } from 'child_process';
+
 import { asyncOra } from '@electron-forge/async-ora';
+import { ElectronProcess, ForgeArch, ForgePlatform, StartOptions } from '@electron-forge/shared-types';
 import chalk from 'chalk';
 import debug from 'debug';
-import { ElectronProcess, ForgeArch, ForgePlatform, StartOptions } from '@electron-forge/shared-types';
-import { spawn, SpawnOptions } from 'child_process';
 
+import locateElectronExecutable from '../util/electron-executable';
 import { getElectronVersion } from '../util/electron-version';
 import getForgeConfig from '../util/forge-config';
-import locateElectronExecutable from '../util/electron-executable';
+import { runHook } from '../util/hook';
 import { readMutatedPackageJson } from '../util/read-package-json';
 import rebuild from '../util/rebuild';
 import resolveDir from '../util/resolve-dir';
-import { runHook } from '../util/hook';
 
 const d = debug('electron-forge:start');
 

--- a/packages/api/core/src/api/start.ts
+++ b/packages/api/core/src/api/start.ts
@@ -1,4 +1,4 @@
-import { SpawnOptions, spawn } from 'child_process';
+import { spawn, SpawnOptions } from 'child_process';
 
 import { asyncOra } from '@electron-forge/async-ora';
 import { ElectronProcess, ForgeArch, ForgePlatform, StartOptions } from '@electron-forge/shared-types';

--- a/packages/api/core/src/util/download-to-file.ts
+++ b/packages/api/core/src/util/download-to-file.ts
@@ -1,6 +1,7 @@
+import * as path from 'path';
+
 import * as fs from 'fs-extra';
 import got, { HTTPError } from 'got';
-import * as path from 'path';
 import ProgressBar from 'progress';
 
 const PROGRESS_BAR_DELAY_IN_SECONDS = 30;

--- a/packages/api/core/src/util/electron-executable.ts
+++ b/packages/api/core/src/util/electron-executable.ts
@@ -1,6 +1,7 @@
+import path from 'path';
+
 import chalk from 'chalk';
 import logSymbols from 'log-symbols';
-import path from 'path';
 
 import { getElectronModulePath } from './electron-version';
 

--- a/packages/api/core/src/util/electron-version.ts
+++ b/packages/api/core/src/util/electron-version.ts
@@ -1,8 +1,10 @@
+import path from 'path';
+
 import debug from 'debug';
 import findUp from 'find-up';
 import fs from 'fs-extra';
-import path from 'path';
 import semver from 'semver';
+
 import yarnOrNpm from './yarn-or-npm';
 
 const d = debug('electron-forge:electron-version');

--- a/packages/api/core/src/util/forge-config.ts
+++ b/packages/api/core/src/util/forge-config.ts
@@ -1,11 +1,12 @@
+import path from 'path';
+
 import { ForgeConfig, IForgeResolvableMaker } from '@electron-forge/shared-types';
 import fs from 'fs-extra';
-import path from 'path';
 import { template } from 'lodash';
 
-import { readRawPackageJson } from './read-package-json';
-import PluginInterface from './plugin-interface';
 import { runMutatingHook } from './hook';
+import PluginInterface from './plugin-interface';
+import { readRawPackageJson } from './read-package-json';
 
 const underscoreCase = (str: string) =>
   str

--- a/packages/api/core/src/util/index.ts
+++ b/packages/api/core/src/util/index.ts
@@ -1,7 +1,7 @@
-import { BuildIdentifierConfig, BuildIdentifierMap, fromBuildIdentifier } from './forge-config';
 import { getElectronVersion } from './electron-version';
-import { hasYarn, yarnOrNpmSpawn } from './yarn-or-npm';
+import { BuildIdentifierConfig, BuildIdentifierMap, fromBuildIdentifier } from './forge-config';
 import rebuildHook from './rebuild';
+import { hasYarn, yarnOrNpmSpawn } from './yarn-or-npm';
 
 export default class ForgeUtils {
   /**

--- a/packages/api/core/src/util/install-dependencies.ts
+++ b/packages/api/core/src/util/install-dependencies.ts
@@ -1,6 +1,7 @@
-import debug from 'debug';
 import { ExitError } from '@malept/cross-spawn-promise';
-import { yarnOrNpmSpawn, hasYarn } from './yarn-or-npm';
+import debug from 'debug';
+
+import { hasYarn, yarnOrNpmSpawn } from './yarn-or-npm';
 
 const d = debug('electron-forge:dependency-installer');
 

--- a/packages/api/core/src/util/linux-installer.ts
+++ b/packages/api/core/src/util/linux-installer.ts
@@ -1,5 +1,6 @@
-import { promisify } from 'util';
 import { spawnSync } from 'child_process';
+import { promisify } from 'util';
+
 import sudoPrompt from 'sudo-prompt';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/api/core/src/util/out-dir.ts
+++ b/packages/api/core/src/util/out-dir.ts
@@ -1,5 +1,6 @@
-import { ForgeConfig } from '@electron-forge/shared-types';
 import path from 'path';
+
+import { ForgeConfig } from '@electron-forge/shared-types';
 
 const BASE_OUT_DIR = 'out';
 

--- a/packages/api/core/src/util/parse-archs.ts
+++ b/packages/api/core/src/util/parse-archs.ts
@@ -1,4 +1,4 @@
-import { ForgePlatform, ForgeArch } from '@electron-forge/shared-types';
+import { ForgeArch, ForgePlatform } from '@electron-forge/shared-types';
 
 // TODO: convert to an import statement when this is a public API
 // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/packages/api/core/src/util/plugin-interface.ts
+++ b/packages/api/core/src/util/plugin-interface.ts
@@ -1,8 +1,9 @@
 import PluginBase from '@electron-forge/plugin-base';
-import { IForgePluginInterface, ForgeConfig, IForgePlugin, StartResult } from '@electron-forge/shared-types';
+import { ForgeConfig, IForgePlugin, IForgePluginInterface, StartResult } from '@electron-forge/shared-types';
 import debug from 'debug';
 
 import { StartOptions } from '../api';
+
 import requireSearch from './require-search';
 
 const d = debug('electron-forge:plugins');

--- a/packages/api/core/src/util/publish-state.ts
+++ b/packages/api/core/src/util/publish-state.ts
@@ -1,7 +1,8 @@
-import { ForgeMakeResult } from '@electron-forge/shared-types';
 import crypto from 'crypto';
-import fs from 'fs-extra';
 import path from 'path';
+
+import { ForgeMakeResult } from '@electron-forge/shared-types';
+import fs from 'fs-extra';
 
 const EXTENSION = '.forge.publish';
 

--- a/packages/api/core/src/util/read-package-json.ts
+++ b/packages/api/core/src/util/read-package-json.ts
@@ -1,6 +1,7 @@
+import path from 'path';
+
 import { ForgeConfig } from '@electron-forge/shared-types';
 import fs from 'fs-extra';
-import path from 'path';
 
 import { runMutatingHook } from './hook';
 

--- a/packages/api/core/src/util/rebuild.ts
+++ b/packages/api/core/src/util/rebuild.ts
@@ -1,7 +1,6 @@
 import { asyncOra } from '@electron-forge/async-ora';
-import { ForgePlatform, ForgeArch } from '@electron-forge/shared-types';
-
-import { rebuild, RebuildOptions } from 'electron-rebuild';
+import { ForgeArch, ForgePlatform } from '@electron-forge/shared-types';
+import { RebuildOptions, rebuild } from 'electron-rebuild';
 
 export default async (
   buildPath: string,

--- a/packages/api/core/src/util/rebuild.ts
+++ b/packages/api/core/src/util/rebuild.ts
@@ -1,6 +1,6 @@
 import { asyncOra } from '@electron-forge/async-ora';
 import { ForgeArch, ForgePlatform } from '@electron-forge/shared-types';
-import { RebuildOptions, rebuild } from 'electron-rebuild';
+import { rebuild, RebuildOptions } from 'electron-rebuild';
 
 export default async (
   buildPath: string,

--- a/packages/api/core/src/util/require-search.ts
+++ b/packages/api/core/src/util/require-search.ts
@@ -1,5 +1,6 @@
-import debug from 'debug';
 import path from 'path';
+
+import debug from 'debug';
 
 const d = debug('electron-forge:require-search');
 

--- a/packages/api/core/src/util/resolve-dir.ts
+++ b/packages/api/core/src/util/resolve-dir.ts
@@ -1,8 +1,10 @@
+import path from 'path';
+
 import debug from 'debug';
 import fs from 'fs-extra';
-import path from 'path';
-import { readRawPackageJson } from './read-package-json';
+
 import { getElectronVersion } from './electron-version';
+import { readRawPackageJson } from './read-package-json';
 
 const d = debug('electron-forge:project-resolver');
 

--- a/packages/api/core/src/util/upgrade-forge-config.ts
+++ b/packages/api/core/src/util/upgrade-forge-config.ts
@@ -1,5 +1,7 @@
-import { ForgeConfig, ForgePlatform, IForgeResolvableMaker, IForgeResolvablePublisher } from '@electron-forge/shared-types';
 import path from 'path';
+
+import { ForgeConfig, ForgePlatform, IForgeResolvableMaker, IForgeResolvablePublisher } from '@electron-forge/shared-types';
+
 import { siblingDep } from '../api/init-scripts/init-npm';
 
 type MakeTargets = { string: string[] };

--- a/packages/api/core/src/util/yarn-or-npm.ts
+++ b/packages/api/core/src/util/yarn-or-npm.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import { CrossSpawnArgs, CrossSpawnOptions, spawn } from '@malept/cross-spawn-promise';
+import chalk from 'chalk';
 import logSymbols from 'log-symbols';
 import yarnOrNpm from 'yarn-or-npm';
 

--- a/packages/api/core/test/fast/electron-executable_spec.ts
+++ b/packages/api/core/test/fast/electron-executable_spec.ts
@@ -1,5 +1,6 @@
-import chai, { expect } from 'chai';
 import path from 'path';
+
+import chai, { expect } from 'chai';
 import { createSandbox } from 'sinon';
 import sinonChai from 'sinon-chai';
 

--- a/packages/api/core/test/fast/electron-version_spec.ts
+++ b/packages/api/core/test/fast/electron-version_spec.ts
@@ -1,9 +1,11 @@
-import { expect } from 'chai';
-import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
-import { getElectronModulePath, getElectronVersion, updateElectronDependency } from '../../src/util/electron-version';
+
+import { expect } from 'chai';
+import fs from 'fs-extra';
+
 import { devDeps, exactDevDeps } from '../../src/api/init-scripts/init-npm';
+import { getElectronModulePath, getElectronVersion, updateElectronDependency } from '../../src/util/electron-version';
 
 describe('updateElectronDependency', () => {
   it('adds an Electron dep if one does not already exist', () => {

--- a/packages/api/core/test/fast/forge-config_spec.ts
+++ b/packages/api/core/test/fast/forge-config_spec.ts
@@ -4,8 +4,8 @@ import { ForgeConfig } from '@electron-forge/shared-types';
 import { expect } from 'chai';
 
 import findConfig, {
-  PackageJSONForInitialForgeConfig,
   forgeConfigIsValidFilePath,
+  PackageJSONForInitialForgeConfig,
   renderConfigTemplate,
   setInitialForgeConfig,
 } from '../../src/util/forge-config';

--- a/packages/api/core/test/fast/forge-config_spec.ts
+++ b/packages/api/core/test/fast/forge-config_spec.ts
@@ -1,10 +1,11 @@
-import { expect } from 'chai';
-import { ForgeConfig } from '@electron-forge/shared-types';
 import path from 'path';
 
+import { ForgeConfig } from '@electron-forge/shared-types';
+import { expect } from 'chai';
+
 import findConfig, {
-  forgeConfigIsValidFilePath,
   PackageJSONForInitialForgeConfig,
+  forgeConfigIsValidFilePath,
   renderConfigTemplate,
   setInitialForgeConfig,
 } from '../../src/util/forge-config';

--- a/packages/api/core/test/fast/hook_spec.ts
+++ b/packages/api/core/test/fast/hook_spec.ts
@@ -1,6 +1,6 @@
 import { ForgeConfig, ForgeHookFn } from '@electron-forge/shared-types';
 import { expect } from 'chai';
-import { stub, SinonStub } from 'sinon';
+import { SinonStub, stub } from 'sinon';
 
 import { runHook, runMutatingHook } from '../../src/util/hook';
 

--- a/packages/api/core/test/fast/make_spec.ts
+++ b/packages/api/core/test/fast/make_spec.ts
@@ -1,6 +1,7 @@
-import { expect } from 'chai';
-import { ForgeMakeResult } from '@electron-forge/shared-types';
 import * as path from 'path';
+
+import { ForgeMakeResult } from '@electron-forge/shared-types';
+import { expect } from 'chai';
 import proxyquire from 'proxyquire';
 
 import { MakeOptions } from '../../src/api';

--- a/packages/api/core/test/fast/out-dir_spec.ts
+++ b/packages/api/core/test/fast/out-dir_spec.ts
@@ -1,6 +1,7 @@
+import path from 'path';
+
 import { ForgeConfig } from '@electron-forge/shared-types';
 import { expect } from 'chai';
-import path from 'path';
 
 import getCurrentOutDir from '../../src/util/out-dir';
 

--- a/packages/api/core/test/fast/publish_spec.ts
+++ b/packages/api/core/test/fast/publish_spec.ts
@@ -1,8 +1,9 @@
-import { expect } from 'chai';
-import fs from 'fs-extra';
-import { ForgeConfigPublisher, IForgePublisher } from '@electron-forge/shared-types';
 import os from 'os';
 import path from 'path';
+
+import { ForgeConfigPublisher, IForgePublisher } from '@electron-forge/shared-types';
+import { expect } from 'chai';
+import fs from 'fs-extra';
 import proxyquire from 'proxyquire';
 import { SinonStub, stub } from 'sinon';
 

--- a/packages/api/core/test/fast/read-package-json_spec.ts
+++ b/packages/api/core/test/fast/read-package-json_spec.ts
@@ -1,8 +1,9 @@
-import { ForgeConfig } from '@electron-forge/shared-types';
-import { expect } from 'chai';
 import path from 'path';
 
-import { readRawPackageJson, readMutatedPackageJson } from '../../src/util/read-package-json';
+import { ForgeConfig } from '@electron-forge/shared-types';
+import { expect } from 'chai';
+
+import { readMutatedPackageJson, readRawPackageJson } from '../../src/util/read-package-json';
 
 const emptyForgeConfig: Partial<ForgeConfig> = {
   packagerConfig: {},

--- a/packages/api/core/test/fast/require-search_spec.ts
+++ b/packages/api/core/test/fast/require-search_spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 
-import requireSearch from '../../src/util/require-search';
 import findConfig from '../../src/util/forge-config';
+import requireSearch from '../../src/util/require-search';
 
 describe('require-search', () => {
   it('should resolve null if no file exists', () => {

--- a/packages/api/core/test/fast/resolve-dir_spec.ts
+++ b/packages/api/core/test/fast/resolve-dir_spec.ts
@@ -1,5 +1,6 @@
-import { expect } from 'chai';
 import path from 'path';
+
+import { expect } from 'chai';
 
 import resolveDir from '../../src/util/resolve-dir';
 

--- a/packages/api/core/test/fast/yarn-or-npm_spec.ts
+++ b/packages/api/core/test/fast/yarn-or-npm_spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
-
 import systemYarnOrNpm from 'yarn-or-npm';
+
 import yarnOrNpm from '../../src/util/yarn-or-npm';
 
 describe('yarn-or-npm', () => {

--- a/packages/api/core/test/fixture/custom-maker.ts
+++ b/packages/api/core/test/fixture/custom-maker.ts
@@ -1,5 +1,5 @@
-import { ForgePlatform } from '@electron-forge/shared-types';
 import MakerBase from '@electron-forge/maker-base';
+import { ForgePlatform } from '@electron-forge/shared-types';
 
 interface Config {
   artifactPath: string;

--- a/packages/api/core/test/fixture/custom_init/index.js
+++ b/packages/api/core/test/fixture/custom_init/index.js
@@ -1,6 +1,7 @@
+const path = require('path');
+
 const baseTemplate = require('@electron-forge/template-base').default;
 const fs = require('fs-extra');
-const path = require('path');
 
 module.exports = {
   requiredForgeVersion: '>= 6.0.0-beta.1',

--- a/packages/api/core/test/slow/api_spec_slow.ts
+++ b/packages/api/core/test/slow/api_spec_slow.ts
@@ -1,16 +1,17 @@
-import { createDefaultCertificate } from '@electron-forge/maker-appx';
-import { ensureTestDirIsNonexistent, expectLintToPass, expectProjectPathExists } from '@electron-forge/test-utils';
 import { execSync } from 'child_process';
-import { expect } from 'chai';
-import { ForgeConfig, IForgeResolvableMaker } from '@electron-forge/shared-types';
-import fs from 'fs-extra';
 import path from 'path';
-import proxyquire from 'proxyquire';
-import { readMetadata } from 'electron-installer-common';
 
+import { createDefaultCertificate } from '@electron-forge/maker-appx';
+import { ForgeConfig, IForgeResolvableMaker } from '@electron-forge/shared-types';
+import { ensureTestDirIsNonexistent, expectLintToPass, expectProjectPathExists } from '@electron-forge/test-utils';
+import { expect } from 'chai';
+import { readMetadata } from 'electron-installer-common';
+import fs from 'fs-extra';
+import proxyquire from 'proxyquire';
+
+import { InitOptions } from '../../src/api';
 import installDeps from '../../src/util/install-dependencies';
 import { readRawPackageJson } from '../../src/util/read-package-json';
-import { InitOptions } from '../../src/api';
 
 const forge = proxyquire.noCallThru().load('../../src/api', {
   './install': async () => {

--- a/packages/api/core/test/slow/init_git_spec_slow.ts
+++ b/packages/api/core/test/slow/init_git_spec_slow.ts
@@ -1,9 +1,9 @@
 import { execSync } from 'child_process';
-import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
 
 import { expect } from 'chai';
+import fs from 'fs-extra';
 
 import initGit from '../../src/api/init-scripts/init-git';
 

--- a/packages/api/core/test/slow/install-dependencies_spec_slow.ts
+++ b/packages/api/core/test/slow/install-dependencies_spec_slow.ts
@@ -1,7 +1,8 @@
-import { expect } from 'chai';
-import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
+
+import { expect } from 'chai';
+import fs from 'fs-extra';
 
 import installDeps from '../../src/util/install-dependencies';
 

--- a/packages/maker/appx/src/MakerAppX.ts
+++ b/packages/maker/appx/src/MakerAppX.ts
@@ -1,14 +1,14 @@
+import path from 'path';
+
 import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';
-
-import fs from 'fs-extra';
-import path from 'path';
 import resolveCommand from 'cross-spawn/lib/util/resolveCommand';
 import windowsStore from 'electron-windows-store';
 import { isValidPublisherName, makeCert } from 'electron-windows-store/lib/sign';
+import fs from 'fs-extra';
 
-import getNameFromAuthor from './util/author-name';
 import { MakerAppXConfig } from './Config';
+import getNameFromAuthor from './util/author-name';
 
 // NB: This is not a typo, we require AppXs to be built on 64-bit
 // but if we're running in a 32-bit node.js process, we're going to

--- a/packages/maker/appx/src/util/author-name.ts
+++ b/packages/maker/appx/src/util/author-name.ts
@@ -1,5 +1,5 @@
-import parseAuthor from 'parse-author';
 import { PackagePerson } from '@electron-forge/shared-types';
+import parseAuthor from 'parse-author';
 
 export default function getNameFromAuthor(author: PackagePerson): string {
   let publisher: PackagePerson = author || '';

--- a/packages/maker/appx/test/MakerAppX_spec.ts
+++ b/packages/maker/appx/test/MakerAppX_spec.ts
@@ -1,7 +1,8 @@
 import { tmpdir } from 'os';
 import { join } from 'path';
-import fs from 'fs-extra';
+
 import { expect } from 'chai';
+import fs from 'fs-extra';
 
 import { createDefaultCertificate } from '../src/MakerAppX';
 

--- a/packages/maker/base/src/Maker.ts
+++ b/packages/maker/base/src/Maker.ts
@@ -1,6 +1,7 @@
+import path from 'path';
+
 import { ForgeArch, ForgeConfig, ForgePlatform, IForgeMaker } from '@electron-forge/shared-types';
 import fs from 'fs-extra';
-import path from 'path';
 import which from 'which';
 
 export type EmptyConfig = Record<string, never>;

--- a/packages/maker/base/test/ensure-output_spec.ts
+++ b/packages/maker/base/test/ensure-output_spec.ts
@@ -1,7 +1,8 @@
-import { expect } from 'chai';
-import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
+
+import { expect } from 'chai';
+import fs from 'fs-extra';
 
 import MakerBase, { EmptyConfig } from '../src/Maker';
 

--- a/packages/maker/deb/src/MakerDeb.ts
+++ b/packages/maker/deb/src/MakerDeb.ts
@@ -1,6 +1,7 @@
+import path from 'path';
+
 import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
 import { ForgeArch, ForgePlatform } from '@electron-forge/shared-types';
-import path from 'path';
 
 import { MakerDebConfig } from './Config';
 

--- a/packages/maker/deb/test/MakerDeb_spec.ts
+++ b/packages/maker/deb/test/MakerDeb_spec.ts
@@ -1,10 +1,10 @@
+import path from 'path';
+
 import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
 import { ForgeArch } from '@electron-forge/shared-types';
-
 import { expect } from 'chai';
-import path from 'path';
 import proxyquire from 'proxyquire';
-import { stub, SinonStub } from 'sinon';
+import { SinonStub, stub } from 'sinon';
 
 import { MakerDebConfig } from '../src/Config';
 import { debianArch } from '../src/MakerDeb';

--- a/packages/maker/dmg/src/MakerDMG.ts
+++ b/packages/maker/dmg/src/MakerDMG.ts
@@ -1,8 +1,9 @@
+import path from 'path';
+
 import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';
-
 import fs from 'fs-extra';
-import path from 'path';
+
 import { MakerDMGConfig } from './Config';
 
 export default class MakerDMG extends MakerBase<MakerDMGConfig> {

--- a/packages/maker/dmg/test/MakerDMG_spec.ts
+++ b/packages/maker/dmg/test/MakerDMG_spec.ts
@@ -1,10 +1,10 @@
+import path from 'path';
+
 import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
 import { ForgeArch } from '@electron-forge/shared-types';
-
 import { expect } from 'chai';
-import path from 'path';
 import proxyquire from 'proxyquire';
-import { stub, SinonStub } from 'sinon';
+import { SinonStub, stub } from 'sinon';
 
 import { MakerDMGConfig } from '../src/Config';
 

--- a/packages/maker/flatpak/src/MakerFlatpak.ts
+++ b/packages/maker/flatpak/src/MakerFlatpak.ts
@@ -1,8 +1,8 @@
+import path from 'path';
+
 import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
 import { ForgeArch, ForgePlatform } from '@electron-forge/shared-types';
-
 import fs from 'fs-extra';
-import path from 'path';
 
 import { MakerFlatpakConfig } from './Config';
 

--- a/packages/maker/flatpak/test/MakerFlatpak_spec.ts
+++ b/packages/maker/flatpak/test/MakerFlatpak_spec.ts
@@ -1,14 +1,14 @@
+import path from 'path';
+
 import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
 import { ForgeArch } from '@electron-forge/shared-types';
-
 import { expect } from 'chai';
 import 'chai-as-promised';
-import path from 'path';
 import proxyquire from 'proxyquire';
-import { stub, SinonStub } from 'sinon';
+import { SinonStub, stub } from 'sinon';
 
-import { flatpakArch } from '../src/MakerFlatpak';
 import { MakerFlatpakConfig } from '../src/Config';
+import { flatpakArch } from '../src/MakerFlatpak';
 
 type MakeFunction = (opts: Partial<MakerOptions>) => Promise<string[]>;
 

--- a/packages/maker/pkg/src/MakerPKG.ts
+++ b/packages/maker/pkg/src/MakerPKG.ts
@@ -1,8 +1,9 @@
+import path from 'path';
+
 import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';
 import { flatAsync } from '@electron/osx-sign';
 
-import path from 'path';
 import { MakerPKGConfig } from './Config';
 
 export default class MakerPKG extends MakerBase<MakerPKGConfig> {

--- a/packages/maker/pkg/test/MakerPKG_spec.ts
+++ b/packages/maker/pkg/test/MakerPKG_spec.ts
@@ -1,10 +1,10 @@
+import path from 'path';
+
 import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
 import { ForgeArch } from '@electron-forge/shared-types';
-
 import { expect } from 'chai';
-import path from 'path';
 import proxyquire from 'proxyquire';
-import { stub, SinonStub } from 'sinon';
+import { SinonStub, stub } from 'sinon';
 
 import { MakerPKGConfig } from '../src/Config';
 

--- a/packages/maker/rpm/src/MakerRpm.ts
+++ b/packages/maker/rpm/src/MakerRpm.ts
@@ -1,6 +1,7 @@
+import path from 'path';
+
 import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
 import { ForgeArch, ForgePlatform } from '@electron-forge/shared-types';
-import path from 'path';
 
 import { MakerRpmConfig } from './Config';
 

--- a/packages/maker/rpm/test/MakerRpm_spec.ts
+++ b/packages/maker/rpm/test/MakerRpm_spec.ts
@@ -1,10 +1,10 @@
-import { ForgeArch } from '@electron-forge/shared-types';
-import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
-
-import { expect } from 'chai';
 import path from 'path';
+
+import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
+import { ForgeArch } from '@electron-forge/shared-types';
+import { expect } from 'chai';
 import proxyquire from 'proxyquire';
-import { stub, SinonStub } from 'sinon';
+import { SinonStub, stub } from 'sinon';
 
 import { MakerRpmConfig } from '../src/Config';
 import { rpmArch } from '../src/MakerRpm';

--- a/packages/maker/snap/src/MakerSnap.ts
+++ b/packages/maker/snap/src/MakerSnap.ts
@@ -1,6 +1,7 @@
-import { ForgePlatform } from '@electron-forge/shared-types';
-import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
 import path from 'path';
+
+import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
+import { ForgePlatform } from '@electron-forge/shared-types';
 
 import { MakerSnapConfig } from './Config';
 

--- a/packages/maker/snap/test/MakerSnap_spec.ts
+++ b/packages/maker/snap/test/MakerSnap_spec.ts
@@ -1,10 +1,10 @@
-import { ForgeArch } from '@electron-forge/shared-types';
-import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
-
-import { expect } from 'chai';
 import path from 'path';
+
+import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
+import { ForgeArch } from '@electron-forge/shared-types';
+import { expect } from 'chai';
 import proxyquire from 'proxyquire';
-import { stub, SinonStub } from 'sinon';
+import { SinonStub, stub } from 'sinon';
 
 import { MakerSnapConfig } from '../src/Config';
 

--- a/packages/maker/squirrel/src/MakerSquirrel.ts
+++ b/packages/maker/squirrel/src/MakerSquirrel.ts
@@ -2,7 +2,7 @@ import path from 'path';
 
 import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';
-import { Options as ElectronWinstallerOptions, convertVersion, createWindowsInstaller } from 'electron-winstaller';
+import { convertVersion, createWindowsInstaller, Options as ElectronWinstallerOptions } from 'electron-winstaller';
 import fs from 'fs-extra';
 
 export type MakerSquirrelConfig = Omit<ElectronWinstallerOptions, 'appDirectory' | 'outputDirectory'>;

--- a/packages/maker/squirrel/src/MakerSquirrel.ts
+++ b/packages/maker/squirrel/src/MakerSquirrel.ts
@@ -1,9 +1,9 @@
+import path from 'path';
+
 import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';
-
-import { convertVersion, createWindowsInstaller, Options as ElectronWinstallerOptions } from 'electron-winstaller';
+import { Options as ElectronWinstallerOptions, convertVersion, createWindowsInstaller } from 'electron-winstaller';
 import fs from 'fs-extra';
-import path from 'path';
 
 export type MakerSquirrelConfig = Omit<ElectronWinstallerOptions, 'appDirectory' | 'outputDirectory'>;
 

--- a/packages/maker/wix/src/Config.ts
+++ b/packages/maker/wix/src/Config.ts
@@ -1,4 +1,4 @@
-import { MSICreator, Features } from 'electron-wix-msi/lib/creator';
+import { Features, MSICreator } from 'electron-wix-msi/lib/creator';
 
 export interface MakerWixConfig {
   /**

--- a/packages/maker/wix/src/MakerWix.ts
+++ b/packages/maker/wix/src/MakerWix.ts
@@ -1,14 +1,13 @@
-import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
-import { ForgePlatform } from '@electron-forge/shared-types';
-
-import chalk from 'chalk';
-import logSymbols from 'log-symbols';
 import path from 'path';
 
+import MakerBase, { MakerOptions } from '@electron-forge/maker-base';
+import { ForgePlatform } from '@electron-forge/shared-types';
+import chalk from 'chalk';
 import { MSICreator, MSICreatorOptions } from 'electron-wix-msi/lib/creator';
-import getNameFromAuthor from './util/author-name';
+import logSymbols from 'log-symbols';
 
 import { MakerWixConfig } from './Config';
+import getNameFromAuthor from './util/author-name';
 
 export default class MakerWix extends MakerBase<MakerWixConfig> {
   name = 'wix';

--- a/packages/maker/wix/src/util/author-name.ts
+++ b/packages/maker/wix/src/util/author-name.ts
@@ -1,5 +1,5 @@
-import parseAuthor from 'parse-author';
 import { PackagePerson } from '@electron-forge/shared-types';
+import parseAuthor from 'parse-author';
 
 export default function getNameFromAuthor(author: PackagePerson): string {
   let publisher: PackagePerson = author || '';

--- a/packages/maker/zip/src/MakerZIP.ts
+++ b/packages/maker/zip/src/MakerZIP.ts
@@ -1,8 +1,8 @@
-import MakerBase, { EmptyConfig, MakerOptions } from '@electron-forge/maker-base';
-import { ForgePlatform } from '@electron-forge/shared-types';
-
 import path from 'path';
 import { promisify } from 'util';
+
+import MakerBase, { EmptyConfig, MakerOptions } from '@electron-forge/maker-base';
+import { ForgePlatform } from '@electron-forge/shared-types';
 
 export type MakerZIPConfig = EmptyConfig;
 

--- a/packages/plugin/auto-unpack-natives/src/AutoUnpackNativesPlugin.ts
+++ b/packages/plugin/auto-unpack-natives/src/AutoUnpackNativesPlugin.ts
@@ -1,5 +1,5 @@
-import { ForgeConfig, ForgeHookFn } from '@electron-forge/shared-types';
 import PluginBase from '@electron-forge/plugin-base';
+import { ForgeConfig, ForgeHookFn } from '@electron-forge/shared-types';
 
 import { AutoUnpackNativesConfig } from './Config';
 

--- a/packages/plugin/compile/src/CompilePlugin.ts
+++ b/packages/plugin/compile/src/CompilePlugin.ts
@@ -1,6 +1,7 @@
-import { ForgeHookFn } from '@electron-forge/shared-types';
-import PluginBase, { StartOptions } from '@electron-forge/plugin-base';
 import * as path from 'path';
+
+import PluginBase, { StartOptions } from '@electron-forge/plugin-base';
+import { ForgeHookFn } from '@electron-forge/shared-types';
 
 import { CompilePluginConfig } from './Config';
 import { createCompileHook } from './lib/compile-hook';

--- a/packages/plugin/compile/src/lib/compile-hook.ts
+++ b/packages/plugin/compile/src/lib/compile-hook.ts
@@ -1,7 +1,8 @@
+import path from 'path';
+
 import { asyncOra } from '@electron-forge/async-ora';
 import { ForgeConfig } from '@electron-forge/shared-types';
 import fs from 'fs-extra';
-import path from 'path';
 
 export const createCompileHook =
   (originalDir: string) =>

--- a/packages/plugin/electronegativity/src/ElectronegativityPlugin.ts
+++ b/packages/plugin/electronegativity/src/ElectronegativityPlugin.ts
@@ -1,6 +1,6 @@
-import { ForgeConfig, ForgeHookFn } from '@electron-forge/shared-types';
-import PluginBase from '@electron-forge/plugin-base';
 import runElectronegativity from '@doyensec/electronegativity';
+import PluginBase from '@electron-forge/plugin-base';
+import { ForgeConfig, ForgeHookFn } from '@electron-forge/shared-types';
 
 // To be more precise, postPackage options we care about.
 type PostPackageOptions = {

--- a/packages/plugin/local-electron/src/LocalElectronPlugin.ts
+++ b/packages/plugin/local-electron/src/LocalElectronPlugin.ts
@@ -1,5 +1,5 @@
-import { ForgeConfig, ForgeHookFn } from '@electron-forge/shared-types';
 import PluginBase from '@electron-forge/plugin-base';
+import { ForgeConfig, ForgeHookFn } from '@electron-forge/shared-types';
 import fs from 'fs-extra';
 
 import { LocalElectronPluginConfig } from './Config';

--- a/packages/plugin/local-electron/test/LocalElectronPlugin_spec.ts
+++ b/packages/plugin/local-electron/test/LocalElectronPlugin_spec.ts
@@ -1,8 +1,9 @@
-import { expect } from 'chai';
-import { ForgeConfig } from '@electron-forge/shared-types';
-import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
+
+import { ForgeConfig } from '@electron-forge/shared-types';
+import { expect } from 'chai';
+import fs from 'fs-extra';
 
 import LocalElectronPlugin from '../src/LocalElectronPlugin';
 

--- a/packages/plugin/webpack/src/Config.ts
+++ b/packages/plugin/webpack/src/Config.ts
@@ -1,5 +1,6 @@
 import { Configuration as RawWebpackConfiguration } from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
+
 import { ConfigurationFactory as WebpackConfigurationFactory } from './WebpackConfig';
 
 export interface WebpackPluginEntryPointBase {

--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -1,8 +1,10 @@
+import path from 'path';
+
 import debug from 'debug';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
-import path from 'path';
 import webpack, { Configuration, WebpackPluginInstance } from 'webpack';
 import { merge as webpackMerge } from 'webpack-merge';
+
 import { WebpackPluginConfig, WebpackPluginEntryPoint, WebpackPluginEntryPointLocalWindow, WebpackPluginEntryPointPreloadOnly } from './Config';
 import AssetRelocatorPatch from './util/AssetRelocatorPatch';
 import processConfig from './util/processConfig';

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -14,10 +14,10 @@ import WebpackDevServer from 'webpack-dev-server';
 import { merge } from 'webpack-merge';
 
 import { WebpackPluginConfig } from './Config';
-import WebpackConfigGenerator from './WebpackConfig';
 import ElectronForgeLoggingPlugin from './util/ElectronForgeLogging';
 import once from './util/once';
 import { isLocalWindow, isPreloadOnly } from './util/rendererTypeUtils';
+import WebpackConfigGenerator from './WebpackConfig';
 
 const d = debug('electron-forge:plugin:webpack');
 const DEFAULT_PORT = 3000;

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -1,22 +1,22 @@
+import http from 'http';
+import path from 'path';
+
 import { asyncOra } from '@electron-forge/async-ora';
+import { utils } from '@electron-forge/core';
 import PluginBase from '@electron-forge/plugin-base';
 import { ElectronProcess, ForgeArch, ForgeConfig, ForgeHookFn, ForgePlatform } from '@electron-forge/shared-types';
 import Logger, { Tab } from '@electron-forge/web-multi-logger';
-
 import chalk from 'chalk';
 import debug from 'debug';
 import fs from 'fs-extra';
-import http from 'http';
-import { merge } from 'webpack-merge';
-import path from 'path';
-import { utils } from '@electron-forge/core';
 import webpack, { Configuration, Watching } from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
+import { merge } from 'webpack-merge';
 
 import { WebpackPluginConfig } from './Config';
+import WebpackConfigGenerator from './WebpackConfig';
 import ElectronForgeLoggingPlugin from './util/ElectronForgeLogging';
 import once from './util/once';
-import WebpackConfigGenerator from './WebpackConfig';
 import { isLocalWindow, isPreloadOnly } from './util/rendererTypeUtils';
 
 const d = debug('electron-forge:plugin:webpack');

--- a/packages/plugin/webpack/src/util/ElectronForgeLogging.ts
+++ b/packages/plugin/webpack/src/util/ElectronForgeLogging.ts
@@ -1,6 +1,7 @@
 import { asyncOra } from '@electron-forge/async-ora';
 import { Tab } from '@electron-forge/web-multi-logger';
 import { Compiler } from 'webpack';
+
 import once from './once';
 
 const pluginName = 'ElectronForgeLogging';

--- a/packages/plugin/webpack/src/util/processConfig.ts
+++ b/packages/plugin/webpack/src/util/processConfig.ts
@@ -1,4 +1,5 @@
 import { Configuration } from 'webpack';
+
 import { ConfigurationFactory } from '../WebpackConfig';
 
 const trivialConfigurationFactory =

--- a/packages/plugin/webpack/test/AssetRelocatorPatch_spec.ts
+++ b/packages/plugin/webpack/test/AssetRelocatorPatch_spec.ts
@@ -1,12 +1,14 @@
-import { Configuration, webpack } from 'webpack';
-import path from 'path';
-import { expect } from 'chai';
 import http from 'http';
-import { pathExists, readFile } from 'fs-extra';
+import path from 'path';
+
 import { spawn } from '@malept/cross-spawn-promise';
+import { expect } from 'chai';
+import { pathExists, readFile } from 'fs-extra';
+import { Configuration, webpack } from 'webpack';
+import which from 'which';
+
 import { WebpackPluginConfig, WebpackPluginEntryPointLocalWindow } from '../src/Config';
 import WebpackConfigGenerator from '../src/WebpackConfig';
-import which from 'which';
 
 type Closeable = {
   close: () => void;

--- a/packages/plugin/webpack/test/WebpackConfig_spec.ts
+++ b/packages/plugin/webpack/test/WebpackConfig_spec.ts
@@ -1,9 +1,10 @@
-import { Compiler, Entry, WebpackPluginInstance, Configuration } from 'webpack';
-import { expect } from 'chai';
 import path from 'path';
 
+import { expect } from 'chai';
+import { Compiler, Configuration, Entry, WebpackPluginInstance } from 'webpack';
+
+import { WebpackConfiguration, WebpackPluginConfig, WebpackPluginEntryPoint, WebpackPluginEntryPointLocalWindow } from '../src/Config';
 import WebpackConfigGenerator, { ConfigurationFactory } from '../src/WebpackConfig';
-import { WebpackPluginConfig, WebpackPluginEntryPoint, WebpackConfiguration, WebpackPluginEntryPointLocalWindow } from '../src/Config';
 import AssetRelocatorPatch from '../src/util/AssetRelocatorPatch';
 
 const mockProjectDir = process.platform === 'win32' ? 'C:\\path' : '/path';

--- a/packages/plugin/webpack/test/WebpackConfig_spec.ts
+++ b/packages/plugin/webpack/test/WebpackConfig_spec.ts
@@ -4,8 +4,8 @@ import { expect } from 'chai';
 import { Compiler, Configuration, Entry, WebpackPluginInstance } from 'webpack';
 
 import { WebpackConfiguration, WebpackPluginConfig, WebpackPluginEntryPoint, WebpackPluginEntryPointLocalWindow } from '../src/Config';
-import WebpackConfigGenerator, { ConfigurationFactory } from '../src/WebpackConfig';
 import AssetRelocatorPatch from '../src/util/AssetRelocatorPatch';
+import WebpackConfigGenerator, { ConfigurationFactory } from '../src/WebpackConfig';
 
 const mockProjectDir = process.platform === 'win32' ? 'C:\\path' : '/path';
 

--- a/packages/plugin/webpack/test/WebpackPlugin_spec.ts
+++ b/packages/plugin/webpack/test/WebpackPlugin_spec.ts
@@ -1,9 +1,10 @@
-import { expect } from 'chai';
-import { ForgeConfig } from '@electron-forge/shared-types';
-import * as fs from 'fs-extra';
-import { IgnoreFunction } from 'electron-packager';
 import * as os from 'os';
 import * as path from 'path';
+
+import { ForgeConfig } from '@electron-forge/shared-types';
+import { expect } from 'chai';
+import { IgnoreFunction } from 'electron-packager';
+import * as fs from 'fs-extra';
 
 import { WebpackPluginConfig } from '../src/Config';
 import WebpackPlugin from '../src/WebpackPlugin';

--- a/packages/plugin/webpack/test/fixtures/apps/native-modules/src/index.js
+++ b/packages/plugin/webpack/test/fixtures/apps/native-modules/src/index.js
@@ -1,4 +1,4 @@
-import { BrowserWindow, app, ipcMain } from 'electron';
+import { app, BrowserWindow, ipcMain } from 'electron';
 
 let count = 0;
 ipcMain.on('stdout', (_, line) => {

--- a/packages/plugin/webpack/test/fixtures/apps/native-modules/src/index.js
+++ b/packages/plugin/webpack/test/fixtures/apps/native-modules/src/index.js
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain } from 'electron';
+import { BrowserWindow, app, ipcMain } from 'electron';
 
 let count = 0;
 ipcMain.on('stdout', (_, line) => {

--- a/packages/plugin/webpack/test/once_spec.ts
+++ b/packages/plugin/webpack/test/once_spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { fake } from 'sinon';
+
 import once from '../src/util/once';
 
 describe('Once', () => {

--- a/packages/plugin/webpack/test/util/processConfig_spec.ts
+++ b/packages/plugin/webpack/test/util/processConfig_spec.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+
 import { ConfigurationFactory } from '../../src/WebpackConfig';
 import processConfig, { ConfigProcessor } from '../../src/util/processConfig';
 

--- a/packages/plugin/webpack/test/util/processConfig_spec.ts
+++ b/packages/plugin/webpack/test/util/processConfig_spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 
-import { ConfigurationFactory } from '../../src/WebpackConfig';
 import processConfig, { ConfigProcessor } from '../../src/util/processConfig';
+import { ConfigurationFactory } from '../../src/WebpackConfig';
 
 const sampleWebpackConfig = {
   module: {

--- a/packages/publisher/base/src/Publisher.ts
+++ b/packages/publisher/base/src/Publisher.ts
@@ -1,4 +1,4 @@
-import { ForgePlatform, ForgeConfig, ForgeMakeResult, IForgePublisher } from '@electron-forge/shared-types';
+import { ForgeConfig, ForgeMakeResult, ForgePlatform, IForgePublisher } from '@electron-forge/shared-types';
 
 export interface PublisherOptions {
   /**

--- a/packages/publisher/bitbucket/src/PublisherBitbucket.ts
+++ b/packages/publisher/bitbucket/src/PublisherBitbucket.ts
@@ -1,10 +1,10 @@
-import PublisherBase, { PublisherOptions } from '@electron-forge/publisher-base';
-import { asyncOra } from '@electron-forge/async-ora';
+import path from 'path';
 
-import fetch from 'node-fetch';
+import { asyncOra } from '@electron-forge/async-ora';
+import PublisherBase, { PublisherOptions } from '@electron-forge/publisher-base';
 import FormData from 'form-data';
 import fs from 'fs-extra';
-import path from 'path';
+import fetch from 'node-fetch';
 
 import { PublisherBitbucketConfig } from './Config';
 

--- a/packages/publisher/electron-release-server/src/PublisherERS.ts
+++ b/packages/publisher/electron-release-server/src/PublisherERS.ts
@@ -1,12 +1,12 @@
-import PublisherBase, { PublisherOptions } from '@electron-forge/publisher-base';
-import { asyncOra } from '@electron-forge/async-ora';
-import { ForgePlatform, ForgeArch } from '@electron-forge/shared-types';
+import path from 'path';
 
+import { asyncOra } from '@electron-forge/async-ora';
+import PublisherBase, { PublisherOptions } from '@electron-forge/publisher-base';
+import { ForgeArch, ForgePlatform } from '@electron-forge/shared-types';
 import debug from 'debug';
-import fetch, { RequestInfo, RequestInit, Response } from 'node-fetch';
 import FormData from 'form-data';
 import fs from 'fs-extra';
-import path from 'path';
+import fetch, { RequestInfo, RequestInit, Response } from 'node-fetch';
 
 import { PublisherERSConfig } from './Config';
 

--- a/packages/publisher/electron-release-server/test/PublisherERS_spec.ts
+++ b/packages/publisher/electron-release-server/test/PublisherERS_spec.ts
@@ -1,5 +1,5 @@
-import { expect } from 'chai';
 import { ForgeConfig, ForgeMakeResult } from '@electron-forge/shared-types';
+import { expect } from 'chai';
 import fetchMock from 'fetch-mock';
 import proxyquire from 'proxyquire';
 import { stub } from 'sinon';

--- a/packages/publisher/github/src/PublisherGithub.ts
+++ b/packages/publisher/github/src/PublisherGithub.ts
@@ -1,14 +1,15 @@
+import path from 'path';
+
 import { asyncOra } from '@electron-forge/async-ora';
+import PublisherBase, { PublisherOptions } from '@electron-forge/publisher-base';
 import { ForgeMakeResult } from '@electron-forge/shared-types';
+import { GetResponseDataTypeFromEndpointMethod } from '@octokit/types';
 import fs from 'fs-extra';
 import mime from 'mime-types';
-import path from 'path';
-import PublisherBase, { PublisherOptions } from '@electron-forge/publisher-base';
-import { GetResponseDataTypeFromEndpointMethod } from '@octokit/types';
 
+import { PublisherGitHubConfig } from './Config';
 import GitHub from './util/github';
 import NoReleaseError from './util/no-release-error';
-import { PublisherGitHubConfig } from './Config';
 
 interface GitHubRelease {
   tag_name: string;

--- a/packages/publisher/github/src/util/github.ts
+++ b/packages/publisher/github/src/util/github.ts
@@ -1,7 +1,7 @@
-import debug from 'debug';
-import { Octokit } from '@octokit/rest';
-import { retry } from '@octokit/plugin-retry';
 import { OctokitOptions } from '@octokit/core/dist-types/types.d';
+import { retry } from '@octokit/plugin-retry';
+import { Octokit } from '@octokit/rest';
+import debug from 'debug';
 
 const logInfo = debug('electron-forge:publisher:github:info');
 const logDebug = debug('electron-forge:publisher:github:debug');

--- a/packages/publisher/github/test/github_spec.ts
+++ b/packages/publisher/github/test/github_spec.ts
@@ -1,6 +1,6 @@
-import { expect } from 'chai';
-import { Octokit } from '@octokit/rest';
 import { OctokitOptions } from '@octokit/core/dist-types/types.d';
+import { Octokit } from '@octokit/rest';
+import { expect } from 'chai';
 import proxyquire from 'proxyquire';
 import { SinonSpy, spy } from 'sinon';
 

--- a/packages/publisher/nucleus/src/PublisherNucleus.ts
+++ b/packages/publisher/nucleus/src/PublisherNucleus.ts
@@ -1,10 +1,11 @@
-import PublisherBase, { PublisherOptions } from '@electron-forge/publisher-base';
+import fs from 'fs';
+import path from 'path';
+
 import { asyncOra } from '@electron-forge/async-ora';
+import PublisherBase, { PublisherOptions } from '@electron-forge/publisher-base';
 import debug from 'debug';
 import FormData from 'form-data';
-import fs from 'fs';
 import fetch from 'node-fetch';
-import path from 'path';
 
 import { PublisherNucleusConfig } from './Config';
 

--- a/packages/publisher/s3/src/PublisherS3.ts
+++ b/packages/publisher/s3/src/PublisherS3.ts
@@ -1,12 +1,12 @@
-import { Credentials } from '@aws-sdk/types';
-import debug from 'debug';
 import fs from 'fs';
 import path from 'path';
+
 import { S3Client } from '@aws-sdk/client-s3';
 import { Progress, Upload } from '@aws-sdk/lib-storage';
-
-import PublisherBase, { PublisherOptions } from '@electron-forge/publisher-base';
+import { Credentials } from '@aws-sdk/types';
 import { asyncOra } from '@electron-forge/async-ora';
+import PublisherBase, { PublisherOptions } from '@electron-forge/publisher-base';
+import debug from 'debug';
 
 import { PublisherS3Config } from './Config';
 

--- a/packages/publisher/snapcraft/src/PublisherSnapcraft.ts
+++ b/packages/publisher/snapcraft/src/PublisherSnapcraft.ts
@@ -1,8 +1,8 @@
-import PublisherBase, { PublisherOptions } from '@electron-forge/publisher-base';
-import { asyncOra } from '@electron-forge/async-ora';
-
-import fs from 'fs-extra';
 import path from 'path';
+
+import { asyncOra } from '@electron-forge/async-ora';
+import PublisherBase, { PublisherOptions } from '@electron-forge/publisher-base';
+import fs from 'fs-extra';
 
 import { PublisherSnapcraftConfig } from './Config';
 

--- a/packages/template/base/src/BaseTemplate.ts
+++ b/packages/template/base/src/BaseTemplate.ts
@@ -1,8 +1,9 @@
-import { asyncOra } from '@electron-forge/async-ora';
-import debug from 'debug';
-import { ForgeTemplate, InitTemplateOptions } from '@electron-forge/shared-types';
-import fs from 'fs-extra';
 import path from 'path';
+
+import { asyncOra } from '@electron-forge/async-ora';
+import { ForgeTemplate, InitTemplateOptions } from '@electron-forge/shared-types';
+import debug from 'debug';
+import fs from 'fs-extra';
 
 import determineAuthor from './determine-author';
 

--- a/packages/template/base/src/determine-author.ts
+++ b/packages/template/base/src/determine-author.ts
@@ -1,6 +1,6 @@
-import debug from 'debug';
 import { PackagePerson } from '@electron-forge/shared-types';
 import { spawn } from '@malept/cross-spawn-promise';
+import debug from 'debug';
 import username from 'username';
 
 const d = debug('electron-forge:determine-author');

--- a/packages/template/base/test/determine-author_spec.ts
+++ b/packages/template/base/test/determine-author_spec.ts
@@ -1,8 +1,7 @@
+import { PackagePerson } from '@electron-forge/shared-types';
 import { expect } from 'chai';
 import proxyquire from 'proxyquire';
 import { stub } from 'sinon';
-
-import { PackagePerson } from '@electron-forge/shared-types';
 
 describe('determineAuthor', () => {
   let determineAuthor: (dir: string) => Promise<PackagePerson>;

--- a/packages/template/typescript-webpack/src/TypeScriptWebpackTemplate.ts
+++ b/packages/template/typescript-webpack/src/TypeScriptWebpackTemplate.ts
@@ -1,8 +1,9 @@
+import path from 'path';
+
 import { asyncOra } from '@electron-forge/async-ora';
+import { InitTemplateOptions } from '@electron-forge/shared-types';
 import { BaseTemplate } from '@electron-forge/template-base';
 import fs from 'fs-extra';
-import { InitTemplateOptions } from '@electron-forge/shared-types';
-import path from 'path';
 
 class TypeScriptWebpackTemplate extends BaseTemplate {
   public templateDir = path.resolve(__dirname, '..', 'tmpl');

--- a/packages/template/typescript-webpack/test/TypeScriptWebpackTemplate_spec.ts
+++ b/packages/template/typescript-webpack/test/TypeScriptWebpackTemplate_spec.ts
@@ -1,9 +1,11 @@
-import * as testUtils from '@electron-forge/test-utils';
-import fs from 'fs-extra';
-import glob from 'fast-glob';
 import path from 'path';
-import template from '../src/TypeScriptWebpackTemplate';
+
+import * as testUtils from '@electron-forge/test-utils';
 import { expect } from 'chai';
+import glob from 'fast-glob';
+import fs from 'fs-extra';
+
+import template from '../src/TypeScriptWebpackTemplate';
 
 describe('TypeScriptWebpackTemplate', () => {
   let dir: string;

--- a/packages/template/webpack/src/WebpackTemplate.ts
+++ b/packages/template/webpack/src/WebpackTemplate.ts
@@ -1,8 +1,9 @@
+import path from 'path';
+
 import { asyncOra } from '@electron-forge/async-ora';
+import { InitTemplateOptions } from '@electron-forge/shared-types';
 import { BaseTemplate } from '@electron-forge/template-base';
 import fs from 'fs-extra';
-import { InitTemplateOptions } from '@electron-forge/shared-types';
-import path from 'path';
 
 class WebpackTemplate extends BaseTemplate {
   public templateDir = path.resolve(__dirname, '..', 'tmpl');

--- a/packages/template/webpack/test/WebpackTemplate_spec.ts
+++ b/packages/template/webpack/test/WebpackTemplate_spec.ts
@@ -1,7 +1,9 @@
+import path from 'path';
+
 import * as testUtils from '@electron-forge/test-utils';
 import { expect } from 'chai';
 import fs from 'fs-extra';
-import path from 'path';
+
 import template from '../src/WebpackTemplate';
 
 describe('WebpackTemplate', () => {

--- a/packages/utils/async-ora/src/ora-handler.ts
+++ b/packages/utils/async-ora/src/ora-handler.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+
 import ora from './ora';
 
 export class OraImpl {

--- a/packages/utils/async-ora/test/ora-handler_spec.ts
+++ b/packages/utils/async-ora/test/ora-handler_spec.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import proxyquire from 'proxyquire';
 import { spy } from 'sinon';
 
-import { asyncOra as ora, OraImpl } from '../src/index';
+import { OraImpl, asyncOra as ora } from '../src/index';
 
 type MockOra = OraImpl & {
   _text: string;

--- a/packages/utils/async-ora/test/ora-handler_spec.ts
+++ b/packages/utils/async-ora/test/ora-handler_spec.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import proxyquire from 'proxyquire';
 import { spy } from 'sinon';
 
-import { OraImpl, asyncOra as ora } from '../src/index';
+import { asyncOra as ora, OraImpl } from '../src/index';
 
 type MockOra = OraImpl & {
   _text: string;

--- a/packages/utils/test-utils/src/index.ts
+++ b/packages/utils/test-utils/src/index.ts
@@ -1,8 +1,9 @@
-import { expect } from 'chai';
-import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
+
 import { ExitError, spawn } from '@malept/cross-spawn-promise';
+import { expect } from 'chai';
+import fs from 'fs-extra';
 
 async function runNPM(dir: string, ...args: string[]) {
   await spawn('npm', args, { cwd: dir });

--- a/packages/utils/types/src/index.ts
+++ b/packages/utils/types/src/index.ts
@@ -1,4 +1,5 @@
 import { ChildProcess } from 'child_process';
+
 import { ArchOption, Options as ElectronPackagerOptions, TargetPlatform } from 'electron-packager';
 import { RebuildOptions } from 'electron-rebuild';
 

--- a/packages/utils/web-multi-logger/src/Logger.ts
+++ b/packages/utils/web-multi-logger/src/Logger.ts
@@ -1,7 +1,8 @@
-import express from 'express';
-import path from 'path';
-import ews from 'express-ws';
 import http from 'http';
+import path from 'path';
+
+import express from 'express';
+import ews from 'express-ws';
 
 import Tab from './Tab';
 

--- a/tools/bump.ts
+++ b/tools/bump.ts
@@ -1,9 +1,10 @@
 #!node_modules/.bin/ts-node
 
+import path from 'path';
+
+import { spawn } from '@malept/cross-spawn-promise';
 import chalk from 'chalk';
 import * as fs from 'fs-extra';
-import path from 'path';
-import { spawn } from '@malept/cross-spawn-promise';
 import * as semver from 'semver';
 
 const BASE_DIR = path.resolve(__dirname, '..');

--- a/tools/fix-deps.ts
+++ b/tools/fix-deps.ts
@@ -1,5 +1,6 @@
-import * as fs from 'fs-extra';
 import * as path from 'path';
+
+import * as fs from 'fs-extra';
 
 import { getPackageInfo } from './utils';
 

--- a/tools/gen-docs.ts
+++ b/tools/gen-docs.ts
@@ -1,6 +1,8 @@
 import * as path from 'path';
-import { getPackageInfo } from './utils';
+
 import * as typedoc from 'typedoc';
+
+import { getPackageInfo } from './utils';
 
 function generatedSidebarGroups(projReflection: typedoc.ProjectReflection) {
   const maker = new typedoc.ReflectionGroup('Makers', 2);

--- a/tools/gen-ts-glue.ts
+++ b/tools/gen-ts-glue.ts
@@ -14,6 +14,7 @@
 
 import { promises as fs } from 'fs';
 import path from 'path';
+
 import { getPackageInfo } from './utils';
 
 // NOTE: this interface only defines the fields in the package.json that are

--- a/tools/gen-tsconfigs.ts
+++ b/tools/gen-tsconfigs.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'fs';
 import * as path from 'path';
+
 import { getPackageInfo } from './utils';
 
 const BASE_TS_CONFIG = {

--- a/tools/position-docs.ts
+++ b/tools/position-docs.ts
@@ -1,6 +1,8 @@
-import * as fs from 'fs-extra';
-import glob from 'fast-glob';
 import * as path from 'path';
+
+import glob from 'fast-glob';
+import * as fs from 'fs-extra';
+
 import { getPackageInfo } from './utils';
 
 const DOCS_PATH = path.resolve(__dirname, '..', 'docs');

--- a/tools/publish.js
+++ b/tools/publish.js
@@ -1,9 +1,11 @@
-const chalk = require('chalk');
 const childProcess = require('child_process');
+const path = require('path');
+
+const { spawn } = require('@malept/cross-spawn-promise');
+const chalk = require('chalk');
 const fs = require('fs-extra');
 const { Listr } = require('listr2');
-const path = require('path');
-const { spawn } = require('@malept/cross-spawn-promise');
+
 require('ts-node').register();
 
 const BASE_DIR = path.resolve(__dirname, '..');

--- a/tools/sync-readmes.ts
+++ b/tools/sync-readmes.ts
@@ -1,7 +1,8 @@
-import fetch from 'node-fetch';
+import * as path from 'path';
+
 import * as fs from 'fs-extra';
 import { Listr } from 'listr2';
-import * as path from 'path';
+import fetch from 'node-fetch';
 
 const workspaceMappings: { [space: string]: { [packageName: string]: string | undefined } } = {
   maker: {

--- a/tools/test-dist.ts
+++ b/tools/test-dist.ts
@@ -1,6 +1,7 @@
+import * as path from 'path';
+
 import chalk from 'chalk';
 import * as fs from 'fs-extra';
-import * as path from 'path';
 
 const BASE_DIR = path.resolve(__dirname, '..');
 const PACKAGES_DIR = path.resolve(BASE_DIR, 'packages');

--- a/tools/test-globber.ts
+++ b/tools/test-globber.ts
@@ -1,6 +1,7 @@
+import * as path from 'path';
+
 import glob from 'fast-glob';
 import minimist from 'minimist';
-import * as path from 'path';
 
 import { getPackageInfoSync } from './utils';
 

--- a/tools/update-dependencies.js
+++ b/tools/update-dependencies.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
+const { spawn } = require('@malept/cross-spawn-promise');
 const glob = require('fast-glob');
 const { satisfies } = require('semver');
-const { spawn } = require('@malept/cross-spawn-promise');
 
 const DO_NOT_UPGRADE = [
   '@types/node-fetch', // No longer needed when node-fetch is upgraded to >= 3.0.0

--- a/tools/update-node-version.ts
+++ b/tools/update-node-version.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env ts-node
 
 import path from 'path';
+
 import { readJsonSync, writeJsonSync } from 'fs-extra';
 
 import { getPackageInfoSync } from './utils';

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -1,5 +1,6 @@
-import * as fs from 'fs-extra';
 import * as path from 'path';
+
+import * as fs from 'fs-extra';
 
 const BASE_DIR = path.resolve(__dirname, '..');
 const PACKAGES_DIR = path.resolve(BASE_DIR, 'packages');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1834,7 +1834,7 @@
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
-  integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+  integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
 "@types/keyv@*":
   version "3.1.3"
@@ -2511,13 +2511,13 @@ array-flatten@^2.1.0:
   integrity sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==
 
 array-includes@^3.1.4:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.4.tgz#f5b493162c760f3539631f005ba2bb46acb45ba9"
-  integrity sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.5.tgz#2c320010db8d31031fd2a5f6b3bbd4b1aad31bdb"
+  integrity sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==
   dependencies:
     call-bind "^1.0.2"
-    define-properties "^1.1.3"
-    es-abstract "^1.19.1"
+    define-properties "^1.1.4"
+    es-abstract "^1.19.5"
     get-intrinsic "^1.1.1"
     is-string "^1.0.7"
 
@@ -2527,13 +2527,14 @@ array-union@^2.1.0:
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
 array.prototype.flat@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz#07e0975d84bbc7c48cd1879d609e682598d33e13"
-  integrity sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz#0b0c1567bf57b38b56b4c97b8aa72ab45e4adc7b"
+  integrity sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==
   dependencies:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
-    es-abstract "^1.19.0"
+    es-abstract "^1.19.2"
+    es-shim-unscopables "^1.0.0"
 
 asap@^2.0.0:
   version "2.0.6"
@@ -3283,7 +3284,7 @@ compression@^1.7.4:
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
 config-chain@^1.1.11:
   version "1.1.13"
@@ -3553,12 +3554,13 @@ define-lazy-prop@^2.0.0:
   resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
   integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
 
-define-properties@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
-  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
+define-properties@^1.1.3, define-properties@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.4.tgz#0b14d7bd7fbeb2f3572c3a7eda80ea5d57fb05b1"
+  integrity sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==
   dependencies:
-    object-keys "^1.0.12"
+    has-property-descriptors "^1.0.0"
+    object-keys "^1.1.1"
 
 del@^6.0.0:
   version "6.0.0"
@@ -3996,36 +3998,47 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.19.0, es-abstract@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.19.1.tgz#d4885796876916959de78edaa0df456627115ec3"
-  integrity sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==
+es-abstract@^1.19.0, es-abstract@^1.19.1, es-abstract@^1.19.2, es-abstract@^1.19.5:
+  version "1.20.4"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.20.4.tgz#1d103f9f8d78d4cf0713edcd6d0ed1a46eed5861"
+  integrity sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==
   dependencies:
     call-bind "^1.0.2"
     es-to-primitive "^1.2.1"
     function-bind "^1.1.1"
-    get-intrinsic "^1.1.1"
+    function.prototype.name "^1.1.5"
+    get-intrinsic "^1.1.3"
     get-symbol-description "^1.0.0"
     has "^1.0.3"
-    has-symbols "^1.0.2"
+    has-property-descriptors "^1.0.0"
+    has-symbols "^1.0.3"
     internal-slot "^1.0.3"
-    is-callable "^1.2.4"
-    is-negative-zero "^2.0.1"
+    is-callable "^1.2.7"
+    is-negative-zero "^2.0.2"
     is-regex "^1.1.4"
-    is-shared-array-buffer "^1.0.1"
+    is-shared-array-buffer "^1.0.2"
     is-string "^1.0.7"
-    is-weakref "^1.0.1"
-    object-inspect "^1.11.0"
+    is-weakref "^1.0.2"
+    object-inspect "^1.12.2"
     object-keys "^1.1.1"
-    object.assign "^4.1.2"
-    string.prototype.trimend "^1.0.4"
-    string.prototype.trimstart "^1.0.4"
-    unbox-primitive "^1.0.1"
+    object.assign "^4.1.4"
+    regexp.prototype.flags "^1.4.3"
+    safe-regex-test "^1.0.0"
+    string.prototype.trimend "^1.0.5"
+    string.prototype.trimstart "^1.0.5"
+    unbox-primitive "^1.0.2"
 
 es-module-lexer@^0.9.0:
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.9.3.tgz#6f13db00cc38417137daf74366f535c8eb438f19"
   integrity sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==
+
+es-shim-unscopables@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz#702e632193201e3edf8713635d083d378e510241"
+  integrity sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==
+  dependencies:
+    has "^1.0.3"
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -4151,13 +4164,12 @@ eslint-import-resolver-node@^0.3.6:
     debug "^3.2.7"
     resolve "^1.20.0"
 
-eslint-module-utils@^2.7.2:
-  version "2.7.3"
-  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz#ad7e3a10552fdd0642e1e55292781bd6e34876ee"
-  integrity sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==
+eslint-module-utils@^2.7.3:
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz#4f3e41116aaf13a20792261e61d3a2e7e0583974"
+  integrity sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==
   dependencies:
     debug "^3.2.7"
-    find-up "^2.1.0"
 
 eslint-plugin-es@^3.0.0:
   version "3.0.1"
@@ -4167,24 +4179,24 @@ eslint-plugin-es@^3.0.0:
     eslint-utils "^2.0.0"
     regexpp "^3.0.0"
 
-eslint-plugin-import@^2.24.2:
-  version "2.25.4"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz#322f3f916a4e9e991ac7af32032c25ce313209f1"
-  integrity sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==
+eslint-plugin-import@^2.26.0:
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz#f812dc47be4f2b72b478a021605a59fc6fe8b88b"
+  integrity sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==
   dependencies:
     array-includes "^3.1.4"
     array.prototype.flat "^1.2.5"
     debug "^2.6.9"
     doctrine "^2.1.0"
     eslint-import-resolver-node "^0.3.6"
-    eslint-module-utils "^2.7.2"
+    eslint-module-utils "^2.7.3"
     has "^1.0.3"
-    is-core-module "^2.8.0"
+    is-core-module "^2.8.1"
     is-glob "^4.0.3"
-    minimatch "^3.0.4"
+    minimatch "^3.1.2"
     object.values "^1.1.5"
-    resolve "^1.20.0"
-    tsconfig-paths "^3.12.0"
+    resolve "^1.22.0"
+    tsconfig-paths "^3.14.1"
 
 eslint-plugin-mocha@^9.0.0:
   version "9.0.0"
@@ -4724,7 +4736,7 @@ find-up@^1.0.0:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
 
-find-up@^2.0.0, find-up@^2.1.0:
+find-up@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
@@ -4926,10 +4938,25 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+function.prototype.name@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.5.tgz#cce0505fe1ffb80503e6f9e46cc64e46a12a9621"
+  integrity sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.19.0"
+    functions-have-names "^1.2.2"
+
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
+functions-have-names@^1.2.2:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
+  integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
 galactus@^0.2.1:
   version "0.2.1"
@@ -5028,14 +5055,14 @@ get-installed-path@^2.0.3:
   dependencies:
     global-modules "1.0.0"
 
-get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
-  integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.3.tgz#063c84329ad93e83893c7f4f243ef63ffa351385"
+  integrity sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==
   dependencies:
     function-bind "^1.1.1"
     has "^1.0.3"
-    has-symbols "^1.0.1"
+    has-symbols "^1.0.3"
 
 get-package-info@^1.0.0:
   version "1.0.0"
@@ -5287,10 +5314,10 @@ har-validator@~5.1.3:
     ajv "^6.12.3"
     har-schema "^2.0.0"
 
-has-bigints@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
-  integrity sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==
+has-bigints@^1.0.1, has-bigints@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
+  integrity sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -5302,10 +5329,17 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
-has-symbols@^1.0.1, has-symbols@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
-  integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
+has-property-descriptors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz#610708600606d36961ed04c196193b6a607fa861"
+  integrity sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==
+  dependencies:
+    get-intrinsic "^1.1.1"
+
+has-symbols@^1.0.2, has-symbols@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
+  integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
 
 has-tostringtag@^1.0.0:
   version "1.0.0"
@@ -5702,15 +5736,22 @@ is-boolean-object@^1.1.0:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
-is-callable@^1.1.4, is-callable@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
-  integrity sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==
+is-callable@^1.1.4, is-callable@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
+  integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
 
-is-core-module@^2.1.0, is-core-module@^2.8.0, is-core-module@^2.8.1:
+is-core-module@^2.1.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.1.tgz#f59fdfca701d5879d0a6b100a40aa1560ce27211"
   integrity sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==
+  dependencies:
+    has "^1.0.3"
+
+is-core-module@^2.8.1, is-core-module@^2.9.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.11.0.tgz#ad4cb3e3863e814523c96f3f58d26cc570ff0144"
+  integrity sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==
   dependencies:
     has "^1.0.3"
 
@@ -5729,7 +5770,7 @@ is-docker@^2.0.0, is-docker@^2.1.1:
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
-  integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
+  integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
 
 is-finite@^1.0.0:
   version "1.1.0"
@@ -5791,15 +5832,15 @@ is-my-json-valid@^2.20.0:
     jsonpointer "^5.0.0"
     xtend "^4.0.0"
 
-is-negative-zero@^2.0.1:
+is-negative-zero@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.2.tgz#7bf6f03a28003b8b3965de3ac26f664d765f3150"
   integrity sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==
 
 is-number-object@^1.0.4:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.6.tgz#6a7aaf838c7f0686a50b4553f7e54a96494e89f0"
-  integrity sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.7.tgz#59d50ada4c45251784e9904f5246c742f07a42fc"
+  integrity sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==
   dependencies:
     has-tostringtag "^1.0.0"
 
@@ -5858,10 +5899,12 @@ is-regex@^1.0.4, is-regex@^1.1.4:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
-is-shared-array-buffer@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz#97b0c85fbdacb59c9c446fe653b82cf2b5b7cfe6"
-  integrity sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==
+is-shared-array-buffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz#8f259c573b60b6a32d4058a1a07430c0a7344c79"
+  integrity sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==
+  dependencies:
+    call-bind "^1.0.2"
 
 is-stream@^1.1.0:
   version "1.1.0"
@@ -5907,7 +5950,7 @@ is-utf8@^0.2.0:
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
-is-weakref@^1.0.1:
+is-weakref@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.2.tgz#9529f383a9338205e89765e0392efc2f100f06f2"
   integrity sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==
@@ -6617,6 +6660,13 @@ minimatch@^3.0.2, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimatch@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.0.1.tgz#fb9022f7528125187c92bd9e9b6366be1cf3415b"
@@ -6624,10 +6674,15 @@ minimatch@^5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
+minimist@^1.2.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
+  integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
 
 minimist@^1.2.6:
   version "1.2.6"
@@ -6769,7 +6824,7 @@ module-not-found-error@^1.0.1:
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
-  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
+  integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
 
 ms@2.1.2:
   version "2.1.2"
@@ -7092,10 +7147,15 @@ object-assign@^4.0.1, object-assign@^4.1.1:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
-object-inspect@^1.11.0, object-inspect@^1.12.0, object-inspect@^1.9.0:
+object-inspect@^1.12.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.0.tgz#6e2c120e868fd1fd18cb4f18c31741d0d6e776f0"
   integrity sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==
+
+object-inspect@^1.12.2, object-inspect@^1.9.0:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
+  integrity sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==
 
 object-is@^1.0.1:
   version "1.1.5"
@@ -7105,7 +7165,7 @@ object-is@^1.0.1:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
-object-keys@^1.0.12, object-keys@^1.1.1:
+object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
@@ -7115,14 +7175,14 @@ object-keys@~0.4.0:
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-0.4.0.tgz#28a6aae7428dd2c3a92f3d95f21335dd204e0336"
   integrity sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=
 
-object.assign@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.2.tgz#0ed54a342eceb37b38ff76eb831a0e788cb63940"
-  integrity sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==
+object.assign@^4.1.4:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.4.tgz#9673c7c7c351ab8c4d0b516f4343ebf4dfb7799f"
+  integrity sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==
   dependencies:
-    call-bind "^1.0.0"
-    define-properties "^1.1.3"
-    has-symbols "^1.0.1"
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    has-symbols "^1.0.3"
     object-keys "^1.1.1"
 
 object.getownpropertydescriptors@^2.0.3:
@@ -7886,6 +7946,15 @@ regexp.prototype.flags@^1.2.0:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
+regexp.prototype.flags@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz#87cab30f80f66660181a3bb7bf5981a872b367ac"
+  integrity sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    functions-have-names "^1.2.2"
+
 regexpp@^3.0.0, regexpp@^3.1.0, regexpp@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
@@ -8002,12 +8071,21 @@ resolve-package@^1.0.1:
   dependencies:
     get-installed-path "^2.0.3"
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.1, resolve@^1.20.0:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.1:
   version "1.22.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.0.tgz#5e0b8c67c15df57a89bdbabe603a002f21731198"
   integrity sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==
   dependencies:
     is-core-module "^2.8.1"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
+resolve@^1.20.0, resolve@^1.22.0:
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
+  integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
+  dependencies:
+    is-core-module "^2.9.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
@@ -8130,6 +8208,15 @@ safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, 
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+safe-regex-test@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/safe-regex-test/-/safe-regex-test-1.0.0.tgz#793b874d524eb3640d1873aad03596db2d4f2295"
+  integrity sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.3"
+    is-regex "^1.1.4"
 
 "safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
@@ -8591,21 +8678,23 @@ string-width@^5.0.0:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
-string.prototype.trimend@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz#e75ae90c2942c63504686c18b287b4a0b1a45f80"
-  integrity sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==
+string.prototype.trimend@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz#914a65baaab25fbdd4ee291ca7dde57e869cb8d0"
+  integrity sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==
   dependencies:
     call-bind "^1.0.2"
-    define-properties "^1.1.3"
+    define-properties "^1.1.4"
+    es-abstract "^1.19.5"
 
-string.prototype.trimstart@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz#b36399af4ab2999b4c9c648bd7a3fb2bb26feeed"
-  integrity sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==
+string.prototype.trimstart@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz#5466d93ba58cfa2134839f81d7f42437e8c01fef"
+  integrity sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==
   dependencies:
     call-bind "^1.0.2"
-    define-properties "^1.1.3"
+    define-properties "^1.1.4"
+    es-abstract "^1.19.5"
 
 string_decoder@^1.1.1:
   version "1.3.0"
@@ -8671,7 +8760,7 @@ strip-bom@^2.0.0:
 strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
-  integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
+  integrity sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==
 
 strip-bom@^4.0.0:
   version "4.0.0"
@@ -8982,14 +9071,14 @@ ts-node@^10.0.0:
     v8-compile-cache-lib "^3.0.0"
     yn "3.1.1"
 
-tsconfig-paths@^3.12.0:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz#19769aca6ee8f6a1a341e38c8fa45dd9fb18899b"
-  integrity sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==
+tsconfig-paths@^3.14.1:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz#ba0734599e8ea36c862798e920bcf163277b137a"
+  integrity sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==
   dependencies:
     "@types/json5" "^0.0.29"
     json5 "^1.0.1"
-    minimist "^1.2.0"
+    minimist "^1.2.6"
     strip-bom "^3.0.0"
 
 tslib@^1.11.1, tslib@^1.8.1, tslib@^1.9.0:
@@ -9114,14 +9203,14 @@ typescript@~4.2.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
   integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
 
-unbox-primitive@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.1.tgz#085e215625ec3162574dc8859abee78a59b14471"
-  integrity sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==
+unbox-primitive@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.2.tgz#29032021057d5e6cdbd08c5129c226dff8ed6f9e"
+  integrity sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==
   dependencies:
-    function-bind "^1.1.1"
-    has-bigints "^1.0.1"
-    has-symbols "^1.0.2"
+    call-bind "^1.0.2"
+    has-bigints "^1.0.2"
+    has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
 
 unique-filename@^1.1.1:


### PR DESCRIPTION
No user facing changes, but clean code is good code.  And these imports were annoying me, eslint now orders import statements and import members _nicely_.