### PR TITLE
chore: fix `got` deps in lockfile

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10846,7 +10846,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"got@npm:^14.0.0, got@npm:^14.4.5":
+"got@npm:^14.4.5":
   version: 14.6.4
   resolution: "got@npm:14.6.4"
   dependencies:


### PR DESCRIPTION
Two PRs landed recently with lockfile changes (#4189 #4190). I think there was a collision in the diffs causing `yarn --immutable` to fail on `next`.

We might want to turn on the merge queue for `next` to fix this issue. 🤔 