### PR TITLE
fix(core): prevent duplicate app restarts when typing 'rs' multiple times

### DIFF
--- a/packages/api/core/src/api/start.ts
+++ b/packages/api/core/src/api/start.ts
@@ -287,7 +287,7 @@ export default autoTrace(
 
     if (interactive) {
       process.stdin.on('data', (data) => {
-        if (data.toString().trim() === 'rs' && lastSpawned) {
+        if (data.toString().trim() === 'rs' && lastSpawned && !lastSpawned.restarted) {
           readline.moveCursor(process.stdout, 0, -1);
           readline.clearLine(process.stdout, 0);
           readline.cursorTo(process.stdout, 0);


### PR DESCRIPTION
When typing 'rs' multiple times before the app restarts, each 'rs' command attached a new 'exit' listener. This caused multiple apps to launch when the process finally exited. Adding a check for lastSpawned.restarted ensures subsequent 'rs' commands are ignored until the restart completes.
