### PR TITLE
fix(plugin-vite): ignore .git directory in dev mode file watcher

### DIFF
--- a/packages/plugin/vite/src/config/vite.base.config.ts
+++ b/packages/plugin/vite/src/config/vite.base.config.ts
@@ -24,7 +24,7 @@ export function getBuildConfig(env: ConfigEnv<'build'>): UserConfig {
       emptyOutDir: false,
       // 🚧 Multiple builds may conflict.
       outDir: '.vite/build',
-      watch: command === 'serve' ? {} : null,
+      watch: command === 'serve' ? { exclude: '**/.git/**' } : null,
       minify: command === 'build',
     },
     clearScreen: false,


### PR DESCRIPTION
## Summary
- Adds `**/.git/**` to the Rolldown `watch.exclude` pattern in `getBuildConfig()` when running in dev mode
- Prevents unnecessary HMR reloads triggered by git operations (e.g. rebase writing to `.git/rebase-merge/`)

## Context

When running `electron-forge start` with `plugin-vite`, the base build config sets `watch: {}` with no `ignored` patterns. This means Rolldown watches the entire project directory, including `.git/` subdirectories. Any git operation that writes files (rebase, merge, cherry-pick) triggers rebuilds and Vite HMR reloads.

## Test plan
- [x] Run `electron-forge start` with the Vite plugin
- [x] Perform a `git rebase` in the project directory during dev
- [x] Verify no HMR reloads are triggered by `.git/` file changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)