### PR TITLE
feat(plugin-vite): run main/preload dev builds in subprocess workers

### DIFF
--- a/packages/plugin/vite/src/VitePlugin.ts
+++ b/packages/plugin/vite/src/VitePlugin.ts
@@ -8,6 +8,7 @@ import fs from 'fs-extra';
 import { Listr, PRESET_TIMER } from 'listr2';
 import * as vite from 'vite';
 
+import { viteDevServerUrls } from './config/vite.base.config.js';
 import ViteConfigGenerator from './ViteConfig.js';
 
 import type { VitePluginConfig } from './Config.js';
@@ -16,6 +17,7 @@ import type {
   ForgeMultiHookMap,
   ResolvedForgeConfig,
 } from '@electron-forge/shared-types';
+import type { ChildProcess } from 'node:child_process';
 import type { AddressInfo } from 'node:net';
 import type { LibraryOptions } from 'vite';
 
@@ -76,6 +78,72 @@ function spawnViteBuild(
   });
 }
 
+function spawnViteBuildWatch(
+  pluginConfig: Pick<VitePluginConfig, 'build' | 'renderer'>,
+  index: number,
+  projectDir: string,
+  devServerUrls: Record<string, string>,
+  onReloadRenderers: () => void,
+): { child: ChildProcess; firstBuild: Promise<void> } {
+  const child = spawn(process.execPath, [subprocessWorkerPath], {
+    cwd: projectDir,
+    env: {
+      ...process.env,
+      FORGE_VITE_PROJECT_DIR: projectDir,
+      FORGE_VITE_KIND: 'build',
+      FORGE_VITE_INDEX: String(index),
+      FORGE_VITE_CONFIG: JSON.stringify(pluginConfig),
+      FORGE_VITE_WATCH: '1',
+      FORGE_VITE_DEV_SERVER_URLS: JSON.stringify(devServerUrls),
+    },
+    stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+  });
+
+  let settled = false;
+  let stderr = '';
+  child.stderr!.setEncoding('utf8');
+  child.stderr!.on('data', (chunk) => {
+    if (!settled) stderr += chunk;
+    process.stderr.write(chunk);
+  });
+  child.stdout!.setEncoding('utf8');
+  child.stdout!.on('data', (chunk) => process.stdout.write(chunk));
+
+  const firstBuild = new Promise<void>((resolve, reject) => {
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      stderr = '';
+      fn();
+    };
+
+    child.on('message', (msg: { type: string; message?: string }) => {
+      if (msg.type === 'first-build-done') {
+        settle(resolve);
+      } else if (msg.type === 'first-build-error') {
+        settle(() => reject(new Error(msg.message)));
+      } else if (msg.type === 'reload-renderers') {
+        onReloadRenderers();
+      }
+    });
+    child.on('error', (err) => settle(() => reject(err)));
+    child.on('close', (code, signal) => {
+      const reason = signal
+        ? `killed by signal ${signal}`
+        : `exited with code ${code}`;
+      settle(() =>
+        reject(
+          new Error(
+            `Vite watch subprocess ${reason} before first build completed${stderr ? `:\n${stderr}` : ''}`,
+          ),
+        ),
+      );
+    });
+  });
+
+  return { child, firstBuild };
+}
+
 function entryToDisplay(entry: LibraryOptions['entry']): string {
   if (typeof entry === 'string') return entry;
   if (Array.isArray(entry)) return entry.join(' ');
@@ -101,16 +169,9 @@ export default class VitePlugin extends PluginBase<VitePluginConfig> {
 
   private configGeneratorCache!: ViteConfigGenerator;
 
-  private watchers: vite.Rollup.RollupWatcher[] = [];
+  private watchChildren: ChildProcess[] = [];
 
   private servers: vite.ViteDevServer[] = [];
-
-  // Matches the format of the default Vite logger
-  private timeFormatter = new Intl.DateTimeFormat(undefined, {
-    hour: 'numeric',
-    minute: 'numeric',
-    second: 'numeric',
-  });
 
   init = (dir: string): void => {
     this.setDirectories(dir);
@@ -285,10 +346,11 @@ the generated files). Instead, it is ${JSON.stringify(pj.main)}.`);
 
   // Main process, Preload scripts and Worker process, etc.
   build = async (task?: ForgeListrTask<null>): Promise<Listr | void> => {
+    const targets = this.config.build
+      .map((spec, index) => ({ spec, index }))
+      .filter(({ spec }) => spec.config);
+
     if (this.isProd) {
-      const targets = this.config.build
-        .map((spec, index) => ({ spec, index }))
-        .filter(({ spec }) => spec.config);
       return task?.newListr(
         targets.map(({ spec, index }) => ({
           title: `Building ${chalk.green(entryToDisplay(spec.entry))}`,
@@ -309,129 +371,28 @@ the generated files). Instead, it is ${JSON.stringify(pj.main)}.`);
       );
     }
 
