### PR TITLE
fix: use `file://` URLs when dynamically importing local paths

### DIFF
--- a/packages/api/core/spec/slow/install-dependencies.slow.spec.ts
+++ b/packages/api/core/spec/slow/install-dependencies.slow.spec.ts
@@ -7,6 +7,7 @@ import {
   PACKAGE_MANAGERS,
 } from '@electron-forge/core-utils';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { pathToFileURL } from 'node:url';
 
 describe.runIf(!(process.platform === 'linux' && process.env.CI))(
   'install-dependencies',
@@ -25,7 +26,9 @@ describe.runIf(!(process.platform === 'linux' && process.env.CI))(
       ]);
 
       const packageJSON = await import(
-        path.resolve(installDir, 'node_modules', 'debug', 'package.json')
+        pathToFileURL(
+          path.resolve(installDir, 'node_modules', 'debug', 'package.json'),
+        ).toString()
       );
       expect(packageJSON.version).not.toEqual('2.0.0');
     });

--- a/packages/api/core/src/util/forge-config.ts
+++ b/packages/api/core/src/util/forge-config.ts
@@ -7,6 +7,7 @@ import { createJiti } from 'jiti';
 import { runMutatingHook } from './hook.js';
 import PluginInterface from './plugin-interface.js';
 import { readRawPackageJson } from './read-package-json.js';
+import { pathToFileURL } from 'node:url';
 
 const underscoreCase = (str: string) =>
   str
@@ -173,7 +174,7 @@ export default async (dir: string): Promise<ResolvedForgeConfig> => {
       if (loadFn) {
         loaded = await loadFn(forgeConfigPath);
       } else {
-        loaded = await import(forgeConfigPath);
+        loaded = await import(pathToFileURL(forgeConfigPath).toString());
       }
       const maybeForgeConfig = 'default' in loaded ? loaded.default : loaded;
       forgeConfig =

--- a/packages/api/core/src/util/import-search.ts
+++ b/packages/api/core/src/util/import-search.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 
 import { PossibleModule } from '@electron-forge/shared-types';
 import debug from 'debug';
+import { pathToFileURL } from 'node:url';
 
 const d = debug('electron-forge:import-search');
 
@@ -50,7 +51,7 @@ async function importSearchRaw<T>(
         moduleName,
       );
       d('testing local forge build', { moduleType, moduleName, localPath });
-      return await import(localPath);
+      return await import(pathToFileURL(localPath).toString());
     } catch {
       // Ignore
     }

--- a/packages/external/create-electron-app/spec/slow/init.slow.verdaccio.spec.ts
+++ b/packages/external/create-electron-app/spec/slow/init.slow.verdaccio.spec.ts
@@ -9,6 +9,7 @@ import semver from 'semver';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import { init } from '../../src/init';
+import { pathToFileURL } from 'node:url';
 
 describe('init', () => {
   let dir: string;
@@ -55,7 +56,9 @@ describe('init', () => {
         dir,
         electronVersion: 'v38.0.0',
       });
-      const packageJSON = await import(path.resolve(dir, 'package.json'));
+      const packageJSON = await import(
+        pathToFileURL(path.resolve(dir, 'package.json')).toString()
+      );
       expect(packageJSON.devDependencies.electron).toEqual('38.0.0');
     });
 
@@ -64,7 +67,9 @@ describe('init', () => {
         dir,
         electronVersion: '40.0.0-nightly.20251020',
       });
-      const packageJSON = await import(path.resolve(dir, 'package.json'));
+      const packageJSON = await import(
+        pathToFileURL(path.resolve(dir, 'package.json')).toString()
+      );
       expect(
         semver.valid(packageJSON.devDependencies['electron-nightly']),
       ).not.toBeNull();
@@ -76,7 +81,9 @@ describe('init', () => {
         dir,
         electronVersion: 'beta',
       });
-      const packageJSON = await import(path.resolve(dir, 'package.json'));
+      const packageJSON = await import(
+        pathToFileURL(path.resolve(dir, 'package.json')).toString()
+      );
       const prereleaseTag = semver.prerelease(
         packageJSON.devDependencies.electron,
       );
@@ -90,7 +97,9 @@ describe('init', () => {
         dir,
         electronVersion: 'nightly',
       });
-      const packageJSON = await import(path.resolve(dir, 'package.json'));
+      const packageJSON = await import(
+        pathToFileURL(path.resolve(dir, 'package.json')).toString()
+      );
       expect(
         semver.valid(packageJSON.devDependencies['electron-nightly']),
       ).not.toBeNull();

--- a/packages/external/create-electron-app/src/import.ts
+++ b/packages/external/create-electron-app/src/import.ts
@@ -18,6 +18,7 @@ import { merge } from 'lodash-es';
 
 import { initGit } from './init-scripts/init-git.js';
 import { deps, devDeps, exactDevDeps } from './init-scripts/init-npm.js';
+import { pathToFileURL } from 'node:url';
 
 const d = debug('electron-forge:import');
 
