### PR TITLE
fix(create-electron-app): add missing `repository` field

### DIFF
--- a/packages/external/create-electron-app/package.json
+++ b/packages/external/create-electron-app/package.json
@@ -2,6 +2,7 @@
   "name": "create-electron-app",
   "version": "7.11.0",
   "description": "Create Electron App",
+  "repository": "https://github.com/electron/forge",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "author": "Samuel Attard",


### PR DESCRIPTION
Backport of https://github.com/electron/forge/commit/1aa6e408c2db32dbe57a7407b4e875b5a4f6ce96. Our v7.11.0 publish job failed here due to npm provenance in `create-electron-app` requiring `repository` in package.json