### PR TITLE
fix(maker-msix): use path.basename(dir) for artifact

### DIFF
--- a/packages/maker/msix/spec/MakerMSIX.spec.ts
+++ b/packages/maker/msix/spec/MakerMSIX.spec.ts
@@ -30,10 +30,11 @@ vi.mock(import('fs-extra'), async (importOriginal) => {
 });
 
 describe('MakerMSIX', () => {
-  const dir = '/my/test/dir/out';
-  const makeDir = '/my/test/dir/make';
   const appName = 'My Test App';
+  const targetPlatform = 'win32';
   const targetArch = 'x64' as ForgeArch;
+  const dir = `/my/test/dir/${appName}-${targetPlatform}-${targetArch}`;
+  const makeDir = '/my/test/dir/make';
   const packageJSON = { version: '1.2.3' };
 
   it('should generate an MSIX with version and arch in the filename', async () => {
@@ -45,7 +46,7 @@ describe('MakerMSIX', () => {
       appName,
       targetArch,
       packageJSON,
-      targetPlatform: 'win32',
+      targetPlatform,
       forgeConfig: null as any,
     });
 
@@ -55,7 +56,7 @@ describe('MakerMSIX', () => {
         makeDir,
         'msix',
         targetArch,
-        `${appName}-${packageJSON.version}-win32-${targetArch}.msix`,
+        `${path.basename(dir)}-${packageJSON.version}.msix`,
       ),
     );
     expect(vi.mocked(packageMSIX)).toHaveBeenCalledOnce();
@@ -65,7 +66,7 @@ describe('MakerMSIX', () => {
         makeDir,
         'msix',
         targetArch,
-        `${appName}-${packageJSON.version}-win32-${targetArch}.msix`,
+        `${path.basename(dir)}-${packageJSON.version}.msix`,
       ),
     );
   });

--- a/packages/maker/msix/src/MakerMSIX.ts
+++ b/packages/maker/msix/src/MakerMSIX.ts
@@ -26,7 +26,6 @@ export default class MakerMSIX extends MakerBase<MakerMSIXConfig> {
     dir,
     makeDir,
     targetArch,
-    targetPlatform,
     packageJSON,
     appName,
   }: MakerOptions): Promise<string[]> {
@@ -57,7 +56,7 @@ export default class MakerMSIX extends MakerBase<MakerMSIXConfig> {
         makeDir,
         'msix',
         targetArch,
-        `${appName}-${packageJSON.version}-${targetPlatform}-${targetArch}.msix`,
+        `${path.basename(dir)}-${packageJSON.version}.msix`,
       );
       await fs.mkdirp(path.dirname(outputPath));
       await fs.move(result.msixPackage, outputPath);


### PR DESCRIPTION
Sorry, made a dumb mistake in #4225 and didn't order the segments in the string correctly. This PR gets around it by actually reusing what `maker-zip` does and using `path.basename(dir)` to create the unversioned asset name:

https://github.com/electron/forge/blob/5ffffa426ac8d9fa6368dbdd928e41d7b6bcd855/packages/maker/zip/src/MakerZIP.ts#L50