-    const configs = await this.configGenerator.getBuildConfigs();
-    /**
-     * Checks if the result of the Vite build is a Rollup watcher.
-     * This should happen iff we're running `electron-forge start`.
-     */
-    const isRollupWatcher = (
-      x:
-        | vite.Rollup.RollupWatcher
-        | vite.Rollup.RollupOutput
-        | vite.Rollup.RollupOutput[],
-    ): x is vite.Rollup.RollupWatcher =>
-      x &&
-      typeof x === 'object' &&
-      'on' in x &&
-      typeof x.on === 'function' &&
-      'close' in x &&
-      typeof x.close === 'function';
-
-    /**
-     * Rollup's `input` can be a string, an array of strings, or an object.
-     * This function converts the input to a string for the Forge CLI to consume.
-     *
-     * @see https://rollupjs.org/configuration-options/#input
-     */
-    const parseInputOptionToString = (input: vite.Rollup.InputOption) => {
-      if (typeof input === 'string') {
-        return input;
-      } else if (Array.isArray(input)) {
-        return input.join(' ');
-      } else {
-        return Object.keys(input).join(' ');
-      }
-    };
-
     return task?.newListr(
-      configs.map((userConfig) => {
-        let target = '';
-        const input = userConfig.build?.rollupOptions?.input;
-        if (input) {
-          target = parseInputOptionToString(input);
-        } else if (
-          typeof userConfig.build?.lib !== 'boolean' &&
-          userConfig.build?.lib?.entry
-        ) {
-          target = parseInputOptionToString(userConfig.build.lib.entry);
-        }
-
-        return {
-          title: `Building ${chalk.green(target)} target`,
-          task: async (_ctx, subtask) => {
-            // We wrap this function in a Promise to ensure that the task is marked as completed
-            // only after all bundles are done generated. This is done in the `closeBundle` Rollup hook
-            // rather than when the `vite.build` promise resolves.
-            await new Promise<void>((resolve, reject) => {
-              vite
-                .build({
-                  // Avoid recursive builds caused by users configuring @electron-forge/plugin-vite in Vite config file.
-                  configFile: false,
-                  // We suppress Vite output and instead log lines using RollupWatcher events
-                  logLevel: 'silent',
-                  ...userConfig,
-                  plugins: [
-                    // This plugin controls the output of the first-time Vite build that happens.
-                    // `buildEnd` and `closeBundle` are Rollup output generation hooks.
-                    // See https://rollupjs.org/plugin-development/#output-generation-hooks
-                    {
-                      name: '@electron-forge/plugin-vite:build-done',
-                      buildEnd(err) {
-                        if (err instanceof Error) {
-                          d(
-                            'buildEnd rollup hook called with error so build failed',
-                          );
-                          reject(err);
-                        }
-                      },
-                      closeBundle() {
-                        d(
-                          'no error in buildEnd and reached closeBundle so build succeeded',
-                        );
-                        resolve();
-                      },
-                    },
-                    ...(userConfig.plugins ?? []),
-                  ],
-                  clearScreen: false,
-                })
-                .then((result) => {
-                  // When running `start` and enabling watch mode in Vite, the Rollup watcher
-                  // emits events for subsequent builds.
-                  if (isRollupWatcher(result)) {
-                    result.on('event', (event) => {
-                      if (
-                        event.code === 'ERROR' &&
-                        userConfig.logLevel !== 'silent'
-                      ) {
-                        console.error(
-                          `\n${chalk.dim(this.timeFormatter.format(new Date()))} ${event.error.message}`,
-                        );
-                      } else if (
-                        event.code === 'BUNDLE_END' &&
-                        (!userConfig.logLevel || userConfig.logLevel === 'info')
-                      ) {
-                        console.log(
-                          `${chalk.dim(this.timeFormatter.format(new Date()))} ${chalk.cyan.bold('[@electron-forge/plugin-vite]')} ${chalk.green(
-                            'target built',
-                          )} ${chalk.dim(target)}`,
-                        );
-                      }
-                    });
-                    this.watchers.push(result);
-                  } else {
-                    subtask.title = `Built target ${chalk.dim(target)}`;
-                  }
-                  return result;
-                })
-                .catch(reject);
-            });
-          },
-        };
-      }),
+      targets.map(({ spec, index }) => ({
+        title: `Building ${chalk.green(entryToDisplay(spec.entry))} target`,
+        task: async () => {
+          const { child, firstBuild } = spawnViteBuildWatch(
+            this.serializableConfig,
+            index,
+            this.projectDir,
+            viteDevServerUrls,
+            () => {
+              for (const server of this.servers) {
+                server.ws.send({ type: 'full-reload' });
+              }
+            },
+          );
+          this.watchChildren.push(child);
+          await firstBuild;
+        },
+      })),
       {
         concurrent: this.config.concurrent ?? true,
-        exitOnError: this.isProd,
+        exitOnError: false,
       },
     );
   };
