### PR TITLE
fix(core): convert absolute file path to file URL in `locateElectronExecutable`

### DIFF
--- a/packages/api/core/src/util/electron-executable.ts
+++ b/packages/api/core/src/util/electron-executable.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 
 import { getElectronModulePath } from '@electron-forge/core-utils';
 import logSymbols from 'log-symbols';
+import { pathToFileURL } from 'node:url';
 
 type PackageJSON = Record<string, unknown>;
 
@@ -23,7 +24,9 @@ export default async function locateElectronExecutable(
   const electronModuleEntryPoint = electronModulePath
     ? path.join(electronModulePath, 'index.js')
     : path.resolve(dir, 'node_modules/electron/index.js');
-  const { default: electronExecPath } = await import(electronModuleEntryPoint);
+  const { default: electronExecPath } = await import(
+    pathToFileURL(electronModuleEntryPoint).toString()
+  );
 
   if (typeof electronExecPath === 'string') {
     return electronExecPath;
@@ -33,7 +36,9 @@ export default async function locateElectronExecutable(
       `Returned Electron executable path (${electronExecPath}) is not a string. Defaulting to node_modules/electron.`,
     );
     const { default: fallbackExecPath } = await import(
-      path.resolve(dir, 'node_modules/electron/index.js')
+      pathToFileURL(
+        path.resolve(dir, 'node_modules/electron/index.js'),
+      ).toString()
     );
     return fallbackExecPath;
   }


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This prevents the following error when running `electron-forge start` on Windows:

```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
```

# Testing
- on a Windows machine, run `yarn spawn-verdaccio` to start the Verdaccio local registry
- create a project using the local version of `create-electron-app` with `$env:NPM_CONFIG_REGISTRY="http://127.0.0.1:4873"; node ./packages/external/create-electron-app/dist/create-electron-app.js vite-esm-test --template=vite-typescript`
- start the project with `cd vite-esm-test ; yarn electron-forge start`; it should launch the app correctly (on the `next` branch, I get the error mentioned above instead)
- there should be no changes on macOS or Linux