### PR TITLE
feat: improve Yarn Berry support

### DIFF
--- a/packages/api/cli/spec/util/check-system.spec.ts
+++ b/packages/api/cli/spec/util/check-system.spec.ts
@@ -87,6 +87,27 @@ describe('checkPackageManager', () => {
     );
   });
 
+  it('should throw if using yarn without node-linker=node-modules', async () => {
+    vi.mocked(resolvePackageManager).mockResolvedValue({
+      executable: 'yarn',
+      install: 'add',
+      dev: '--dev',
+      exact: '--exact',
+    });
+    vi.mocked(spawnPackageManager).mockImplementation((_pm, args) => {
+      if (args?.join(' ') === 'config get nodeLinker') {
+        return Promise.resolve('isolated');
+      } else if (args?.join(' ') === '--version') {
+        return Promise.resolve('4.1.0');
+      } else {
+        throw new Error('Unexpected command');
+      }
+    });
+    await expect(checkPackageManager()).rejects.toThrow(
+      'When using Yarn 2+, `nodeLinker` must be set to "node-modules". Run `yarn config set nodeLinker node-modules` to set this config value, or add it to your project\'s `.yarnrc` file.',
+    );
+  });
+
   it.each(['hoist-pattern', 'public-hoist-pattern'])(
     'should pass without validation if user has set %s in their pnpm config',
     async (cfg) => {

--- a/packages/api/cli/src/util/check-system.ts
+++ b/packages/api/cli/src/util/check-system.ts
@@ -68,6 +68,25 @@ async function checkPnpmConfig() {
   }
 }
 
+async function checkYarnConfig() {
+  const { yarn } = PACKAGE_MANAGERS;
+  const yarnVersion = await spawnPackageManager(yarn, ['--version']);
+  const nodeLinker = await spawnPackageManager(yarn, [
+    'config',
+    'get',
+    'nodeLinker',
+  ]);
+  if (
+    yarnVersion &&
+    semver.gte(yarnVersion, '2.0.0') &&
+    nodeLinker !== 'node-modules'
+  ) {
+    throw new Error(
+      'When using Yarn 2+, `nodeLinker` must be set to "node-modules". Run `yarn config set nodeLinker node-modules` to set this config value, or add it to your project\'s `.yarnrc` file.',
+    );
+  }
+}
+
 // TODO(erickzhao): Drop antiquated versions of npm for Forge v8
 const ALLOWLISTED_VERSIONS: Record<
   SupportedPackageManager,
@@ -108,6 +127,8 @@ export async function checkPackageManager() {
 
   if (pm.executable === 'pnpm') {
     await checkPnpmConfig();
+  } else if (pm.executable === 'yarn') {
+    await checkYarnConfig();
   }
 
   return `${pm.executable}@${versionString}`;

--- a/packages/template/base/package.json
+++ b/packages/template/base/package.json
@@ -16,6 +16,7 @@
     "@malept/cross-spawn-promise": "^2.0.0",
     "debug": "^4.3.1",
     "fs-extra": "^10.0.0",
+    "semver": "^7.2.1",
     "username": "^5.1.0"
   },
   "devDependencies": {

--- a/packages/template/base/src/BaseTemplate.ts
+++ b/packages/template/base/src/BaseTemplate.ts
@@ -8,6 +8,7 @@ import {
 } from '@electron-forge/shared-types';
 import debug from 'debug';
 import fs from 'fs-extra';
+import semver from 'semver';
 
 import determineAuthor from './determine-author';
 
@@ -71,6 +72,13 @@ export class BaseTemplate implements ForgeTemplate {
 
           if (pm.executable === 'pnpm') {
             rootFiles.push('_npmrc');
+          } else if (
+            // Support Yarn 2+ by default by initializing with nodeLinker: node-modules
+            pm.executable === 'yarn' &&
+            pm.version &&
+            semver.gte(pm.version, '2.0.0')
+          ) {
+            rootFiles.push('_yarnrc');
           }
 
           if (copyCIFiles) {

--- a/packages/template/base/tmpl/_yarnrc
+++ b/packages/template/base/tmpl/_yarnrc
@@ -1,0 +1,1 @@
+nodeLinker: node-modules


### PR DESCRIPTION
Similar to https://github.com/electron/forge/pull/3822, this PR adds a `.yarnrc` with `nodeLinker: node-modules` to get `create-electron-app` working out of the box with Yarn Berry (v2+). It also prevents Forge from starting if this option isn't set.

The package manager resolver util had to be hardened a bit to properly fetch the version of Yarn on runtime.