@@ -524,11 +485,11 @@ the generated files). Instead, it is ${JSON.stringify(pj.main)}.`);
   ): void => {
     d('handling process exit with:', options);
     if (options.cleanup) {
-      for (const watcher of this.watchers) {
-        d('cleaning vite watcher');
-        watcher.close();
+      for (const child of this.watchChildren) {
+        d('killing vite watch subprocess');
+        child.kill();
       }
-      this.watchers = [];
+      this.watchChildren = [];
 
       for (const server of this.servers) {
         d('cleaning http server');

--- a/packages/plugin/vite/src/config/vite.base.config.ts
+++ b/packages/plugin/vite/src/config/vite.base.config.ts
@@ -11,7 +11,7 @@ export const external = [
 
 // Used for hot reload after preload scripts.
 const viteDevServers: Record<string, ViteDevServer> = {};
-const viteDevServerUrls: Record<string, string> = {};
+export const viteDevServerUrls: Record<string, string> = {};
 
 export function getBuildConfig(env: ConfigEnv<'build'>): UserConfig {
   const { root, mode, command } = env;

--- a/packages/plugin/vite/src/subprocess-worker.ts
+++ b/packages/plugin/vite/src/subprocess-worker.ts
@@ -1,5 +1,7 @@
+import chalk from 'chalk';
 import { build } from 'vite';
 
+import { viteDevServerUrls } from './config/vite.base.config.js';
 import ViteConfigGenerator from './ViteConfig.js';
 
 import type {
@@ -7,11 +9,14 @@ import type {
   VitePluginConfig,
   VitePluginRendererConfig,
 } from './Config.js';
+import type { Rollup } from 'vite';
 
 const projectDir = process.env.FORGE_VITE_PROJECT_DIR;
 const kind = process.env.FORGE_VITE_KIND as 'build' | 'renderer';
 const index = Number(process.env.FORGE_VITE_INDEX);
 const rawConfig = process.env.FORGE_VITE_CONFIG;
+const watch = process.env.FORGE_VITE_WATCH === '1';
+const rawDevServerUrls = process.env.FORGE_VITE_DEV_SERVER_URLS;
 
 if (!projectDir || !kind || !rawConfig || !Number.isInteger(index)) {
   console.error(
@@ -25,7 +30,7 @@ if (!projectDir || !kind || !rawConfig || !Number.isInteger(index)) {
 // defines when building main targets.
 const pluginConfig = JSON.parse(rawConfig) as VitePluginConfig;
 
-const generator = new ViteConfigGenerator(pluginConfig, projectDir, true);
+const generator = new ViteConfigGenerator(pluginConfig, projectDir, !watch);
 
 let spec: VitePluginBuildConfig | VitePluginRendererConfig;
 let target: 'main' | 'preload' | 'renderer';
@@ -37,11 +42,98 @@ if (kind === 'build') {
   target = 'renderer';
 }
 
+// Seed the module-level URL map so getBuildDefine() produces the same
+// *_VITE_DEV_SERVER_URL defines the in-process path would have.
+if (rawDevServerUrls) {
+  Object.assign(viteDevServerUrls, JSON.parse(rawDevServerUrls));
+}
+
 const resolved = await generator.resolveConfig(spec, target);
 
-await build({
-  configFile: false,
-  logLevel: 'error',
-  ...resolved,
-  clearScreen: false,
-});
+if (!watch) {
+  await build({
+    configFile: false,
+    logLevel: 'error',
+    ...resolved,
+    clearScreen: false,
+  });
+} else {
+  const timeFormatter = new Intl.DateTimeFormat(undefined, {
+    hour: 'numeric',
+    minute: 'numeric',
+    second: 'numeric',
+  });
+
+  const input =
+    resolved.build?.rollupOptions?.input ??
+    (typeof resolved.build?.lib !== 'boolean'
+      ? resolved.build?.lib?.entry
+      : undefined);
+  const targetDisplay = !input
+    ? ''
+    : typeof input === 'string'
+      ? input
+      : Array.isArray(input)
+        ? input.join(' ')
+        : Object.keys(input).join(' ');
+
+  let firstBuildSent = false;
+  const sendOnce = (msg: { type: string; message?: string }) => {
+    if (firstBuildSent) return;
+    firstBuildSent = true;
+    process.send?.(msg);
+  };
+
+  const result = await build({
+    configFile: false,
+    logLevel: 'silent',
+    ...resolved,
+    plugins: [
+      {
+        name: '@electron-forge/plugin-vite:build-done',
+        buildEnd(err) {
+          if (err instanceof Error) {
+            sendOnce({ type: 'first-build-error', message: err.message });
+          }
+        },
+        closeBundle() {
+          sendOnce({ type: 'first-build-done' });
+          if (target === 'preload') {
+            // pluginHotRestart('reload') is a no-op here because viteDevServers
+            // lives in the parent; ask the parent to fan out the ws full-reload.
+            process.send?.({ type: 'reload-renderers' });
+          }
+        },
+      },
+      ...(resolved.plugins ?? []),
+    ],
+    clearScreen: false,
+  });
+
+  const isRollupWatcher = (x: unknown): x is Rollup.RollupWatcher =>
+    !!x &&
+    typeof x === 'object' &&
+    'on' in x &&
+    typeof x.on === 'function' &&
+    'close' in x &&
+    typeof x.close === 'function';
+
+  if (isRollupWatcher(result)) {
+    result.on('event', (event) => {
+      if (event.code === 'ERROR' && resolved.logLevel !== 'silent') {
+        console.error(
+          `\n${chalk.dim(timeFormatter.format(new Date()))} ${event.error.message}`,
+        );
+      } else if (
+        event.code === 'BUNDLE_END' &&
+        (!resolved.logLevel || resolved.logLevel === 'info')
+      ) {
+        console.log(
+          `${chalk.dim(timeFormatter.format(new Date()))} ${chalk.cyan.bold('[@electron-forge/plugin-vite]')} ${chalk.green(
+            'target built',
+          )} ${chalk.dim(targetDisplay)}`,
+        );
+      }
+    });
+  }
+}

--- a/packages/plugin/vite/src/subprocess-worker.ts
+++ b/packages/plugin/vite/src/subprocess-worker.ts
@@ -58,12 +58,15 @@ if (!watch) {
     clearScreen: false,
   });
 } else {
+  // Matches the format of the default Vite logger
   const timeFormatter = new Intl.DateTimeFormat(undefined, {
     hour: 'numeric',
     minute: 'numeric',
     second: 'numeric',
   });
 
+  // Rollup's `input` can be a string, an array of strings, or an object.
+  // https://rollupjs.org/configuration-options/#input
   const input =
     resolved.build?.rollupOptions?.input ??
     (typeof resolved.build?.lib !== 'boolean'
@@ -85,10 +88,14 @@ if (!watch) {
   };
 
   const result = await build({
+    // Avoid recursive builds caused by users configuring @electron-forge/plugin-vite in Vite config file.
     configFile: false,
+    // We suppress Vite output and instead log lines using RollupWatcher events
     logLevel: 'silent',
     ...resolved,
     plugins: [
+      // `buildEnd` and `closeBundle` are Rollup output generation hooks.
+      // https://rollupjs.org/plugin-development/#output-generation-hooks
       {
         name: '@electron-forge/plugin-vite:build-done',
         buildEnd(err) {
@@ -119,6 +126,7 @@ if (!watch) {
     typeof x.close === 'function';
 
   if (isRollupWatcher(result)) {
+    // The Rollup watcher emits events for subsequent builds.
     result.on('event', (event) => {
       if (event.code === 'ERROR' && resolved.logLevel !== 'silent') {
         console.error(


### PR DESCRIPTION
## Summary

- Run main/preload dev-mode (`start`) Vite builds in the existing subprocess worker instead of in-process, matching the production build path.
- Worker gains a `FORGE_VITE_WATCH=1` mode: IPC `first-build-done` / `first-build-error` to resolve the Listr task, and the worker prints rebuild/error log lines itself with the same formatting as before.
- Bridge the two bits of in-process shared state the old path relied on: the renderer dev-server URL map (passed via env and seeded before `getBuildDefine` runs) and preload → renderer hot-reload (IPC `reload-renderers` → parent calls `server.ws.send({type:'full-reload'})`).
- `VitePlugin` now tracks `ChildProcess[]` instead of `RollupWatcher[]`; `exitHandler` kills children. Net −47 lines in `VitePlugin.ts`.

Renderer dev servers remain in-process for now (port/URL handshake is a larger change).

## Test plan

- [x] `yarn build` / `tsc --noEmit` clean
- [x] `yarn vitest run packages/plugin/vite/spec/` — 22/22 pass
- [x] `yarn lint:js` — 0 errors
- [x] Worker harness: seeded `FORGE_VITE_DEV_SERVER_URLS` lands in the bundled output as the `*_VITE_DEV_SERVER_URL` define
- [x] Worker harness: preload target emits `reload-renderers`, main does not
- [x] Worker harness: broken entry → `first-build-error` with no trailing `first-build-done`
- [x] Manual `electron-forge start` against a real Vite app (smoke-tested locally via patched `node_modules`, looks good)