### PR TITLE
chore: update `node-abi` to latest

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -8,5 +8,6 @@ npmPreapprovedPackages:
   - '@electron/*'
   - '@electron-forge/*'
   - electron
+  - node-abi
 
 yarnPath: .yarn/releases/yarn-4.10.3.cjs

--- a/packages/template/vite-typescript/spec/fixtures/test-yarn.lock
+++ b/packages/template/vite-typescript/spec/fixtures/test-yarn.lock
@@ -5110,11 +5110,11 @@ __metadata:
   linkType: hard
 
 "node-abi@npm:^3.45.0":
-  version: 3.78.0
-  resolution: "node-abi@npm:3.78.0"
+  version: 3.80.0
+  resolution: "node-abi@npm:3.80.0"
   dependencies:
     semver: "npm:^7.3.5"
-  checksum: 10c0/aa5e2ac5283934b1175248a0cbe0106faeccebbc1d8e288c3b166f44da8d3665df661f0a63b232bcacab3e2d94c5c450a7f5c85bb70b6f54fbb4cc45cb62a9fb
+  checksum: 10c0/f98534a2d063e85b6b51c5e6f2abebd1d1d313855e29138d493cf178ce5c2ead18e562c3093a758654fd941c9353b8154a79acd10540d553726c4f690c31c44e
   languageName: node
   linkType: hard
 

--- a/packages/template/webpack-typescript/spec/fixtures/test-yarn.lock
+++ b/packages/template/webpack-typescript/spec/fixtures/test-yarn.lock
@@ -6010,11 +6010,11 @@ __metadata:
   linkType: hard
 
 "node-abi@npm:^3.45.0":
-  version: 3.78.0
-  resolution: "node-abi@npm:3.78.0"
+  version: 3.80.0
+  resolution: "node-abi@npm:3.80.0"
   dependencies:
     semver: "npm:^7.3.5"
-  checksum: 10c0/aa5e2ac5283934b1175248a0cbe0106faeccebbc1d8e288c3b166f44da8d3665df661f0a63b232bcacab3e2d94c5c450a7f5c85bb70b6f54fbb4cc45cb62a9fb
+  checksum: 10c0/f98534a2d063e85b6b51c5e6f2abebd1d1d313855e29138d493cf178ce5c2ead18e562c3093a758654fd941c9353b8154a79acd10540d553726c4f690c31c44e
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15170,11 +15170,11 @@ __metadata:
   linkType: hard
 
 "node-abi@npm:^3.45.0":
-  version: 3.76.0
-  resolution: "node-abi@npm:3.76.0"
+  version: 3.80.0
+  resolution: "node-abi@npm:3.80.0"
   dependencies:
     semver: "npm:^7.3.5"
-  checksum: 10c0/f92489e5229ec62b4c9fc3a1690743ddf17b406afd12d5fa2742a3c95bdc06bdc97144882f8c145eebf263c89541de0780266f777a1943e3273b57ebdbf503c8
+  checksum: 10c0/f98534a2d063e85b6b51c5e6f2abebd1d1d313855e29138d493cf178ce5c2ead18e562c3093a758654fd941c9353b8154a79acd10540d553726c4f690c31c44e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Updates `node-abi` for Electron 39 compatibility.
* Updates the lockfile fixtures.
* Adds `node-abi` to the allowlist for pre-approved packages in `.yarnrc.yml`.