### PR TITLE
fix(publisher-gcs): do not gzip artifacts

### DIFF
--- a/packages/publisher/gcs/src/PublisherGCS.ts
+++ b/packages/publisher/gcs/src/PublisherGCS.ts
@@ -73,7 +73,6 @@ export default class PublisherGCS extends PublisherStatic<PublisherGCSConfig> {
           metadata: this.config.metadataGenerator
             ? this.config.metadataGenerator(artifact)
             : {},
-          gzip: true,
           destination: this.keyForArtifact(artifact),
           ...uploadOptions,
         });


### PR DESCRIPTION
Setting `gzip: true` makes uploads faster but it makes download indeterminate and hard to cache by edge CDNs, this should be an opt-in choice so we're reverting to default behavior where assets are uploaded unencoded. This should be a no-op but landing in `next` to be safe