### PR TITLE
fix(vite-typescript): add missing `@types/electron-squirrel-startup` dependency

### DIFF
--- a/packages/template/vite-typescript/tmpl/package.json
+++ b/packages/template/vite-typescript/tmpl/package.json
@@ -1,6 +1,7 @@
 {
   "devDependencies": {
     "@electron-forge/plugin-vite": "ELECTRON_FORGE/VERSION",
+    "@types/electron-squirrel-startup": "^1.0.2",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
     "eslint": "^8.0.1",


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
- Resolves https://github.com/electron/forge/issues/3956.
- On a freshly generated `vite-typescript` template project, `main.ts` contains type errors due to missing `electron-squirrel-startup` package type definitions. This PR adds those type definitions as a dev dependency.