### PR TITLE
fix(maker-msix): ensure output has version and arch

### DIFF
--- a/packages/maker/msix/spec/MakerMSIX.spec.ts
+++ b/packages/maker/msix/spec/MakerMSIX.spec.ts
@@ -1,0 +1,72 @@
+import path from 'node:path';
+
+import { ForgeArch } from '@electron-forge/shared-types';
+import { packageMSIX } from 'electron-windows-msix';
+import fs from 'fs-extra';
+import { describe, expect, it, vi } from 'vitest';
+
+import { MakerMSIX } from '../src/MakerMSIX';
+
+vi.mock(import('electron-windows-msix'), () => {
+  return {
+    packageMSIX: vi.fn().mockResolvedValue({
+      msixPackage: '/tmp/mock-output.msix',
+    }),
+  };
+});
+
+vi.mock(import('fs-extra'), async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    default: {
+      ...mod.default,
+      mkdtemp: vi.fn().mockResolvedValue('/tmp/msix-maker-mock'),
+      mkdirp: vi.fn(),
+      move: vi.fn(),
+      remove: vi.fn(),
+    },
+  };
+});
+
+describe('MakerMSIX', () => {
+  const dir = '/my/test/dir/out';
+  const makeDir = '/my/test/dir/make';
+  const appName = 'My Test App';
+  const targetArch = 'x64' as ForgeArch;
+  const packageJSON = { version: '1.2.3' };
+
+  it('should generate an MSIX with version and arch in the filename', async () => {
+    const maker = new MakerMSIX({}, []);
+    await maker.prepareConfig(targetArch);
+    const output = await maker.make({
+      dir,
+      makeDir,
+      appName,
+      targetArch,
+      packageJSON,
+      targetPlatform: 'win32',
+      forgeConfig: null as any,
+    });
+
+    expect(output).toHaveLength(1);
+    expect(output[0]).toBe(
+      path.resolve(
+        makeDir,
+        'msix',
+        targetArch,
+        `${appName}-${packageJSON.version}-win32-${targetArch}.msix`,
+      ),
+    );
+    expect(vi.mocked(packageMSIX)).toHaveBeenCalledOnce();
+    expect(vi.mocked(fs.move)).toHaveBeenCalledWith(
+      '/tmp/mock-output.msix',
+      path.resolve(
+        makeDir,
+        'msix',
+        targetArch,
+        `${appName}-${packageJSON.version}-win32-${targetArch}.msix`,
+      ),
+    );
+  });
+});

--- a/packages/maker/msix/src/MakerMSIX.ts
+++ b/packages/maker/msix/src/MakerMSIX.ts
@@ -26,6 +26,7 @@ export default class MakerMSIX extends MakerBase<MakerMSIXConfig> {
     dir,
     makeDir,
     targetArch,
+    targetPlatform,
     packageJSON,
     appName,
   }: MakerOptions): Promise<string[]> {
@@ -56,7 +57,7 @@ export default class MakerMSIX extends MakerBase<MakerMSIXConfig> {
         makeDir,
         'msix',
         targetArch,
-        `${appName}.msix`,
+        `${appName}-${packageJSON.version}-${targetPlatform}-${targetArch}.msix`,
       );
       await fs.mkdirp(path.dirname(outputPath));
       await fs.move(result.msixPackage, outputPath);


### PR DESCRIPTION
One-liner fix. This is necessary for update.electronjs.org support (see https://github.com/electron/update.electronjs.org/pull/222).

cc @bitdisaster 