### PR TITLE
fix(cli): detect TTY for interactive mode instead of hardcoding true

### DIFF
--- a/packages/api/cli/spec/electron-forge-start.spec.ts
+++ b/packages/api/cli/spec/electron-forge-start.spec.ts
@@ -1,0 +1,70 @@
+import { api } from '@electron-forge/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockElectronProcess = vi.hoisted(() => ({
+  on: vi.fn((event: string, cb: (code: number) => void) => {
+    if (event === 'exit') cb(0);
+  }),
+  removeListener: vi.fn(),
+  restarted: false,
+}));
+
+vi.mock(import('@electron-forge/core'), async () => {
+  return {
+    api: {
+      start: vi.fn().mockResolvedValue(mockElectronProcess),
+    },
+  };
+});
+
+vi.mock(import('../src/util/terminate'), () => ({}));
+
+describe('electron-forge-start', () => {
+  const originalArgv = process.argv;
+  let originalIsTTY: boolean | undefined;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.argv = ['node', 'electron-forge-start.js'];
+    originalIsTTY = process.stdin.isTTY;
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    process.argv = originalArgv;
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: originalIsTTY,
+      configurable: true,
+    });
+  });
+
+  it('sets interactive to false when stdin is not a TTY', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: undefined,
+      configurable: true,
+    });
+    await import('../src/electron-forge-start');
+    expect(vi.mocked(api.start)).toHaveBeenCalledWith(
+      expect.objectContaining({ interactive: false }),
+    );
+  });
+
+  it('sets interactive to true when stdin is a TTY', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: true,
+      configurable: true,
+    });
+    await import('../src/electron-forge-start');
+    expect(vi.mocked(api.start)).toHaveBeenCalledWith(
+      expect.objectContaining({ interactive: true }),
+    );
+  });
+
+  it('passes args after -- to the Electron app', async () => {
+    process.argv = ['node', 'electron-forge-start.js', '--', '--foo', 'bar'];
+    await import('../src/electron-forge-start');
+    expect(vi.mocked(api.start)).toHaveBeenCalledWith(
+      expect.objectContaining({ args: ['--foo', 'bar'] }),
+    );
+  });
+});

--- a/packages/api/cli/src/electron-forge-start.ts
+++ b/packages/api/cli/src/electron-forge-start.ts
@@ -62,7 +62,7 @@ import { resolveWorkingDir } from './util/resolve-working-dir';
 
   const opts: StartOptions = {
     dir,
-    interactive: true,
+    interactive: process.stdin.isTTY ?? false,
     enableLogging: !!options.enableLogging,
     runAsNode: !!options.runAsNode,
     inspect: !!options.inspectElectron,


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

A very simple change to detect if stdin belongs to a proper tty before enabling interactive mode. This makes running forge in non interactive contexts possible.