### PR TITLE
build: add rule that enforces named exports over default exports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,7 +36,8 @@
         "allowSeparatedGroups": true,
         "ignoreCase": true
       }
-    ]
+    ],
+    "import/no-named-as-default": "error"
   },
   "overrides": [
     {

--- a/packages/api/core/src/api/publish.ts
+++ b/packages/api/core/src/api/publish.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import { asyncOra } from '@electron-forge/async-ora';
-import PublisherBase from '@electron-forge/publisher-base';
+import { PublisherBase } from '@electron-forge/publisher-base';
 import {
   ForgeConfigPublisher,
   ForgeMakeResult,

--- a/packages/api/core/src/util/plugin-interface.ts
+++ b/packages/api/core/src/util/plugin-interface.ts
@@ -1,4 +1,4 @@
-import PluginBase from '@electron-forge/plugin-base';
+import { PluginBase } from '@electron-forge/plugin-base';
 import { IForgePlugin, IForgePluginInterface, ResolvedForgeConfig, StartResult } from '@electron-forge/shared-types';
 import debug from 'debug';
 

--- a/packages/maker/base/test/config-fetcher_spec.ts
+++ b/packages/maker/base/test/config-fetcher_spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { stub } from 'sinon';
 
-import MakerBase from '../src/Maker';
+import { MakerBase } from '../src/Maker';
 
 class MakerImpl extends MakerBase<{ a: number }> {
   name = 'test';

--- a/packages/plugin/local-electron/test/LocalElectronPlugin_spec.ts
+++ b/packages/plugin/local-electron/test/LocalElectronPlugin_spec.ts
@@ -5,7 +5,7 @@ import { ResolvedForgeConfig } from '@electron-forge/shared-types';
 import { expect } from 'chai';
 import fs from 'fs-extra';
 
-import LocalElectronPlugin from '../src/LocalElectronPlugin';
+import { LocalElectronPlugin } from '../src/LocalElectronPlugin';
 
 describe('LocalElectronPlugin', () => {
   describe('start logic', () => {

--- a/packages/plugin/webpack/test/WebpackPlugin_spec.ts
+++ b/packages/plugin/webpack/test/WebpackPlugin_spec.ts
@@ -7,7 +7,7 @@ import { IgnoreFunction } from 'electron-packager';
 import * as fs from 'fs-extra';
 
 import { WebpackPluginConfig } from '../src/Config';
-import WebpackPlugin from '../src/WebpackPlugin';
+import { WebpackPlugin } from '../src/WebpackPlugin';
 
 describe('WebpackPlugin', () => {
   const baseConfig: WebpackPluginConfig = {


### PR DESCRIPTION
Missed a few in #2996 and found a handy rule so we don't miss any again