### PR TITLE
refactor(plugin-vite): use codeSplitting:false for preload

### DIFF
--- a/packages/plugin/vite/spec/ViteConfig.spec.ts
+++ b/packages/plugin/vite/spec/ViteConfig.spec.ts
@@ -81,9 +81,9 @@ describe('ViteConfigGenerator', () => {
       'electron/renderer',
     ]);
     expect(buildConfig.build?.rollupOptions?.input).toEqual('src/preload.js');
+    expect(buildConfig.build?.codeSplitting).toBe(false);
     expect(buildConfig.build?.rollupOptions?.output).toEqual({
       format: 'cjs',
-      inlineDynamicImports: true,
       entryFileNames: '[name].js',
       chunkFileNames: '[name].js',
       assetFileNames: '[name].[ext]',

--- a/packages/plugin/vite/spec/ViteConfig.spec.ts
+++ b/packages/plugin/vite/spec/ViteConfig.spec.ts
@@ -81,9 +81,9 @@ describe('ViteConfigGenerator', () => {
       'electron/renderer',
     ]);
     expect(buildConfig.build?.rollupOptions?.input).toEqual('src/preload.js');
-    expect(buildConfig.build?.codeSplitting).toBe(false);
     expect(buildConfig.build?.rollupOptions?.output).toEqual({
       format: 'cjs',
+      codeSplitting: false,
       entryFileNames: '[name].js',
       chunkFileNames: '[name].js',
       assetFileNames: '[name].[ext]',

--- a/packages/plugin/vite/src/config/vite.preload.config.ts
+++ b/packages/plugin/vite/src/config/vite.preload.config.ts
@@ -14,14 +14,14 @@ export function getConfig(
   const config: UserConfig = {
     build: {
       copyPublicDir: false,
+      // Preload scripts require a single entrypoint.
+      codeSplitting: false,
       rollupOptions: {
         external: [...external, 'electron/renderer'],
         // Preload scripts may contain Web assets, so use the `build.rollupOptions.input` instead `build.lib.entry`.
         input: forgeConfigSelf.entry,
         output: {
           format: 'cjs',
-          // It should not be split chunks.
-          inlineDynamicImports: true,
           entryFileNames: '[name].js',
           chunkFileNames: '[name].js',
           assetFileNames: '[name].[ext]',

--- a/packages/plugin/vite/src/config/vite.preload.config.ts
+++ b/packages/plugin/vite/src/config/vite.preload.config.ts
@@ -14,14 +14,14 @@ export function getConfig(
   const config: UserConfig = {
     build: {
       copyPublicDir: false,
-      // Preload scripts require a single entrypoint.
-      codeSplitting: false,
       rollupOptions: {
         external: [...external, 'electron/renderer'],
         // Preload scripts may contain Web assets, so use the `build.rollupOptions.input` instead `build.lib.entry`.
         input: forgeConfigSelf.entry,
         output: {
           format: 'cjs',
+          // Preload scripts require a single entrypoint.
+          codeSplitting: false,
           entryFileNames: '[name].js',
           chunkFileNames: '[name].js',
           assetFileNames: '[name].[ext]',


### PR DESCRIPTION
Fixes a Vite 8 warning:

```
inlineDynamicImports option is deprecated, please use codeSplitting: false instead.
```