### PR TITLE
build: isolate yarn cache when running verdaccio

### DIFF
--- a/tools/verdaccio/spawn-verdaccio.ts
+++ b/tools/verdaccio/spawn-verdaccio.ts
@@ -137,6 +137,12 @@ async function runCommand(args: string[]) {
   console.log('🗑️  Pruning pnpm store before running command');
   await spawnPromise('pnpm', ['store', 'prune']);
 
+  /**
+   * Avoid polluting the global yarn cache.
+   */
+  const tempYarnGlobal = path.join(STORAGE_PATH, '.yarn-global');
+  fs.promises.mkdir(tempYarnGlobal, { recursive: true });
+
   console.log(`🏃 Running: ${args.join(' ')}`);
   console.log(`   Using registry: ${VERDACCIO_URL}`);
 
@@ -152,6 +158,13 @@ async function runCommand(args: string[]) {
       YARN_NPM_REGISTRY_SERVER: VERDACCIO_URL,
       // https://yarnpkg.com/configuration/yarnrc#unsafeHttpWhitelist
       YARN_UNSAFE_HTTP_WHITELIST: LOCALHOST,
+      // Isolate package manager caches so Verdaccio packages
+      // don't corrupt the global caches. These directories live
+      // under STORAGE_PATH and get cleaned up on next run.
+      // https://yarnpkg.com/configuration/yarnrc#globalFolder
+      YARN_GLOBAL_FOLDER: tempYarnGlobal,
+      // https://yarnpkg.com/configuration/yarnrc#enableGlobalCache
+      YARN_ENABLE_GLOBAL_CACHE: 'false',
     },
   });
 }


### PR DESCRIPTION

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Small PR to avoid polluting the global Yarn Berry cache with Verdaccio.

Without this, running `npx create-electron-app@alpha` with Yarn will generate invalid checksums if you're installing a version number that was previously published to the Verdaccio registry.

This leads to scary errors like:

```text
➤ YN0018: │ @electron-forge/core@npm:8.0.0-alpha.4: The remote archive doesn't match the expected checksum
```

This PR sets the Yarn cache folders to a subfolder of the Verdaccio `STORAGE_PATH`, which gets cleaned up at the end of every Verdaccio run.