### PR TITLE
fix(cli): allow pre-release package manager ranges

### DIFF
--- a/packages/api/cli/spec/util/check-system.spec.ts
+++ b/packages/api/cli/spec/util/check-system.spec.ts
@@ -132,6 +132,29 @@ describe('checkPackageManager', () => {
     },
   );
 
+  it('should accept prerelease versions within the supported range', async () => {
+    vi.mocked(resolvePackageManager).mockResolvedValue({
+      executable: 'pnpm',
+      install: 'add',
+      dev: '--dev',
+      exact: '--exact',
+    });
+    vi.mocked(spawnPackageManager).mockImplementation((_pm, args) => {
+      if (args?.join(' ') === 'config get node-linker') {
+        return Promise.resolve('hoisted');
+      } else if (args?.join(' ') === 'config get hoist-pattern') {
+        return Promise.resolve('undefined');
+      } else if (args?.join(' ') === 'config get public-hoist-pattern') {
+        return Promise.resolve('undefined');
+      } else if (args?.join(' ') === '--version') {
+        return Promise.resolve('11.0.0-beta.1');
+      } else {
+        throw new Error('Unexpected command');
+      }
+    });
+    await expect(checkPackageManager()).resolves.not.toThrow();
+  });
+
   // resolvePackageManager optionally returns a `version` if `npm_config_user_agent` was used to
   // resolve the package manager being used.
   it('should not shell out to child process if version was already parsed via npm_config_user_agent', async () => {

--- a/packages/api/cli/src/util/check-system.ts
+++ b/packages/api/cli/src/util/check-system.ts
@@ -87,15 +87,12 @@ async function checkYarnConfig() {
   }
 }
 
-// TODO(erickzhao): Drop antiquated versions of npm for Forge v8
 const ALLOWLISTED_VERSIONS: Record<
   SupportedPackageManager,
   Record<string, string>
 > = {
   npm: {
-    all: '^3.0.0 || ^4.0.0 || ~5.1.0 || ~5.2.0 || >= 5.4.2',
-    darwin: '>= 5.4.0',
-    linux: '>= 5.4.0',
+    all: '>= 10.9.0',
   },
   yarn: {
     all: '>= 1.0.0',
@@ -119,7 +116,7 @@ export async function checkPackageManager() {
       `Could not check ${pm.executable} version "${version}", assuming incompatible`,
     );
   }
-  if (!semver.satisfies(version, range)) {
+  if (!semver.satisfies(version, range, { includePrerelease: true })) {
     throw new Error(
       `Incompatible version of ${pm.executable} detected: "${version}" must be in range ${range}`,
     );


### PR DESCRIPTION
As reported on Discord:

<img width="1309" height="414" alt="image" src="https://github.com/user-attachments/assets/d0553172-999f-4d36-b53d-d5750db5dc86" />

* Opts us into `includePrerelease` for semver comparisons
* Minimum `npm` version is the one that Node 22.12 ships with.