### PR TITLE
refactor: replace fast-glob with built-in node:fs glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "chalk": "^4.0.0",
     "debug": "^4.3.1",
     "electron": "^41.2.0",
-    "fast-glob": "^3.2.7",
     "fork-ts-checker-webpack-plugin": "^7.2.13",
     "fs-extra": "^10.0.0",
     "husky": "^7.0.1",

--- a/packages/api/core/package.json
+++ b/packages/api/core/package.json
@@ -35,7 +35,6 @@
     "@electron/packager": "^19.0.1",
     "chalk": "^4.0.0",
     "debug": "^4.3.1",
-    "fast-glob": "^3.2.7",
     "filenamify": "^4.1.0",
     "fs-extra": "^10.0.0",
     "jiti": "^2.4.2",

--- a/packages/api/core/src/api/package.ts
+++ b/packages/api/core/src/api/package.ts
@@ -1,3 +1,4 @@
+import { glob } from 'node:fs/promises';
 import path from 'node:path';
 
 import { getHostArch } from '@electron/get';
@@ -25,7 +26,6 @@ import {
 import { autoTrace, delayTraceTillSignal } from '@electron-forge/tracer';
 import chalk from 'chalk';
 import debug from 'debug';
-import glob from 'fast-glob';
 import fs from 'fs-extra';
 import { Listr, PRESET_TIMER } from 'listr2';
 
@@ -272,9 +272,11 @@ export const listrPackage = (
                 signalDone(signalCopyDone, { platform, arch });
               },
               async ({ buildPath }) => {
-                const bins = await glob(path.join(buildPath, '**/.bin/**/*'));
-                for (const bin of bins) {
-                  await fs.remove(bin);
+                const bins = glob('**/node_modules/.bin/**/*', {
+                  cwd: buildPath,
+                });
+                for await (const bin of bins) {
+                  await fs.remove(path.join(buildPath, bin));
                 }
               },
               async ({ buildPath, electronVersion, platform, arch }) => {

--- a/packages/plugin/webpack/package.json
+++ b/packages/plugin/webpack/package.json
@@ -26,7 +26,6 @@
     "@electron-forge/web-multi-logger": "workspace:*",
     "chalk": "^4.0.0",
     "debug": "^4.3.1",
-    "fast-glob": "^3.2.7",
     "fs-extra": "^10.0.0",
     "html-webpack-plugin": "^5.5.3",
     "listr2": "^7.0.2",

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -1,4 +1,5 @@
 import crypto from 'node:crypto';
+import { glob } from 'node:fs/promises';
 import http from 'node:http';
 import path from 'node:path';
 import { pipeline } from 'stream/promises';
@@ -17,7 +18,6 @@ import {
 import Logger, { Tab } from '@electron-forge/web-multi-logger';
 import chalk from 'chalk';
 import debug from 'debug';
-import glob from 'fast-glob';
 import fs from 'fs-extra';
 import { PRESET_TIMER } from 'listr2';
 import webpack from 'webpack';
@@ -276,12 +276,12 @@ export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
                         const mapping: Record<string, string[]> =
                           Object.create(null);
 
-                        const webpackNodeFiles = await glob('**/*.node', {
-                          cwd: firstArchDir,
-                        });
-                        const nodeModulesNodeFiles = await glob('**/*.node', {
-                          cwd: nodeModulesDir,
-                        });
+                        const webpackNodeFiles = await Array.fromAsync(
+                          glob('**/*.node', { cwd: firstArchDir }),
+                        );
+                        const nodeModulesNodeFiles = await Array.fromAsync(
+                          glob('**/*.node', { cwd: nodeModulesDir }),
+                        );
                         const hashToNodeModules: Record<string, string[]> =
                           Object.create(null);
 
@@ -390,12 +390,12 @@ export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
                                           );
                                         }
 
-                                        const nodeModulesNodeFiles = await glob(
-                                          '**/*.node',
-                                          {
-                                            cwd: nodeModulesDir,
-                                          },
-                                        );
+                                        const nodeModulesNodeFiles =
+                                          await Array.fromAsync(
+                                            glob('**/*.node', {
+                                              cwd: nodeModulesDir,
+                                            }),
+                                          );
                                         const nodeModuleToHash: Record<
                                           string,
                                           string

--- a/packages/template/vite-typescript/package.json
+++ b/packages/template/vite-typescript/package.json
@@ -23,7 +23,6 @@
   "devDependencies": {
     "@electron-forge/core-utils": "workspace:*",
     "@electron-forge/test-utils": "workspace:*",
-    "fast-glob": "^3.2.7",
     "vitest": "catalog:"
   },
   "files": [

--- a/packages/template/vite-typescript/spec/ViteTypeScriptTemplate.slow.verdaccio.spec.ts
+++ b/packages/template/vite-typescript/spec/ViteTypeScriptTemplate.slow.verdaccio.spec.ts
@@ -7,7 +7,6 @@ import {
   spawnPackageManager,
 } from '@electron-forge/core-utils';
 import * as testUtils from '@electron-forge/test-utils';
-import glob from 'fast-glob';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 // eslint-disable-next-line n/no-missing-import
@@ -52,7 +51,9 @@ describe('ViteTypeScriptTemplate', () => {
     });
 
     it('should ensure js source files from base template are removed', async () => {
-      const jsFiles = await glob(path.join(dir, 'src', '**', '*.js'));
+      const jsFiles = await Array.fromAsync(
+        fs.promises.glob(path.join(dir, 'src', '**', '*.js')),
+      );
       expect(jsFiles.length).toEqual(0);
     });
 

--- a/packages/template/webpack-typescript/package.json
+++ b/packages/template/webpack-typescript/package.json
@@ -26,7 +26,6 @@
     "@electron-forge/maker-zip": "workspace:*",
     "@electron-forge/plugin-webpack": "workspace:*",
     "@electron-forge/test-utils": "workspace:*",
-    "fast-glob": "^3.2.7",
     "fork-ts-checker-webpack-plugin": "^7.2.13",
     "listr2": "^7.0.2",
     "typescript": "5.9.3",

--- a/packages/template/webpack-typescript/spec/WebpackTypeScript.slow.verdaccio.spec.ts
+++ b/packages/template/webpack-typescript/spec/WebpackTypeScript.slow.verdaccio.spec.ts
@@ -6,7 +6,6 @@ import {
   spawnPackageManager,
 } from '@electron-forge/core-utils';
 import * as testUtils from '@electron-forge/test-utils';
-import glob from 'fast-glob';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 // eslint-disable-next-line n/no-missing-import
@@ -44,7 +43,9 @@ describe('WebpackTypeScriptTemplate', () => {
   });
 
   it('should ensure js source files from base template are removed', async () => {
-    const jsFiles = await glob(path.join(dir, 'src', '**', '*.js'));
+    const jsFiles = await Array.fromAsync(
+      fs.promises.glob(path.join(dir, 'src', '**', '*.js')),
+    );
     expect(jsFiles.length).toEqual(0);
   });
 

--- a/tools/position-docs.ts
+++ b/tools/position-docs.ts
@@ -1,6 +1,6 @@
+import { glob } from 'node:fs/promises';
 import * as path from 'node:path';
 
-import glob from 'fast-glob';
 import * as fs from 'fs-extra';
 
 import { getPackageInfo } from './utils';
@@ -50,7 +50,7 @@ async function normalizeLinks(
 
     // Rewrite assets path to allow better cross-dep caching
     // otherwise each module will have it's own unique JS file :(
-    for (const htmlFile of await glob(path.resolve(docPath, '**', '*.html'))) {
+    for await (const htmlFile of glob(path.resolve(docPath, '**', '*.html'))) {
       await fs.writeFile(htmlFile, await normalizeLinks(htmlFile, subPath));
     }
   }

--- a/tools/test-clear.ts
+++ b/tools/test-clear.ts
@@ -1,13 +1,15 @@
+import { glob } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
 import chalk from 'chalk';
-import glob from 'fast-glob';
 import fs from 'fs-extra';
 
 (async () => {
   // https://github.com/electron/forge/blob/v7.2.0/packages/utils/test-utils/src/index.ts#L24
-  const dirs = await glob(path.resolve(os.tmpdir(), 'electron-forge-test-*'));
+  const dirs = await Array.fromAsync(
+    glob(path.resolve(os.tmpdir(), 'electron-forge-test-*')),
+  );
 
   if (dirs.length) {
     for (const dir of dirs) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -827,7 +827,6 @@ __metadata:
     debug: "npm:^4.3.1"
     electron-forge-template-fixture-two: "portal:./spec/fixture/electron-forge-template-fixture"
     electron-installer-common: "npm:^0.10.2"
-    fast-glob: "npm:^3.2.7"
     filenamify: "npm:^4.1.0"
     fs-extra: "npm:^10.0.0"
     jiti: "npm:^2.4.2"
@@ -1074,7 +1073,6 @@ __metadata:
     "@types/node": "npm:^22.10.7"
     chalk: "npm:^4.0.0"
     debug: "npm:^4.3.1"
-    fast-glob: "npm:^3.2.7"
     fs-extra: "npm:^10.0.0"
     html-webpack-plugin: "npm:^5.5.3"
     listr2: "npm:^7.0.2"
@@ -1238,7 +1236,6 @@ __metadata:
     "@electron-forge/shared-types": "workspace:*"
     "@electron-forge/template-base": "workspace:*"
     "@electron-forge/test-utils": "workspace:*"
-    fast-glob: "npm:^3.2.7"
     fs-extra: "npm:^10.0.0"
     vitest: "catalog:"
   languageName: unknown
@@ -1270,7 +1267,6 @@ __metadata:
     "@electron-forge/shared-types": "workspace:*"
     "@electron-forge/template-base": "workspace:*"
     "@electron-forge/test-utils": "workspace:*"
-    fast-glob: "npm:^3.2.7"
     fork-ts-checker-webpack-plugin: "npm:^7.2.13"
     fs-extra: "npm:^10.0.0"
     listr2: "npm:^7.0.2"
@@ -7820,7 +7816,6 @@ __metadata:
     electron-windows-store: "npm:^2.1.0"
     electron-winstaller: "npm:^5.3.0"
     electron-wix-msi: "npm:^5.1.3"
-    fast-glob: "npm:^3.2.7"
     fork-ts-checker-webpack-plugin: "npm:^7.2.13"
     fs-extra: "npm:^10.0.0"
     husky: "npm:^7.0.1"
@@ -8954,7 +8949,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.2.7, fast-glob@npm:^3.3.3":
+"fast-glob@npm:^3.3.3":
   version: 3.3.3
   resolution: "fast-glob@npm:3.3.3"
   dependencies:


### PR DESCRIPTION
Node >= 22 ships `fs.promises.glob` natively, so we can drop `fast-glob` as a direct dependency across the monorepo. It's now fully removed from the production dependency tree of all published `@electron-forge/*` packages — the only remaining references are transitive devDependencies pulled in by `knip` and `markdownlint-cli2` (via `globby`) at the repo root.

#### Notes
- `fs.promises.glob` returns an `AsyncIterable` rather than `Promise<string[]>`, so call sites either use `for await` or `Array.fromAsync`.
- The `.bin` cleanup pattern in `packages/api/core/src/api/package.ts` changed from `**/.bin/**/*` to `**/node_modules/.bin/**/*` because Node's glob does not descend into dot-directories that immediately follow a `**` segment. In practice `.bin` only ever lives under `node_modules`, so behaviour is equivalent.
- `tools/test-clear.ts` now actually matches the temp directories it intends to delete — previously `fast-glob`'s `onlyFiles: true` default meant it returned nothing.