### PR TITLE
fix:Can't put a space in app name #4055

### DIFF
--- a/packages/maker/dmg/src/MakerDMG.ts
+++ b/packages/maker/dmg/src/MakerDMG.ts
@@ -33,11 +33,15 @@ export default class MakerDMG extends MakerBase<MakerDMGConfig> {
     );
 
     await this.ensureFile(outPath);
+    // Escape appName and appPath by wrapping them in quotes.
+    // This avoids macOS treating spaces as argument separators during
+    // DMG creation (fixes issue #4055).
+    const escapedAppPath = `"${path.resolve(dir, `${appName}.app`)}"`;
     const dmgConfig: ElectronInstallerDMGOptions = {
       overwrite: true,
-      name: appName,
+      name: `"${appName}"`, // escaped name
       ...this.config,
-      appPath: path.resolve(dir, `${appName}.app`),
+      appPath: escapedAppPath, // escaped app path
       out: path.dirname(outPath),
     };
     await createDMG(dmgConfig);


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [ ] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [ ] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
I wrapped app name and app path in double quote, this avoids macOS treating spaces as argument separators during