### PR TITLE
fix(msix): use temp staging folder and fix types

### DIFF
--- a/packages/maker/msix/src/Config.ts
+++ b/packages/maker/msix/src/Config.ts
@@ -9,8 +9,8 @@ type SemiPartial<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
  * The configuration object for the MSIX maker.
  * The `outputDir` and `appDir` parameters are preconfigured by Forge so that the
  * Maker uses the package output and can be then used to publish the app.
- * 
- * Certain manifest variables are given good defaults by Forge, you can override these
+ *
+ * Certain manifest variables are given good defaults by Forge. You can override these
  * if required.
  *
  * @see https://github.com/bitdisaster/electron-windows-msix/blob/master/src/types.ts

--- a/packages/maker/msix/src/MakerMSIX.ts
+++ b/packages/maker/msix/src/MakerMSIX.ts
@@ -49,7 +49,7 @@ export default class MakerMSIX extends MakerBase<MakerMSIXConfig> {
           ...manifestVariables,
         },
         appDir: dir,
-        outputDir: makeDir,
+        outputDir: tmpFolder,
       });
 
       const outputPath = path.resolve(


### PR DESCRIPTION
We shouldn't leave junk in the `makeDir` so instead we do the make in a temp folder and steal the msix when we're done.

Also fixes the types around some defaults