### PR TITLE
docs: update CONTRIBUTING to include build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,6 +146,7 @@ This guide is for maintainers who have:
 - Check that the latest CI run passed on `main` on [GitHub](https://github.com/electron/forge/actions?query=workflow:CI).
 - Remove all untracked files and directories from your checkout with `git clean -fdx`.
 - Install dependencies with `yarn install`.
+- Build packages with `yarn build`.
 
 ### 2. Publish all npm packages
 


### PR DESCRIPTION
- [ ] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [ ] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
After updating our build pipeline, `yarn build` is no longer run automatically prior to publish as part of the `yarn lerna:publish` command - it must be run prior to publish. This PR updates the release process docs accordingly

Addresses #4026