@@ -316,7 +317,12 @@ export const forgeImport = async ({
                       'detected existing Forge config in package.json, merging with base template Forge config',
                     );
                     const templateConfig = await import(
-                      path.resolve(baseTemplate.templateDir, 'forge.config.js')
+                      pathToFileURL(
+                        path.resolve(
+                          baseTemplate.templateDir,
+                          'forge.config.js',
+                        ),
+                      ).toString()
                     );
                     packageJSON = await readRawPackageJson(dir);
                     merge(templateConfig, packageJSON.config.forge); // mutates the templateConfig object

--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -24,6 +24,7 @@ import {
   isPreloadOnly,
   isPreloadOnlyEntries,
 } from './util/rendererTypeUtils.js';
+import { pathToFileURL } from 'node:url';
 
 type EntryType = string | string[] | Record<string, string | string[]>;
 type WebpackMode = 'production' | 'development';
@@ -97,9 +98,9 @@ export default class WebpackConfigGenerator {
 
     let rawConfig =
       typeof config === 'string'
-        ? ((await import(path.resolve(this.projectDir, config))) as MaybeESM<
-            webpack.Configuration | ConfigurationFactory
-          >)
+        ? ((await import(
+            pathToFileURL(path.resolve(this.projectDir, config)).toString()
+          )) as MaybeESM<webpack.Configuration | ConfigurationFactory>)
         : config;
 
     if (rawConfig && typeof rawConfig === 'object' && 'default' in rawConfig) {

--- a/packages/utils/core-utils/spec/package-manager.spec.ts
+++ b/packages/utils/core-utils/spec/package-manager.spec.ts
@@ -6,6 +6,8 @@ import {
   resolvePackageManager,
   spawnPackageManager,
 } from '../src/package-manager';
+import { pathToFileURL } from 'node:url';
+import path from 'node:path';
 
 vi.mock('@malept/cross-spawn-promise');
 vi.mock('find-up', async (importOriginal) => {
@@ -116,55 +118,47 @@ describe('package-manager', () => {
         delete process.env.npm_config_user_agent;
       });
 
+      const packageManagerPath = pathToFileURL(
+        path.resolve(import.meta.dirname, '../src/package-manager'),
+      ).toString();
+
       it('should accept a string with only the package manager name', async () => {
-        const { resolvePackageManager } = await import(
-          '../src/package-manager'
-        );
+        const { resolvePackageManager } = await import(packageManagerPath);
         const first = await resolvePackageManager('pnpm');
         expect(first.executable).toBe('pnpm');
         expect(first.version).toBe('latest');
       });
 
       it('should accept the @latest tag', async () => {
-        const { resolvePackageManager } = await import(
-          '../src/package-manager'
-        );
+        const { resolvePackageManager } = await import(packageManagerPath);
         const first = await resolvePackageManager('yarn@latest');
         expect(first.executable).toBe('yarn');
         expect(first.version).toBe('latest');
       });
 
       it('should accept a full version', async () => {
-        const { resolvePackageManager } = await import(
-          '../src/package-manager'
-        );
+        const { resolvePackageManager } = await import(packageManagerPath);
         const first = await resolvePackageManager('yarn@1.22.22');
         expect(first.executable).toBe('yarn');
         expect(first.version).toBe('1.22.22');
       });
 
       it('should accept a major.minor version', async () => {
-        const { resolvePackageManager } = await import(
-          '../src/package-manager'
-        );
+        const { resolvePackageManager } = await import(packageManagerPath);
         const first = await resolvePackageManager('yarn@1.22');
         expect(first.executable).toBe('yarn');
         expect(first.version).toBe('1.22');
       });
 
       it('should accept a major version', async () => {
-        const { resolvePackageManager } = await import(
-          '../src/package-manager'
-        );
+        const { resolvePackageManager } = await import(packageManagerPath);
         const first = await resolvePackageManager('yarn@1');
         expect(first.executable).toBe('yarn');
         expect(first.version).toBe('1');
       });
 
       it('should cache explicit argument and ignore later env / lockfile', async () => {
-        const { resolvePackageManager } = await import(
-          '../src/package-manager'
-        );
+        const { resolvePackageManager } = await import(packageManagerPath);
         const first = await resolvePackageManager('pnpm@10.0.0');
         expect(first.executable).toBe('pnpm');
         expect(first.version).toBe('10.0.0');
@@ -178,9 +172,7 @@ describe('package-manager', () => {
       });
 
       it('should fallback to npm and cache when explicit argument unsupported', async () => {
-        const { resolvePackageManager } = await import(
-          '../src/package-manager'
-        );
+        const { resolvePackageManager } = await import(packageManagerPath);
         vi.mocked(spawn).mockResolvedValue('9.99.99');
         const result = await resolvePackageManager('good coffee');
         expect(result.executable).toBe('npm');


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Follow-up to https://github.com/electron/forge/pull/4214, there are other dynamic imports failing on Windows right now.

