### PR TITLE
fix(init): ensure base tmpl scripts are added to `package.json`

### DIFF
--- a/packages/template/base/src/BaseTemplate.ts
+++ b/packages/template/base/src/BaseTemplate.ts
@@ -143,10 +143,11 @@ export class BaseTemplate implements ForgeTemplate {
       );
       if (fs.existsSync(templatePackageJSONPath)) {
         const templatePackageJSON = await fs.readJson(templatePackageJSONPath);
-        const { dependencies, devDependencies, ...rest } = templatePackageJSON;
+        const { dependencies, devDependencies, scripts, ...rest } =
+          templatePackageJSON;
         Object.assign(packageJSON, rest);
-        if (rest.scripts) {
-          packageJSON.scripts = { ...packageJSON.scripts, ...rest.scripts };
+        if (scripts) {
+          packageJSON.scripts = { ...packageJSON.scripts, ...scripts };
         }
       }
     }

--- a/packages/template/vite-typescript/spec/ViteTypeScriptTemplate.slow.verdaccio.spec.ts
+++ b/packages/template/vite-typescript/spec/ViteTypeScriptTemplate.slow.verdaccio.spec.ts
@@ -67,6 +67,16 @@ describe('ViteTypeScriptTemplate', () => {
       const packageJSON = JSON.parse(packageJSONString);
       expect(packageJSON).toHaveProperty('private', true);
     });
+
+    it('should contain electron-forge scripts in package.json', async () => {
+      const packageJSON = JSON.parse(
+        await fs.promises.readFile(path.join(dir, 'package.json'), 'utf-8'),
+      );
+      expect(packageJSON.scripts.start).toBe('electron-forge start');
+      expect(packageJSON.scripts.package).toBe('electron-forge package');
+      expect(packageJSON.scripts.make).toBe('electron-forge make');
+      expect(packageJSON.scripts.publish).toBe('electron-forge publish');
+    });
   });
 
   describe('lint', () => {

--- a/packages/template/webpack-typescript/spec/WebpackTypeScript.slow.verdaccio.spec.ts
+++ b/packages/template/webpack-typescript/spec/WebpackTypeScript.slow.verdaccio.spec.ts
@@ -60,6 +60,16 @@ describe('WebpackTypeScriptTemplate', () => {
     expect(packageJSON).toHaveProperty('private', true);
   });
 
+  it('should contain electron-forge scripts in package.json', async () => {
+    const packageJSON = JSON.parse(
+      await fs.promises.readFile(path.join(dir, 'package.json'), 'utf-8'),
+    );
+    expect(packageJSON.scripts.start).toBe('electron-forge start');
+    expect(packageJSON.scripts.package).toBe('electron-forge package');
+    expect(packageJSON.scripts.make).toBe('electron-forge make');
+    expect(packageJSON.scripts.publish).toBe('electron-forge publish');
+  });
+
   describe('lint', () => {
     it('should initially pass the linting process', async () => {
       delete process.env.TS_NODE_PROJECT;


### PR DESCRIPTION
This is a regression from #4175, where `electron-forge` scripts don't get written on init due to improper destructuring before the `Object.assign` call.

Added a few regression tests as well. :)