### PR TITLE
fix(maker-msix): rename and add named exports

### DIFF
--- a/packages/maker/msix/src/Config.ts
+++ b/packages/maker/msix/src/Config.ts
@@ -1,4 +1,4 @@
-import { PackagingOptions } from 'electron-windows-msix';
+import { PackagingOptions as MSIXPackagingOptions } from 'electron-windows-msix';
 
 /**
  * The configuration object for the MSIX maker.
@@ -7,4 +7,7 @@ import { PackagingOptions } from 'electron-windows-msix';
  *
  * @see https://github.com/bitdisaster/electron-windows-msix/blob/master/src/types.ts
  */
-export type MakerMsixConfig = Omit<PackagingOptions, 'outputDir' | 'appDir'>;
+export type MakerMSIXConfig = Omit<
+  MSIXPackagingOptions,
+  'outputDir' | 'appDir'
+>;

--- a/packages/maker/msix/src/MakerMSIX.ts
+++ b/packages/maker/msix/src/MakerMSIX.ts
@@ -3,14 +3,14 @@ import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';
 import { packageMSIX } from 'electron-windows-msix';
 
-import { MakerMsixConfig } from './Config';
+import { MakerMSIXConfig } from './Config';
 import { toMsixArch } from './util/arch';
 
 /**
  * Creates an MSIX package for your Electron app.
  * @experimental
  */
-export default class MakerMsix extends MakerBase<MakerMsixConfig> {
+export default class MakerMSIX extends MakerBase<MakerMSIXConfig> {
   name = 'msix';
   defaultPlatforms: ForgePlatform[] = ['win32'];
 
@@ -47,3 +47,5 @@ export default class MakerMsix extends MakerBase<MakerMsixConfig> {
     return [result.msixPackage];
   }
 }
+
+export { MakerMSIX, MakerMSIXConfig };


### PR DESCRIPTION
Fast follow-up to #3978. Adds some missing named exports we forgot in the initial PR.