### PR TITLE
ci: run post-merge on `next` branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - next
     tags:
       - v[0-9]+.[0-9]+.[0-9]+*
   pull_request:


### PR DESCRIPTION
Ensures that we have a proper post-merge CI