### PR TITLE
feat(package): API returns result

### DIFF
--- a/packages/api/core/spec/slow/package.slow.spec.ts
+++ b/packages/api/core/spec/slow/package.slow.spec.ts
@@ -25,9 +25,20 @@ describe('Package', () => {
   it('can package an Electron app', async () => {
     expect(fs.existsSync(outDir)).toEqual(false);
 
-    await api.package({ dir, outDir });
+    const results = await api.package({ dir, outDir });
 
-    // should respect outDir
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual(
+      expect.objectContaining({
+        platform: process.platform,
+        arch: process.arch,
+        packagedPath: expect.any(String),
+      }),
+    );
+
+    // sanity check: absolute path exists and respects outDir
+    expect(path.isAbsolute(results[0].packagedPath)).toBe(true);
+    expect(fs.existsSync(results[0].packagedPath)).toBe(true);
     expect(fs.existsSync(outDir)).toEqual(true);
 
     // should remove Forge config from packaged app's package.json

--- a/packages/api/core/src/api/index.ts
+++ b/packages/api/core/src/api/index.ts
@@ -1,4 +1,8 @@
-import { ElectronProcess, ForgeMakeResult } from '@electron-forge/shared-types';
+import {
+  ElectronProcess,
+  ForgeMakeResult,
+  ForgePackageResult,
+} from '@electron-forge/shared-types';
 
 import ForgeUtils from '../util/index.js';
 
@@ -16,10 +20,10 @@ export class ForgeAPI {
   }
 
   /**
-   * Resolves hooks if they are a path to a file (instead of a `Function`)
+   * Package an Electron application
    */
-  async package(opts: PackageOptions): Promise<void> {
-    await _package(opts);
+  package(opts: PackageOptions): Promise<ForgePackageResult[]> {
+    return _package(opts);
   }
 
   /**
@@ -44,6 +48,7 @@ const utils = new ForgeUtils();
 
 export {
   ForgeMakeResult,
+  ForgePackageResult,
   ElectronProcess,
   ForgeUtils,
   MakeOptions,

--- a/packages/api/core/src/api/package.ts
+++ b/packages/api/core/src/api/package.ts
@@ -18,6 +18,7 @@ import {
   ForgeListrTask,
   ForgeListrTaskDefinition,
   ForgeListrTaskFn,
+  ForgePackageResult,
   ForgePlatform,
   ResolvedForgeConfig,
 } from '@electron-forge/shared-types';
@@ -70,9 +71,7 @@ type InternalTargetDefinition = TargetDefinition & {
   forUniversal?: boolean;
 };
 
-type PackageResult = TargetDefinition & {
-  packagedPath: string;
-};
+type PackageResult = ForgePackageResult;
 
 export interface PackageOptions {
   /**
@@ -657,7 +656,7 @@ export default autoTrace(
     return runner.ctx.targets.map((target, index) => ({
       platform: target.platform,
       arch: target.arch,
-      packagedPath: outputPaths[index],
+      packagedPath: path.resolve(outputPaths[index]),
     }));
   },
 );

--- a/packages/utils/types/src/index.ts
+++ b/packages/utils/types/src/index.ts
@@ -159,6 +159,25 @@ export interface ResolvedForgeConfig {
   publishers: ForgeConfigPublisher[];
 }
 export type ForgeConfig = Partial<Omit<ResolvedForgeConfig, 'pluginInterface'>>;
+
+/**
+ * Return result for the Package command
+ */
+export interface ForgePackageResult {
+  /**
+   * The platform for this packaged app
+   */
+  platform: ForgePlatform;
+  /**
+   * The arch for this packaged app
+   */
+  arch: ForgeArch;
+  /**
+   * The path to the packaged app
+   */
+  packagedPath: string;
+}
+
 export interface ForgeMakeResult {
   /**
    * An array of paths to artifacts generated for this make run


### PR DESCRIPTION
A bit of additional plumbing.

`make` returns an array of the resulting artifacts. Why not `package` too?