### PR TITLE
chore: update dependencies to dedupe across child packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@types/mime-types": "^2.1.0",
     "@types/node": "^22.10.7",
     "@types/semver": "^7.3.4",
-    "@types/which": "^2.0.0",
+    "@types/which": "^3.0.4",
     "@yarnpkg/types": "^4.0.1",
     "chalk": "^4.0.0",
     "debug": "^4.3.1",

--- a/packages/api/core/package.json
+++ b/packages/api/core/package.json
@@ -35,7 +35,7 @@
     "@electron/packager": "^19.0.1",
     "chalk": "^4.0.0",
     "debug": "^4.3.1",
-    "filenamify": "^4.1.0",
+    "filenamify": "^6.0.0",
     "fs-extra": "^10.0.0",
     "jiti": "^2.4.2",
     "listr2": "^7.0.2",

--- a/packages/maker/base/package.json
+++ b/packages/maker/base/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@electron-forge/shared-types": "workspace:*",
     "fs-extra": "^10.0.0",
-    "which": "^2.0.2"
+    "which": "^6.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin/webpack/package.json
+++ b/packages/plugin/webpack/package.json
@@ -13,7 +13,7 @@
     "@malept/cross-spawn-promise": "^2.0.0",
     "@types/node": "^22.10.7",
     "vitest": "catalog:",
-    "which": "^2.0.2",
+    "which": "^6.0.0",
     "xvfb-maybe": "^0.2.1"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -827,7 +827,7 @@ __metadata:
     debug: "npm:^4.3.1"
     electron-forge-template-fixture-two: "portal:./spec/fixture/electron-forge-template-fixture"
     electron-installer-common: "npm:^0.10.2"
-    filenamify: "npm:^4.1.0"
+    filenamify: "npm:^6.0.0"
     fs-extra: "npm:^10.0.0"
     jiti: "npm:^2.4.2"
     listr2: "npm:^7.0.2"
@@ -860,7 +860,7 @@ __metadata:
     "@electron-forge/shared-types": "workspace:*"
     fs-extra: "npm:^10.0.0"
     vitest: "catalog:"
-    which: "npm:^2.0.2"
+    which: "npm:^6.0.0"
   languageName: unknown
   linkType: soft
 
@@ -1081,7 +1081,7 @@ __metadata:
     webpack: "npm:^5.69.1"
     webpack-dev-server: "npm:^4.0.0"
     webpack-merge: "npm:^5.7.3"
-    which: "npm:^2.0.2"
+    which: "npm:^6.0.0"
     xvfb-maybe: "npm:^0.2.1"
   languageName: unknown
   linkType: soft
@@ -4850,10 +4850,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/which@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "@types/which@npm:2.0.1"
-  checksum: 10c0/70bdcc57ef4cad876d05def62dbec098cdb3f09c708568e5bba97e6c7a5f1814653da04140720d5e45246cb0db4dad37e64c010987aa20cfe72329db4219415b
+"@types/which@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "@types/which@npm:3.0.4"
+  checksum: 10c0/036e4cb243ebfd5cf4893be2ab3b9a60a22368811c1f1c78fb8fc70cadc274024282d04b8d7c0948268372600003252d84e2d3a5e064014a543a5da235c5989d
   languageName: node
   linkType: hard
 
@@ -7804,7 +7804,7 @@ __metadata:
     "@types/mime-types": "npm:^2.1.0"
     "@types/node": "npm:^22.10.7"
     "@types/semver": "npm:^7.3.4"
-    "@types/which": "npm:^2.0.0"
+    "@types/which": "npm:^3.0.4"
     "@yarnpkg/types": "npm:^4.0.1"
     chalk: "npm:^4.0.0"
     debug: "npm:^4.3.1"
@@ -8396,7 +8396,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escape-string-regexp@npm:^1.0.2, escape-string-regexp@npm:^1.0.5":
+"escape-string-regexp@npm:^1.0.5":
   version: 1.0.5
   resolution: "escape-string-regexp@npm:1.0.5"
   checksum: 10c0/a968ad453dd0c2724e14a4f20e177aaf32bb384ab41b674a8454afe9a41c5e6fe8903323e0a1052f56289d04bd600f81278edf140b0fcc02f5cac98d0f5b5371
@@ -9103,28 +9103,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"filename-reserved-regex@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "filename-reserved-regex@npm:2.0.0"
-  checksum: 10c0/453740b7f9fd126e508da555b37e38c1f7ff19f5e9f3d297b2de1beb09854957baddd74c83235e87b16e9ce27a2368798896669edad5a81b5b7bd8cb57c942fc
-  languageName: node
-  linkType: hard
-
 "filename-reserved-regex@npm:^3.0.0":
   version: 3.0.0
   resolution: "filename-reserved-regex@npm:3.0.0"
   checksum: 10c0/2b1df851a37f84723f9d8daf885ddfadd3dea2a124474db405295962abc1a01d6c9b6b27edec33bad32ef601e1a220f8a34d34f30ca5a911709700e2b517e268
-  languageName: node
-  linkType: hard
-
-"filenamify@npm:^4.1.0":
-  version: 4.3.0
-  resolution: "filenamify@npm:4.3.0"
-  dependencies:
-    filename-reserved-regex: "npm:^2.0.0"
-    strip-outer: "npm:^1.0.1"
-    trim-repeated: "npm:^1.0.0"
-  checksum: 10c0/dcfd2f116d66f78c9dd58bb0f0d9b6529d89c801a9f37a4f86e7adc0acecb6881c7fb7c3231dc9e6754b767edcfdca89cba3a492a58afd2b48479b30d14ccf8f
   languageName: node
   linkType: hard
 
@@ -16892,15 +16874,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-outer@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "strip-outer@npm:1.0.1"
-  dependencies:
-    escape-string-regexp: "npm:^1.0.2"
-  checksum: 10c0/c0f38e6f37563d878a221b1c76f0822f180ec5fc39be5ada30ee637a7d5b59d19418093bad2b4db1e69c40d7a7a7ac50828afce07276cf3d51ac8965cb140dfb
-  languageName: node
-  linkType: hard
-
 "strnum@npm:^2.2.0, strnum@npm:^2.2.2":
   version: 2.2.2
   resolution: "strnum@npm:2.2.2"
@@ -17308,15 +17281,6 @@ __metadata:
   version: 3.0.1
   resolution: "trim-newlines@npm:3.0.1"
   checksum: 10c0/03cfefde6c59ff57138412b8c6be922ecc5aec30694d784f2a65ef8dcbd47faef580b7de0c949345abdc56ec4b4abf64dd1e5aea619b200316e471a3dd5bf1f6
-  languageName: node
-  linkType: hard
-
-"trim-repeated@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "trim-repeated@npm:1.0.0"
-  dependencies:
-    escape-string-regexp: "npm:^1.0.2"
-  checksum: 10c0/89acada0142ed0cdb113615a3e82fdb09e7fdb0e3504ded62762dd935bc27debfcc38edefa497dc7145d8dc8602d40dd9eec891e0ea6c28fa0cc384200b692db
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We depend on these elsewhere in the tree at higher versions, so updating is free and dedupes dependencies in the tree