### PR TITLE
feat: add notarization support to MakerPKG

### DIFF
--- a/packages/maker/pkg/package.json
+++ b/packages/maker/pkg/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@electron-forge/maker-base": "workspace:*",
     "@electron-forge/shared-types": "workspace:*",
+    "@electron/notarize": "^3.1.0",
     "@electron/osx-sign": "^2.3.0"
   },
   "publishConfig": {

--- a/packages/maker/pkg/spec/MakerPKG.spec.ts
+++ b/packages/maker/pkg/spec/MakerPKG.spec.ts
@@ -1,9 +1,10 @@
 import path from 'node:path';
 
+import { notarize } from '@electron/notarize';
 import { flat } from '@electron/osx-sign';
 import { MakerOptions } from '@electron-forge/maker-base';
-import { ForgeArch } from '@electron-forge/shared-types';
-import { describe, expect, it, vi } from 'vitest';
+import { ForgeArch, ResolvedForgeConfig } from '@electron-forge/shared-types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MakerPKG } from '../src/MakerPKG';
 
@@ -17,12 +18,28 @@ vi.mock(import('@electron/osx-sign'), async (importOriginal) => {
   };
 });
 
+vi.mock(import('@electron/notarize'), () => ({
+  notarize: vi.fn(),
+}));
+
 describe('MakerPKG', () => {
   const dir = '/my/test/dir/out';
   const makeDir = '/my/test/dir/make';
   const appName = 'My Test App';
   const targetArch = process.arch as ForgeArch;
   const packageJSON = { version: '1.2.3' };
+
+  const makeForgeConfig = (
+    packagerConfig: ResolvedForgeConfig['packagerConfig'] = {},
+  ) =>
+    ({
+      packagerConfig,
+    }) as ResolvedForgeConfig;
+
+  beforeEach(() => {
+    vi.mocked(flat).mockReset();
+    vi.mocked(notarize).mockReset();
+  });
 
   it('should pass through correct defaults', async () => {
     const maker = new MakerPKG({}, []);
@@ -35,6 +52,7 @@ describe('MakerPKG', () => {
       appName,
       targetArch,
       targetPlatform: 'mas',
+      forgeConfig: makeForgeConfig(),
     });
     expect(vi.mocked(flat)).toHaveBeenCalledOnce();
 
@@ -43,6 +61,7 @@ describe('MakerPKG', () => {
       pkg: expect.stringContaining(`My Test App-1.2.3-${targetArch}.pkg`),
       platform: 'mas',
     });
+    expect(vi.mocked(notarize)).not.toHaveBeenCalled();
   });
 
   it('should throw an error on invalid platform', async () => {
@@ -56,10 +75,77 @@ describe('MakerPKG', () => {
       appName,
       targetArch,
       targetPlatform: 'win32',
+      forgeConfig: makeForgeConfig(),
     });
 
     await expect(promise).rejects.toThrow(
       'The pkg maker only supports targeting "mas" and "darwin" builds. You provided "win32".',
     );
+  });
+
+  it('should notarize the generated pkg when signing identity and osxNotarize are configured', async () => {
+    const maker = new MakerPKG({ identity: 'Developer ID Installer: Me' }, []);
+    maker.ensureFile = vi.fn();
+    await maker.prepareConfig(targetArch);
+    const osxNotarize = {
+      appleId: 'me@example.com',
+      appleIdPassword: 'hunter2',
+      teamId: 'TEAM123',
+    };
+    const outPaths = await (maker.make as MakeFunction)({
+      packageJSON,
+      dir,
+      makeDir,
+      appName,
+      targetArch,
+      targetPlatform: 'darwin',
+      forgeConfig: makeForgeConfig({ osxNotarize }),
+    });
+
+    expect(vi.mocked(notarize)).toHaveBeenCalledOnce();
+    expect(vi.mocked(notarize)).toHaveBeenCalledWith({
+      ...osxNotarize,
+      appPath: outPaths[0],
+    });
+  });
+
+  it('should not notarize when signing identity is not configured', async () => {
+    const maker = new MakerPKG({}, []);
+    maker.ensureFile = vi.fn();
+    await maker.prepareConfig(targetArch);
+    await (maker.make as MakeFunction)({
+      packageJSON,
+      dir,
+      makeDir,
+      appName,
+      targetArch,
+      targetPlatform: 'darwin',
+      forgeConfig: makeForgeConfig({
+        osxNotarize: {
+          appleId: 'me@example.com',
+          appleIdPassword: 'hunter2',
+          teamId: 'TEAM123',
+        },
+      }),
+    });
+
+    expect(vi.mocked(notarize)).not.toHaveBeenCalled();
+  });
+
+  it('should not notarize when osxNotarize is not configured', async () => {
+    const maker = new MakerPKG({ identity: 'Developer ID Installer: Me' }, []);
+    maker.ensureFile = vi.fn();
+    await maker.prepareConfig(targetArch);
+    await (maker.make as MakeFunction)({
+      packageJSON,
+      dir,
+      makeDir,
+      appName,
+      targetArch,
+      targetPlatform: 'darwin',
+      forgeConfig: makeForgeConfig(),
+    });
+
+    expect(vi.mocked(notarize)).not.toHaveBeenCalled();
   });
 });

--- a/packages/maker/pkg/src/MakerPKG.ts
+++ b/packages/maker/pkg/src/MakerPKG.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 
+import { notarize } from '@electron/notarize';
 import { flat } from '@electron/osx-sign';
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';
@@ -22,6 +23,7 @@ export default class MakerPKG extends MakerBase<MakerPKGConfig> {
     packageJSON,
     targetPlatform,
     targetArch,
+    forgeConfig,
   }: MakerOptions): Promise<string[]> {
     if (!this.isValidTargetPlatform(targetPlatform)) {
       throw new Error(
@@ -42,6 +44,13 @@ export default class MakerPKG extends MakerBase<MakerPKGConfig> {
       platform: targetPlatform,
     };
     await flat(pkgConfig);
+
+    if (this.config.identity && forgeConfig.packagerConfig.osxNotarize) {
+      await notarize({
+        ...forgeConfig.packagerConfig.osxNotarize,
+        appPath: outPath,
+      });
+    }
 
     return [outPath];
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -927,6 +927,7 @@ __metadata:
   dependencies:
     "@electron-forge/maker-base": "workspace:*"
     "@electron-forge/shared-types": "workspace:*"
+    "@electron/notarize": "npm:^3.1.0"
     "@electron/osx-sign": "npm:^2.3.0"
     vitest: "catalog:"
   languageName: unknown


### PR DESCRIPTION
**Summarize your changes:**

This PR adds macOS notarization support to the MakerPKG maker. When both a signing identity and `osxNotarize` configuration are provided, the generated PKG file will be automatically notarized using the `@electron/notarize` package.

**Changes:**

- Added `@electron/notarize` dependency to MakerPKG
- Updated `MakerPKG.make()` to accept `forgeConfig` parameter containing packager configuration
- Implemented conditional notarization logic that runs when:
  - A signing identity is configured in the maker options
  - `osxNotarize` configuration is present in the forge config
- Added comprehensive test coverage for notarization scenarios:
  - Notarization occurs when both identity and osxNotarize are configured
  - Notarization is skipped when signing identity is missing
  - Notarization is skipped when osxNotarize configuration is missing
- Updated existing tests to pass the required `forgeConfig` parameter

**Test Plan:**

Added unit tests covering all notarization scenarios. Existing tests pass with the new `forgeConfig` parameter requirement.

https://claude.ai/code/session_01AUVesVk6mwR9JX2WoKwiEi