### PR TITLE
build: target "next" branch in gh release create

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,4 +123,4 @@ jobs:
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ fromJSON(steps.secret-service.outputs.secrets).GITHUB_TOKEN }}
-        run: gh release create "v${{ steps.version.outputs.version }}" --generate-notes --prerelease
+        run: gh release create "v${{ steps.version.outputs.version }}" --target next --generate-notes --prerelease


### PR DESCRIPTION
This PR modifies the automated release action to target the `next` branch by default, rather than `main`