### PR TITLE
chore: replace chalk and log-symbols with Node.js built-in styleText

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@types/semver": "^7.3.4",
     "@types/which": "^3.0.4",
     "@yarnpkg/types": "^4.0.1",
-    "chalk": "^4.0.0",
     "debug": "^4.3.1",
     "electron": "^41.2.0",
     "fork-ts-checker-webpack-plugin": "^7.2.13",

--- a/packages/api/cli/package.json
+++ b/packages/api/cli/package.json
@@ -20,12 +20,10 @@
     "@electron-forge/core-utils": "workspace:*",
     "@electron-forge/shared-types": "workspace:*",
     "@electron/get": "^5.0.0",
-    "chalk": "^4.0.0",
     "commander": "^11.1.0",
     "debug": "^4.3.1",
     "fs-extra": "^10.0.0",
     "listr2": "^7.0.2",
-    "log-symbols": "^4.0.0",
     "semver": "^7.2.1"
   },
   "engines": {

--- a/packages/api/cli/src/electron-forge-make.ts
+++ b/packages/api/cli/src/electron-forge-make.ts
@@ -1,9 +1,9 @@
 import url from 'node:url';
+import { styleText } from 'node:util';
 
 import { initializeProxy } from '@electron/get';
 import { api, MakeOptions } from '@electron-forge/core';
 import { resolveWorkingDir } from '@electron-forge/core-utils';
-import chalk from 'chalk';
 import { program } from 'commander';
 
 import './util/terminate.js';
@@ -24,7 +24,7 @@ export async function getMakeOptions(): Promise<MakeOptions> {
     )
     .option(
       '--skip-package',
-      `Skip packaging the Electron application, and use the output from a previous ${chalk.green('package')} run instead.`,
+      `Skip packaging the Electron application, and use the output from a previous ${styleText('green', 'package')} run instead.`,
     )
     .option('-a, --arch [arch]', 'Target build architecture.', process.arch)
     .option(
@@ -34,7 +34,7 @@ export async function getMakeOptions(): Promise<MakeOptions> {
     )
     .option(
       '--targets [targets]',
-      `Override your ${chalk.green('make')} targets for this run.`,
+      `Override your ${styleText('green', 'make')} targets for this run.`,
     )
     .allowUnknownOption(true)
     .action((dir) => {

--- a/packages/api/cli/src/electron-forge-publish.ts
+++ b/packages/api/cli/src/electron-forge-publish.ts
@@ -1,7 +1,8 @@
+import { styleText } from 'node:util';
+
 import { initializeProxy } from '@electron/get';
 import { api, PublishOptions } from '@electron-forge/core';
 import { resolveWorkingDir } from '@electron-forge/core-utils';
-import chalk from 'chalk';
 import { program } from 'commander';
 
 import './util/terminate.js';
@@ -22,7 +23,7 @@ program
   )
   .option(
     '--dry-run',
-    `Run the ${chalk.green('make')} command and save publish metadata without uploading anything.`,
+    `Run the ${styleText('green', 'make')} command and save publish metadata without uploading anything.`,
   )
   .option('--from-dry-run', 'Publish artifacts from the last saved dry run.')
   .allowUnknownOption(true)

--- a/packages/api/cli/src/electron-forge.ts
+++ b/packages/api/cli/src/electron-forge.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 // This file requires a shebang above. If it is missing, this is an error.
 
-import chalk from 'chalk';
+import { styleText } from 'node:util';
+
 import { program } from 'commander';
-import logSymbols from 'log-symbols';
 import semver from 'semver';
 
 import packageJSON from '../package.json' with { type: 'json' };
@@ -13,8 +13,8 @@ import { checkSystem, SystemCheckContext } from './util/check-system.js';
 
 if (!semver.satisfies(process.versions.node, packageJSON.engines.node)) {
   console.error(
-    logSymbols.error,
-    `You are running Node.js version ${chalk.red(process.versions.node)}, but Electron Forge requires Node.js ${chalk.red(packageJSON.engines.node)}. \n`,
+    styleText('red', '✖'),
+    `You are running Node.js version ${styleText('red', process.versions.node)}, but Electron Forge requires Node.js ${styleText('red', packageJSON.engines.node)}. \n`,
   );
   process.exit(1);
 }

--- a/packages/api/cli/src/util/terminate.ts
+++ b/packages/api/cli/src/util/terminate.ts
@@ -1,7 +1,7 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 function redConsoleError(msg: string) {
-  console.error(chalk.red(msg));
+  console.error(styleText('red', msg));
 }
 
 process.on(

--- a/packages/api/core/package.json
+++ b/packages/api/core/package.json
@@ -33,13 +33,11 @@
     "@electron-forge/tracer": "workspace:*",
     "@electron/get": "^5.0.0",
     "@electron/packager": "^20.0.0",
-    "chalk": "^4.0.0",
     "debug": "^4.3.1",
     "filenamify": "^6.0.0",
     "fs-extra": "^10.0.0",
     "jiti": "^2.4.2",
-    "listr2": "^7.0.2",
-    "log-symbols": "^4.0.0"
+    "listr2": "^7.0.2"
   },
   "engines": {
     "node": ">= 22.12.0"

--- a/packages/api/core/src/api/make.ts
+++ b/packages/api/core/src/api/make.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { styleText } from 'node:util';
 
 import { getHostArch } from '@electron/get';
 import { getElectronVersion } from '@electron-forge/core-utils';
@@ -14,11 +15,9 @@ import {
   ResolvedForgeConfig,
 } from '@electron-forge/shared-types';
 import { autoTrace, delayTraceTillSignal } from '@electron-forge/tracer';
-import chalk from 'chalk';
 import filenamify from 'filenamify';
 import fs from 'fs-extra';
 import { Listr, PRESET_TIMER } from 'listr2';
-import logSymbols from 'log-symbols';
 
 import getForgeConfig from '../util/forge-config.js';
 import { getHookListrTasks, runMutatingHook } from '../util/hook.js';
@@ -235,7 +234,7 @@ export const listrMake = (
 
             ctx.makers = makers;
 
-            task.output = `Making for the following targets: ${chalk.magenta(`${makers.map((maker) => maker.name).join(', ')}`)}`;
+            task.output = `Making for the following targets: ${styleText('magenta', `${makers.map((maker) => maker.name).join(', ')}`)}`;
           },
         ),
         rendererOptions: {
@@ -243,7 +242,7 @@ export const listrMake = (
         },
       },
       {
-        title: `Running ${chalk.yellow('package')} command`,
+        title: `Running ${styleText('yellow', 'package')} command`,
         task: childTrace<Parameters<ForgeListrTaskFn<MakeContext>>>(
           { name: 'package()', category: '@electron-forge/core' },
           async (childTrace, ctx, task) => {
@@ -260,8 +259,9 @@ export const listrMake = (
                 'run',
               );
             } else {
-              task.output = chalk.yellow(
-                `${logSymbols.warning} Skipping could result in an out of date build`,
+              task.output = styleText(
+                'yellow',
+                `⚠ Skipping could result in an out of date build`,
               );
               task.skip();
             }
@@ -272,7 +272,7 @@ export const listrMake = (
         },
       },
       {
-        title: `Running ${chalk.yellow('preMake')} hook`,
+        title: `Running ${styleText('yellow', 'preMake')} hook`,
         task: childTrace<Parameters<ForgeListrTaskFn<MakeContext>>>(
           { name: 'run-preMake-hook', category: '@electron-forge/core' },
           async (childTrace, ctx, task) => {
@@ -327,7 +327,7 @@ export const listrMake = (
               for (const maker of makers) {
                 const uniqMaker = maker();
                 subRunner.add({
-                  title: `Making a ${chalk.magenta(uniqMaker.name)} distributable for ${chalk.cyan(`${platform}/${targetArch}`)}`,
+                  title: `Making a ${styleText('magenta', uniqMaker.name)} distributable for ${styleText('cyan', `${platform}/${targetArch}`)}`,
                   task: childTrace<[]>(
                     {
                       name: `make-${maker.name}`,
@@ -380,7 +380,7 @@ export const listrMake = (
         ),
       },
       {
-        title: `Running ${chalk.yellow('postMake')} hook`,
+        title: `Running ${styleText('yellow', 'postMake')} hook`,
         task: childTrace<Parameters<ForgeListrTaskFn<MakeContext>>>(
           { name: 'run-postMake-hook', category: '@electron-forge/core' },
           async (_, ctx, task) => {
@@ -411,7 +411,7 @@ export const listrMake = (
             }
             receiveMakeResults?.(ctx.outputs);
 
-            task.output = `Artifacts available at: ${chalk.green(outputLocations.join(', '))}`;
+            task.output = `Artifacts available at: ${styleText('green', outputLocations.join(', '))}`;
           },
         ),
         rendererOptions: {

--- a/packages/api/core/src/api/package.ts
+++ b/packages/api/core/src/api/package.ts
@@ -1,5 +1,6 @@
 import { glob } from 'node:fs/promises';
 import path from 'node:path';
+import { styleText } from 'node:util';
 
 import { getHostArch } from '@electron/get';
 import {
@@ -24,7 +25,6 @@ import {
   ResolvedForgeConfig,
 } from '@electron-forge/shared-types';
 import { autoTrace, delayTraceTillSignal } from '@electron-forge/tracer';
-import chalk from 'chalk';
 import debug from 'debug';
 import fs from 'fs-extra';
 import { Listr, PRESET_TIMER } from 'listr2';
@@ -147,7 +147,7 @@ export const listrPackage = (
               childTrace,
               task.newListr([
                 {
-                  title: `Running ${chalk.yellow('generateAssets')} hook`,
+                  title: `Running ${styleText('yellow', 'generateAssets')} hook`,
                   task: childTrace<Parameters<ForgeListrTaskFn>>(
                     {
                       name: 'run-generateAssets-hook',
@@ -171,7 +171,7 @@ export const listrPackage = (
                   ),
                 },
                 {
-                  title: `Running ${chalk.yellow('prePackage')} hook`,
+                  title: `Running ${styleText('yellow', 'prePackage')} hook`,
                   task: childTrace<Parameters<ForgeListrTaskFn>>(
                     {
                       name: 'run-prePackage-hook',
@@ -413,7 +413,8 @@ export const listrPackage = (
             if (!packageJSON.version && !packageOpts.appVersion) {
               warn(
                 interactive,
-                chalk.yellow(
+                styleText(
+                  'yellow',
                   'Please set "version" or "config.forge.packagerConfig.appVersion" in your application\'s package.json so auto-updates work properly',
                 ),
               );
@@ -490,7 +491,8 @@ export const listrPackage = (
                   (target): ForgeListrTaskDefinition =>
                     target.arch === 'universal'
                       ? {
-                          title: `Stitching ${chalk.cyan(`${target.platform}/x64`)} and ${chalk.cyan(`${target.platform}/arm64`)} into a ${chalk.green(
+                          title: `Stitching ${styleText('cyan', `${target.platform}/x64`)} and ${styleText('cyan', `${target.platform}/arm64`)} into a ${styleText(
+                            'green',
                             `${target.platform}/universal`,
                           )} package`,
                           task: async () => {
@@ -501,9 +503,9 @@ export const listrPackage = (
                           },
                         }
                       : {
-                          title: `Packaging for ${chalk.cyan(target.arch)} on ${chalk.cyan(target.platform)}${
+                          title: `Packaging for ${styleText('cyan', target.arch)} on ${styleText('cyan', target.platform)}${
                             target.forUniversal
-                              ? chalk.italic(' (for universal package)')
+                              ? styleText('italic', ' (for universal package)')
                               : ''
                           }`,
                           task: childTrace<Parameters<ForgeListrTaskFn<never>>>(
@@ -605,7 +607,7 @@ export const listrPackage = (
         ),
       },
       {
-        title: `Running ${chalk.yellow('postPackage')} hook`,
+        title: `Running ${styleText('yellow', 'postPackage')} hook`,
         task: childTrace<Parameters<ForgeListrTaskFn<PackageContext>>>(
           { name: 'run-postPackage-hook', category: '@electron-forge/core' },
           async (childTrace, { packagerPromise, forgeConfig }, task) => {

--- a/packages/api/core/src/api/publish.ts
+++ b/packages/api/core/src/api/publish.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { styleText } from 'node:util';
 
 import { PublisherBase } from '@electron-forge/publisher-base';
 import {
@@ -12,7 +13,6 @@ import {
   ResolvedForgeConfig,
 } from '@electron-forge/shared-types';
 import { autoTrace, delayTraceTillSignal } from '@electron-forge/tracer';
-import chalk from 'chalk';
 import debug from 'debug';
 import fs from 'fs-extra';
 import { Listr } from 'listr2';
@@ -116,7 +116,7 @@ export default autoTrace(
               childTrace,
               task.newListr<never>(
                 publishers.map((publisher) => ({
-                  title: `${chalk.cyan(`[publisher-${publisher.name}]`)} Running the ${chalk.yellow('publish')} command`,
+                  title: `${styleText('cyan', `[publisher-${publisher.name}]`)} Running the ${styleText('yellow', 'publish')} command`,
                   task: childTrace<Parameters<ForgeListrTaskFn>>(
                     {
                       name: `publish-${publisher.name}`,
@@ -239,7 +239,7 @@ export default autoTrace(
               }
 
               if (ctx.publishers.length) {
-                task.output = `Publishing to the following targets: ${chalk.magenta(`${ctx.publishers.map((publisher) => publisher.name).join(', ')}`)}`;
+                task.output = `Publishing to the following targets: ${styleText('magenta', `${ctx.publishers.map((publisher) => publisher.name).join(', ')}`)}`;
               }
             },
           ),
@@ -250,7 +250,7 @@ export default autoTrace(
         {
           title: dryRunResume
             ? 'Resuming from dry run...'
-            : `Running ${chalk.yellow('make')} command`,
+            : `Running ${styleText('yellow', 'make')} command`,
           task: childTrace<Parameters<ForgeListrTaskFn<PublishContext>>>(
             {
               name: dryRunResume ? 'resume-dry-run' : 'make()',
@@ -278,7 +278,7 @@ export default autoTrace(
                   task.newListr<PublishContext>(
                     publishes.map((publishStates, index) => {
                       return {
-                        title: `Publishing dry-run ${chalk.blue(`#${index + 1}`)}`,
+                        title: `Publishing dry-run ${styleText('blue', `#${index + 1}`)}`,
                         task: childTrace<
                           Parameters<ForgeListrTaskFn<PublishContext>>
                         >(

--- a/packages/api/core/src/api/start.ts
+++ b/packages/api/core/src/api/start.ts
@@ -1,5 +1,6 @@
 import { spawn, SpawnOptions } from 'node:child_process';
 import readline from 'node:readline';
+import { styleText } from 'node:util';
 
 import {
   getElectronVersion,
@@ -15,7 +16,6 @@ import {
   StartOptions,
 } from '@electron-forge/shared-types';
 import { autoTrace, delayTraceTillSignal } from '@electron-forge/tracer';
-import chalk from 'chalk';
 import debug from 'debug';
 import { Listr, PRESET_TIMER } from 'listr2';
 
@@ -127,7 +127,7 @@ export default autoTrace(
           },
         },
         {
-          title: `Running ${chalk.yellow('generateAssets')} hook`,
+          title: `Running ${styleText('yellow', 'generateAssets')} hook`,
           task: childTrace<Parameters<ForgeListrTaskFn<StartContext>>>(
             {
               name: 'run-generateAssets-hook',
@@ -151,7 +151,7 @@ export default autoTrace(
           ),
         },
         {
-          title: `Running ${chalk.yellow('preStart')} hook`,
+          title: `Running ${styleText('yellow', 'preStart')} hook`,
           task: childTrace<Parameters<ForgeListrTaskFn<StartContext>>>(
             { name: 'run-preStart-hook', category: '@electron-forge/core' },
             async (childTrace, { forgeConfig }, task) => {
@@ -167,7 +167,7 @@ export default autoTrace(
         },
         {
           task: (_ctx, task) => {
-            task.title = `${chalk.dim(`Launched Electron app. Type`)} ${chalk.bold('rs')} ${chalk.dim(`in terminal to restart main process.`)}`;
+            task.title = `${styleText('dim', `Launched Electron app. Type`)} ${styleText('bold', 'rs')} ${styleText('dim', `in terminal to restart main process.`)}`;
           },
         },
       ],
@@ -301,7 +301,7 @@ export default autoTrace(
           readline.clearLine(process.stdout, 0);
           readline.cursorTo(process.stdout, 0);
           console.info(
-            `${chalk.green('✔ ')}${chalk.dim('Restarting Electron app')}`,
+            `${styleText('green', '✔ ')}${styleText('dim', 'Restarting Electron app')}`,
           );
           lastSpawned.restarted = true;
           lastSpawned.on('exit', async () => {

--- a/packages/api/core/src/util/electron-executable.ts
+++ b/packages/api/core/src/util/electron-executable.ts
@@ -1,8 +1,8 @@
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { styleText } from 'node:util';
 
 import { getElectronModulePath } from '@electron-forge/core-utils';
-import logSymbols from 'log-symbols';
-import { pathToFileURL } from 'node:url';
 
 type PackageJSON = Record<string, unknown>;
 
@@ -32,7 +32,7 @@ export default async function locateElectronExecutable(
     return electronExecPath;
   } else {
     console.warn(
-      logSymbols.warning,
+      styleText('yellow', '⚠'),
       `Returned Electron executable path (${electronExecPath}) is not a string. Defaulting to node_modules/electron.`,
     );
     const { default: fallbackExecPath } = await import(

--- a/packages/api/core/src/util/hook.ts
+++ b/packages/api/core/src/util/hook.ts
@@ -1,3 +1,5 @@
+import { styleText } from 'node:util';
+
 import {
   ForgeListrTaskDefinition,
   ForgeMutatingHookFn,
@@ -7,7 +9,6 @@ import {
   ResolvedForgeConfig,
 } from '@electron-forge/shared-types';
 import { autoTrace } from '@electron-forge/tracer';
-import chalk from 'chalk';
 import debug from 'debug';
 
 const d = debug('electron-forge:hook');
@@ -47,7 +48,7 @@ export const getHookListrTasks = async <
     if (typeof hooks[hookName] === 'function') {
       d('calling hook:', hookName, 'with args:', hookArgs);
       tasks.push({
-        title: `Running ${chalk.yellow(hookName)} hook from forgeConfig`,
+        title: `Running ${styleText('yellow', hookName)} hook from forgeConfig`,
         task: childTrace(
           {
             name: 'forge-config-hook',

--- a/packages/api/core/src/util/plugin-interface.ts
+++ b/packages/api/core/src/util/plugin-interface.ts
@@ -1,3 +1,5 @@
+import { styleText } from 'node:util';
+
 import { PluginBase } from '@electron-forge/plugin-base';
 import {
   ForgeListrTaskDefinition,
@@ -11,7 +13,6 @@ import {
   StartResult,
 } from '@electron-forge/shared-types';
 import { autoTrace } from '@electron-forge/tracer';
-import chalk from 'chalk';
 import debug from 'debug';
 
 import { StartOptions } from '../api/start.js';
@@ -126,7 +127,7 @@ export default class PluginInterface implements IForgePluginInterface {
           if (typeof hooks === 'function') hooks = [hooks];
           for (const hook of hooks) {
             tasks.push({
-              title: `${chalk.cyan(`[plugin-${plugin.name}]`)} ${(hook as any).__hookName || `Running ${chalk.yellow(hookName)} hook`}`,
+              title: `${styleText('cyan', `[plugin-${plugin.name}]`)} ${(hook as any).__hookName || `Running ${styleText('yellow', hookName)} hook`}`,
               task: childTrace(
                 {
                   name: 'forge-plugin-hook',
@@ -200,7 +201,7 @@ export default class PluginInterface implements IForgePluginInterface {
       if (typeof result === 'object' && 'tasks' in result) {
         result.tasks = result.tasks.map((task) => ({
           ...task,
-          title: `${chalk.cyan(`[plugin-${claimed[0]}]`)} ${task.title}`,
+          title: `${styleText('cyan', `[plugin-${claimed[0]}]`)} ${task.title}`,
         }));
       }
       return result;

--- a/packages/external/create-electron-app/package.json
+++ b/packages/external/create-electron-app/package.json
@@ -22,13 +22,11 @@
     "@inquirer/prompts": "^6.0.1",
     "@listr2/prompt-adapter-inquirer": "^2.0.22",
     "@malept/cross-spawn-promise": "^2.0.0",
-    "chalk": "^4.0.0",
     "commander": "^11.1.0",
     "debug": "^4.3.1",
     "fs-extra": "^10.0.0",
     "listr2": "^7.0.2",
     "lodash-es": "^4.17.21",
-    "log-symbols": "^4.0.0",
     "semver": "^7.2.1"
   },
   "devDependencies": {

--- a/packages/external/create-electron-app/src/create-electron-app.ts
+++ b/packages/external/create-electron-app/src/create-electron-app.ts
@@ -1,9 +1,9 @@
 import fs from 'node:fs';
+import { styleText } from 'node:util';
 
 import { resolveWorkingDir } from '@electron-forge/core-utils';
 import { confirm, select } from '@inquirer/prompts';
 import { ListrInquirerPromptAdapter } from '@listr2/prompt-adapter-inquirer';
-import chalk from 'chalk';
 import { program } from 'commander';
 import { Listr } from 'listr2';
 
@@ -75,7 +75,7 @@ const initCommand = program
               (await fs.promises.readdir(initOpts.dir)).length > 0
             ) {
               const confirmResult = await prompt.run(confirm, {
-                message: `${chalk.cyan(initOpts.dir)} is not empty. Would you like to continue and overwrite existing files?`,
+                message: `${styleText('cyan', initOpts.dir)} is not empty. Would you like to continue and overwrite existing files?`,
                 default: false,
               });
 

--- a/packages/external/create-electron-app/src/import.ts
+++ b/packages/external/create-electron-app/src/import.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { styleText } from 'node:util';
 
 import {
   DepType,
@@ -10,7 +11,6 @@ import {
 } from '@electron-forge/core-utils';
 import { ForgeListrOptions } from '@electron-forge/shared-types';
 import baseTemplate from '@electron-forge/template-base';
-import chalk from 'chalk';
 import debug from 'debug';
 import fs from 'fs-extra';
 import { Listr } from 'listr2';
@@ -133,13 +133,15 @@ export const forgeImport = async ({
 
           let packageJSON = await readRawPackageJson(dir);
           if (!packageJSON.version) {
-            task.output = chalk.yellow(
-              `Please set the ${chalk.green('"version"')} in your application's package.json`,
+            task.output = styleText(
+              'yellow',
+              `Please set the ${styleText('green', '"version"')} in your application's package.json`,
             );
           }
           if (packageJSON.config && packageJSON.config.forge) {
             if (packageJSON.config.forge.makers) {
-              task.output = chalk.green(
+              task.output = styleText(
+                'green',
                 'Existing Electron Forge configuration detected',
               );
               if (typeof shouldContinueOnExisting === 'function') {
@@ -150,7 +152,8 @@ export const forgeImport = async ({
                 }
               }
             } else if (!(typeof packageJSON.config.forge === 'object')) {
-              task.output = chalk.yellow(
+              task.output = styleText(
+                'yellow',
                 "We can't tell if the Electron Forge config is compatible because it's in an external JavaScript file, not trying to convert it and continuing anyway",
               );
             }
@@ -243,7 +246,7 @@ export const forgeImport = async ({
                 title: `Resolving package manager`,
                 task: async (ctx, task) => {
                   ctx.pm = await resolvePackageManager();
-                  task.title = `Resolving package manager: ${chalk.cyan(ctx.pm.executable)}`;
+                  task.title = `Resolving package manager: ${styleText('cyan', ctx.pm.executable)}`;
                 },
               },
               {
@@ -367,7 +370,7 @@ export const forgeImport = async ({
         task: (_ctx, task) => {
           task.output = `We have attempted to convert your app to be in a format that Electron Forge understands.
 
-          Thanks for using ${chalk.green('Electron Forge')}!`;
+          Thanks for using ${styleText('green', 'Electron Forge')}!`;
         },
       },
     ],

--- a/packages/external/create-electron-app/src/index.ts
+++ b/packages/external/create-electron-app/src/index.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 function redConsoleError(msg: string) {
-  console.error(chalk.red(msg));
+  console.error(styleText('red', msg));
 }
 
 process.on(

--- a/packages/external/create-electron-app/src/init-scripts/init-directory.ts
+++ b/packages/external/create-electron-app/src/init-scripts/init-directory.ts
@@ -1,7 +1,6 @@
 import { ForgeListrTask } from '@electron-forge/shared-types';
 import debug from 'debug';
 import fs from 'fs-extra';
-import logSymbols from 'log-symbols';
 
 const d = debug('electron-forge:init:directory');
 
@@ -18,7 +17,7 @@ export const initDirectory = async (
     d(`found ${files.length} files in the directory.  warning the user`);
 
     if (force) {
-      task.output = `${logSymbols.warning} The specified path "${dir}" is not empty. "force" was set to true, so proceeding to initialize. Files may be overwritten`;
+      task.output = `⚠ The specified path "${dir}" is not empty. "force" was set to true, so proceeding to initialize. Files may be overwritten`;
     } else {
       throw new Error(
         `The specified path: "${dir}" is not empty.  Please ensure it is empty before initializing a new project`,

--- a/packages/external/create-electron-app/src/init.ts
+++ b/packages/external/create-electron-app/src/init.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { styleText } from 'node:util';
 
 import {
   DepType,
@@ -10,7 +11,6 @@ import {
 } from '@electron-forge/core-utils';
 import { ForgeTemplate } from '@electron-forge/shared-types';
 import { spawn } from '@malept/cross-spawn-promise';
-import chalk from 'chalk';
 import debug from 'debug';
 import { Listr } from 'listr2';
 import semver from 'semver';
@@ -108,34 +108,34 @@ export async function init({
         title: `Resolving package manager`,
         task: async (ctx, task) => {
           ctx.pm = await resolvePackageManager(packageManager);
-          task.title = `Resolved package manager: ${chalk.cyan(`${ctx.pm.executable}@${ctx.pm.version}`)}`;
+          task.title = `Resolved package manager: ${styleText('cyan', `${ctx.pm.executable}@${ctx.pm.version}`)}`;
         },
       },
       {
-        title: `Resolving template: ${chalk.cyan(template)}`,
+        title: `Resolving template: ${styleText('cyan', template)}`,
         task: async (ctx, task) => {
           const tmpl = await findTemplate(template);
           ctx.templateModule = tmpl.template;
-          task.output = `Using ${chalk.green(tmpl.name)}`;
+          task.output = `Using ${styleText('green', tmpl.name)}`;
         },
         rendererOptions: { persistentOutput: true },
       },
       {
-        title: `Resolving Electron version: ${chalk.cyan(electronVersion)}`,
+        title: `Resolving Electron version: ${styleText('cyan', electronVersion)}`,
         task: async (ctx, task) => {
           if (
             electronVersion === 'latest' ||
             electronVersion === 'beta' ||
             electronVersion === 'nightly'
           ) {
-            task.output = `Using Electron version tag: ${chalk.cyan(electronVersion)}`;
+            task.output = `Using Electron version tag: ${styleText('cyan', electronVersion)}`;
             ctx.parsedElectronVersion = electronVersion;
           } else {
             // semver.clean allows us to accept `v` versions and trims whitespace
             const maybeVersion = semver.clean(electronVersion);
 
             if (maybeVersion) {
-              task.output = `Using Electron version: ${chalk.cyan(maybeVersion)}`;
+              task.output = `Using Electron version: ${styleText('cyan', maybeVersion)}`;
               ctx.parsedElectronVersion = maybeVersion;
             } else {
               throw new Error(
@@ -191,10 +191,10 @@ export async function init({
             await spawn('corepack', ['use', pmString], {
               cwd: dir,
             });
-            task.title = `Set ${chalk.cyan(pmString)} via Corepack`;
+            task.title = `Set ${styleText('cyan', pmString)} via Corepack`;
           } catch (e) {
             d('corepack failed to run with error', e);
-            task.title = `Forge was unable to set ${chalk.cyan(pmString)} via Corepack and will fall back to ${chalk.cyan('npm')}. If you are using Node.js >= 25, you will need to install corepack via ${chalk.green('npm install -g corepack')}. Otherwise, you may need to enable Corepack shims via ${chalk.green('corepack enable')}.`;
+            task.title = `Forge was unable to set ${styleText('cyan', pmString)} via Corepack and will fall back to ${styleText('cyan', 'npm')}. If you are using Node.js >= 25, you will need to install corepack via ${styleText('green', 'npm install -g corepack')}. Otherwise, you may need to enable Corepack shims via ${styleText('green', 'corepack enable')}.`;
           }
         },
       },

--- a/packages/maker/wix/package.json
+++ b/packages/maker/wix/package.json
@@ -15,9 +15,7 @@
     "@electron-forge/core-utils": "workspace:*",
     "@electron-forge/maker-base": "workspace:*",
     "@electron-forge/shared-types": "workspace:*",
-    "chalk": "^4.0.0",
     "electron-wix-msi": "^5.1.3",
-    "log-symbols": "^4.0.0",
     "semver": "^7.2.1"
   },
   "publishConfig": {

--- a/packages/maker/wix/src/MakerWix.ts
+++ b/packages/maker/wix/src/MakerWix.ts
@@ -1,11 +1,10 @@
 import path from 'node:path';
+import { styleText } from 'node:util';
 
 import { getNameFromAuthor } from '@electron-forge/core-utils';
 import { MakerBase, type MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';
-import chalk from 'chalk';
 import { MSICreator, type MSICreatorOptions } from 'electron-wix-msi';
-import logSymbols from 'log-symbols';
 import semver from 'semver';
 
 import { MakerWixConfig } from './Config.js';
@@ -40,8 +39,9 @@ export default class MakerWix extends MakerBase<MakerWixConfig> {
       (Array.isArray(parsed?.build) && parsed.build.length > 0)
     ) {
       console.warn(
-        logSymbols.warning,
-        chalk.yellow(
+        styleText('yellow', '⚠'),
+        styleText(
+          'yellow',
           'WARNING: MSI packages follow Windows version format "major.minor.build.revision".\n' +
             `The provided semantic version "${version}" will be transformed to Windows version format. Prerelease component will not be retained.`,
         ),

--- a/packages/plugin/vite/package.json
+++ b/packages/plugin/vite/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@electron-forge/plugin-base": "workspace:*",
     "@electron-forge/shared-types": "workspace:*",
-    "chalk": "^4.0.0",
     "debug": "^4.3.1",
     "fs-extra": "^10.0.0",
     "listr2": "^7.0.2"

--- a/packages/plugin/vite/src/VitePlugin.ts
+++ b/packages/plugin/vite/src/VitePlugin.ts
@@ -1,8 +1,8 @@
 import { spawn } from 'node:child_process';
 import path from 'node:path';
+import { styleText } from 'node:util';
 
 import { namedHookWithTaskFn, PluginBase } from '@electron-forge/plugin-base';
-import chalk from 'chalk';
 import debug from 'debug';
 import fs from 'fs-extra';
 import { Listr, PRESET_TIMER } from 'listr2';
@@ -288,7 +288,9 @@ export default class VitePlugin extends PluginBase<VitePluginConfig> {
     if (forgeConfig.packagerConfig.ignore) {
       if (typeof forgeConfig.packagerConfig.ignore !== 'function') {
         console.error(
-          chalk.yellow(`You have set packagerConfig.ignore, the Electron Forge Vite plugin normally sets this automatically.
+          styleText(
+            'yellow',
+            `You have set packagerConfig.ignore, the Electron Forge Vite plugin normally sets this automatically.
 
 Your packaged app may be larger than expected if you dont ignore everything other than the '.vite' folder`),
         );
@@ -353,7 +355,7 @@ the generated files). Instead, it is ${JSON.stringify(pj.main)}.`);
     if (this.isProd) {
       return task?.newListr(
         targets.map(({ spec, index }) => ({
-          title: `Building ${chalk.green(entryToDisplay(spec.entry))}`,
+          title: `Building ${styleText('green', entryToDisplay(spec.entry))}`,
           task: async (_ctx, subtask) => {
             await spawnViteBuild(
               this.serializableConfig,
@@ -361,7 +363,7 @@ the generated files). Instead, it is ${JSON.stringify(pj.main)}.`);
               index,
               this.projectDir,
             );
-            subtask.title = `Built target ${chalk.dim(entryToDisplay(spec.entry))}`;
+            subtask.title = `Built target ${styleText('dim', entryToDisplay(spec.entry))}`;
           },
         })),
         {
@@ -373,7 +375,7 @@ the generated files). Instead, it is ${JSON.stringify(pj.main)}.`);
 
     return task?.newListr(
       targets.map(({ spec, index }) => ({
-        title: `Building ${chalk.green(entryToDisplay(spec.entry))} target`,
+        title: `Building ${styleText('green', entryToDisplay(spec.entry))} target`,
         task: async () => {
           const { child, firstBuild } = spawnViteBuildWatch(
             this.serializableConfig,
@@ -405,7 +407,7 @@ the generated files). Instead, it is ${JSON.stringify(pj.main)}.`);
         .filter(({ spec }) => spec.config);
       return task?.newListr(
         targets.map(({ spec, index }) => ({
-          title: `Building ${chalk.green(spec.name)}`,
+          title: `Building ${styleText('green', spec.name)}`,
           task: async (_ctx, subtask) => {
             await spawnViteBuild(
               this.serializableConfig,
@@ -413,7 +415,7 @@ the generated files). Instead, it is ${JSON.stringify(pj.main)}.`);
               index,
               this.projectDir,
             );
-            subtask.title = `Built target ${chalk.dim(spec.name)}`;
+            subtask.title = `Built target ${styleText('dim', spec.name)}`;
           },
         })),
         {
@@ -432,7 +434,7 @@ the generated files). Instead, it is ${JSON.stringify(pj.main)}.`);
             logLevel: 'error',
             ...userConfig,
           });
-          subtask.title = `Built target ${chalk.dim(path.basename(userConfig.build?.outDir ?? ''))}`;
+          subtask.title = `Built target ${styleText('dim', path.basename(userConfig.build?.outDir ?? ''))}`;
         },
       })),
       {
@@ -445,7 +447,7 @@ the generated files). Instead, it is ${JSON.stringify(pj.main)}.`);
     const rendererConfigs = await this.configGenerator.getRendererConfig();
     return task?.newListr(
       rendererConfigs.map((userConfig) => ({
-        title: `Target ${chalk.cyan(path.basename(userConfig.build?.outDir ?? ''))}`,
+        title: `Target ${styleText('cyan', path.basename(userConfig.build?.outDir ?? ''))}`,
         task: async (_ctx, subtask) => {
           const viteDevServer = await vite.createServer({
             configFile: false,
@@ -510,18 +512,24 @@ the generated files). Instead, it is ${JSON.stringify(pj.main)}.`);
 function getServerURLs(urls: vite.ResolvedServerUrls) {
   let output = '';
   const colorUrl = (url: string) =>
-    chalk.cyan(url.replace(/:(\d+)\//, (_, port) => `:${chalk.bold(port)}/`));
+    styleText(
+      'cyan',
+      url.replace(/:(\d+)\//, (_, port) => `:${styleText('bold', port)}/`),
+    );
   for (const url of urls.local) {
-    output += `  ${chalk.green('➜')}  ${chalk.bold('Local')}:   ${colorUrl(url)}`;
+    output += `  ${styleText('green', '➜')}  ${styleText('bold', 'Local')}:   ${colorUrl(url)}`;
   }
   for (const url of urls.network) {
-    output += `  \n${chalk.green('➜')}  ${chalk.bold('Network')}: ${colorUrl(url)}`;
+    output += `  \n${styleText('green', '➜')}  ${styleText('bold', 'Network')}: ${colorUrl(url)}`;
   }
   if (urls.network.length === 0) {
     output +=
-      chalk.dim(`  \n${chalk.green('➜')}  ${chalk.bold('Network')}: use `) +
-      chalk.bold('--host') +
-      chalk.dim(' to expose');
+      styleText(
+        'dim',
+        `  \n${styleText('green', '➜')}  ${styleText('bold', 'Network')}: use `,
+      ) +
+      styleText('bold', '--host') +
+      styleText('dim', ' to expose');
   }
 
   return output;

--- a/packages/plugin/vite/src/VitePlugin.ts
+++ b/packages/plugin/vite/src/VitePlugin.ts
@@ -292,7 +292,8 @@ export default class VitePlugin extends PluginBase<VitePluginConfig> {
             'yellow',
             `You have set packagerConfig.ignore, the Electron Forge Vite plugin normally sets this automatically.
 
-Your packaged app may be larger than expected if you dont ignore everything other than the '.vite' folder`),
+Your packaged app may be larger than expected if you dont ignore everything other than the '.vite' folder`,
+          ),
         );
       }
       return forgeConfig;

--- a/packages/plugin/vite/src/subprocess-worker.ts
+++ b/packages/plugin/vite/src/subprocess-worker.ts
@@ -1,4 +1,5 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
+
 import { build } from 'vite';
 
 import { viteDevServerUrls } from './config/vite.base.config.js';
@@ -130,16 +131,17 @@ if (!watch) {
     result.on('event', (event) => {
       if (event.code === 'ERROR' && resolved.logLevel !== 'silent') {
         console.error(
-          `\n${chalk.dim(timeFormatter.format(new Date()))} ${event.error.message}`,
+          `\n${styleText('dim', timeFormatter.format(new Date()))} ${event.error.message}`,
         );
       } else if (
         event.code === 'BUNDLE_END' &&
         (!resolved.logLevel || resolved.logLevel === 'info')
       ) {
         console.log(
-          `${chalk.dim(timeFormatter.format(new Date()))} ${chalk.cyan.bold('[@electron-forge/plugin-vite]')} ${chalk.green(
+          `${styleText('dim', timeFormatter.format(new Date()))} ${styleText(['cyan', 'bold'], '[@electron-forge/plugin-vite]')} ${styleText(
+            'green',
             'target built',
-          )} ${chalk.dim(targetDisplay)}`,
+          )} ${styleText('dim', targetDisplay)}`,
         );
       }
     });

--- a/packages/plugin/webpack/package.json
+++ b/packages/plugin/webpack/package.json
@@ -24,7 +24,6 @@
     "@electron-forge/plugin-base": "workspace:*",
     "@electron-forge/shared-types": "workspace:*",
     "@electron-forge/web-multi-logger": "workspace:*",
-    "chalk": "^4.0.0",
     "debug": "^4.3.1",
     "fs-extra": "^10.0.0",
     "html-webpack-plugin": "^5.5.3",

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -2,6 +2,7 @@ import crypto from 'node:crypto';
 import { glob } from 'node:fs/promises';
 import http from 'node:http';
 import path from 'node:path';
+import { styleText } from 'node:util';
 import { pipeline } from 'stream/promises';
 
 import {
@@ -16,7 +17,6 @@ import {
   ResolvedForgeConfig,
 } from '@electron-forge/shared-types';
 import Logger, { Tab } from '@electron-forge/web-multi-logger';
-import chalk from 'chalk';
 import debug from 'debug';
 import fs from 'fs-extra';
 import { PRESET_TIMER } from 'listr2';
@@ -219,7 +219,7 @@ export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
               title: 'Launching dev servers for renderer process code',
               task: async (_, task) => {
                 await this.launchRendererDevServers(logger);
-                task.output = `Output Available: ${chalk.cyan(`http://localhost:${this.loggerPort}`)}\n`;
+                task.output = `Output Available: ${styleText('cyan', `http://localhost:${this.loggerPort}`)}\n`;
               },
               rendererOptions: {
                 persistentOutput: true,
@@ -330,7 +330,7 @@ export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
                         return task.newListr(
                           otherArches.map(
                             (pArch): ListrTask<NativeDepsCtx> => ({
-                              title: `Generating ${chalk.magenta(pArch)} bundle`,
+                              title: `Generating ${styleText('magenta', pArch)} bundle`,
                               task: async (_, innerTask) => {
                                 return innerTask.newListr(
                                   [
@@ -477,7 +477,7 @@ export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
             return task.newListr<NativeDepsCtx>(
               [
                 {
-                  title: `Preparing native dependencies for ${chalk.magenta(firstArch)}`,
+                  title: `Preparing native dependencies for ${styleText('magenta', firstArch)}`,
                   task: async (_, innerTask) => {
                     await listrCompatibleRebuildHook(
                       this.projectDir,
@@ -569,7 +569,9 @@ export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
     if (forgeConfig.packagerConfig.ignore) {
       if (typeof forgeConfig.packagerConfig.ignore !== 'function') {
         console.error(
-          chalk.red(`You have set packagerConfig.ignore, the Electron Forge webpack plugin normally sets this automatically.
+          styleText(
+            'red',
+            `You have set packagerConfig.ignore, the Electron Forge webpack plugin normally sets this automatically.
 
 Your packaged app may be larger than expected if you dont ignore everything other than the '.webpack' folder`),
         );

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -573,7 +573,8 @@ export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
             'red',
             `You have set packagerConfig.ignore, the Electron Forge webpack plugin normally sets this automatically.
 
-Your packaged app may be larger than expected if you dont ignore everything other than the '.webpack' folder`),
+Your packaged app may be larger than expected if you dont ignore everything other than the '.webpack' folder`,
+          ),
         );
       }
       return forgeConfig;

--- a/packages/publisher/github/package.json
+++ b/packages/publisher/github/package.json
@@ -22,10 +22,8 @@
     "@octokit/request-error": "^5.1.1",
     "@octokit/rest": "^20.1.2",
     "@octokit/types": "^6.1.2",
-    "chalk": "^4.0.0",
     "debug": "^4.3.1",
     "fs-extra": "^10.0.0",
-    "log-symbols": "^4.0.0",
     "mime-types": "^2.1.25"
   },
   "publishConfig": {

--- a/packages/publisher/github/src/PublisherGitHub.ts
+++ b/packages/publisher/github/src/PublisherGitHub.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { styleText } from 'node:util';
 
 import {
   PublisherBase,
@@ -7,9 +8,7 @@ import {
 import { ForgeMakeResult } from '@electron-forge/shared-types';
 import { RequestError } from '@octokit/request-error';
 import { GetResponseDataTypeFromEndpointMethod } from '@octokit/types';
-import chalk from 'chalk';
 import fs from 'fs-extra';
-import logSymbols from 'log-symbols';
 import mime from 'mime-types';
 
 import { PublisherGitHubConfig } from './Config.js';
@@ -165,8 +164,9 @@ export default class PublisherGitHub extends PublisherBase<PublisherGitHubConfig
               if (uploadedAsset.name !== sanitizedArtifactName) {
                 // There's definitely a bug with GitHub.sanitizeName
                 console.warn(
-                  logSymbols.warning,
-                  chalk.yellow(
+                  styleText('yellow', '⚠'),
+                  styleText(
+                    'yellow',
                     `Expected artifact's name to be '${sanitizedArtifactName}' - got '${uploadedAsset.name}'`,
                   ),
                 );

--- a/tools/test-clear.ts
+++ b/tools/test-clear.ts
@@ -1,8 +1,8 @@
 import { glob } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { styleText } from 'node:util';
 
-import chalk from 'chalk';
 import fs from 'fs-extra';
 
 (async () => {
@@ -21,7 +21,8 @@ import fs from 'fs-extra';
     }
   } else {
     console.log(
-      chalk.gray(
+      styleText(
+        'gray',
         'There is no "electron-forge-test-*" dir that needs to be cleaned.',
       ),
     );

--- a/tools/test-dist.ts
+++ b/tools/test-dist.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { styleText } from 'node:util';
 
-import chalk from 'chalk';
 import fs from 'fs-extra';
 
 const BASE_DIR = path.resolve(import.meta.dirname, '..');
@@ -47,8 +47,8 @@ const SKIP_IMPORT = new Set(['create-electron-app']);
     }
     if (!main || !(await fs.pathExists(path.resolve(dir, main)))) {
       console.error(
-        `${chalk.cyan(`[${pj.name}]`)}:`,
-        chalk.red(`Main entry not found (${main})`),
+        `${styleText('cyan', `[${pj.name}]`)}:`,
+        styleText('red', `Main entry not found (${main})`),
       );
       bad = true;
     } else if (!SKIP_IMPORT.has(pj.name)) {
@@ -57,16 +57,16 @@ const SKIP_IMPORT = new Set(['create-electron-app']);
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err);
         console.error(
-          `${chalk.cyan(`[${pj.name}]`)}:`,
-          chalk.red(`Failed to import main entry (${main}): ${message}`),
+          `${styleText('cyan', `[${pj.name}]`)}:`,
+          styleText('red', `Failed to import main entry (${main}): ${message}`),
         );
         bad = true;
       }
     }
     if (!typings || !(await fs.pathExists(path.resolve(dir, typings)))) {
       console.error(
-        `${chalk.cyan(`[${pj.name}]`)}:`,
-        chalk.red(`Typings entry not found (${typings})`),
+        `${styleText('cyan', `[${pj.name}]`)}:`,
+        styleText('red', `Typings entry not found (${typings})`),
       );
       bad = true;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -768,12 +768,10 @@ __metadata:
     "@electron-forge/shared-types": "workspace:*"
     "@electron/get": "npm:^5.0.0"
     "@malept/cross-spawn-promise": "npm:^2.0.0"
-    chalk: "npm:^4.0.0"
     commander: "npm:^11.1.0"
     debug: "npm:^4.3.1"
     fs-extra: "npm:^10.0.0"
     listr2: "npm:^7.0.2"
-    log-symbols: "npm:^4.0.0"
     semver: "npm:^7.2.1"
     vitest: "catalog:"
   bin:
@@ -823,7 +821,6 @@ __metadata:
     "@electron-forge/tracer": "workspace:*"
     "@electron/get": "npm:^5.0.0"
     "@electron/packager": "npm:^20.0.0"
-    chalk: "npm:^4.0.0"
     debug: "npm:^4.3.1"
     electron-forge-template-fixture-two: "portal:./spec/fixture/electron-forge-template-fixture"
     electron-installer-common: "npm:^0.10.2"
@@ -831,7 +828,6 @@ __metadata:
     fs-extra: "npm:^10.0.0"
     jiti: "npm:^2.4.2"
     listr2: "npm:^7.0.2"
-    log-symbols: "npm:^4.0.0"
     vitest: "catalog:"
   languageName: unknown
   linkType: soft
@@ -982,9 +978,7 @@ __metadata:
     "@electron-forge/core-utils": "workspace:*"
     "@electron-forge/maker-base": "workspace:*"
     "@electron-forge/shared-types": "workspace:*"
-    chalk: "npm:^4.0.0"
     electron-wix-msi: "npm:^5.1.3"
-    log-symbols: "npm:^4.0.0"
     semver: "npm:^7.2.1"
   languageName: unknown
   linkType: soft
@@ -1051,7 +1045,6 @@ __metadata:
     "@electron-forge/shared-types": "workspace:*"
     "@electron/packager": "npm:^20.0.0"
     "@types/node": "npm:^22.10.7"
-    chalk: "npm:^4.0.0"
     debug: "npm:^4.3.1"
     fs-extra: "npm:^10.0.0"
     listr2: "npm:^7.0.2"
@@ -1072,7 +1065,6 @@ __metadata:
     "@electron/packager": "npm:^20.0.0"
     "@malept/cross-spawn-promise": "npm:^2.0.0"
     "@types/node": "npm:^22.10.7"
-    chalk: "npm:^4.0.0"
     debug: "npm:^4.3.1"
     fs-extra: "npm:^10.0.0"
     html-webpack-plugin: "npm:^5.5.3"
@@ -1141,10 +1133,8 @@ __metadata:
     "@octokit/request-error": "npm:^5.1.1"
     "@octokit/rest": "npm:^20.1.2"
     "@octokit/types": "npm:^6.1.2"
-    chalk: "npm:^4.0.0"
     debug: "npm:^4.3.1"
     fs-extra: "npm:^10.0.0"
-    log-symbols: "npm:^4.0.0"
     mime-types: "npm:^2.1.25"
     vitest: "catalog:"
   languageName: unknown
@@ -7142,13 +7132,11 @@ __metadata:
     "@inquirer/prompts": "npm:^6.0.1"
     "@listr2/prompt-adapter-inquirer": "npm:^2.0.22"
     "@malept/cross-spawn-promise": "npm:^2.0.0"
-    chalk: "npm:^4.0.0"
     commander: "npm:^11.1.0"
     debug: "npm:^4.3.1"
     fs-extra: "npm:^10.0.0"
     listr2: "npm:^7.0.2"
     lodash-es: "npm:^4.17.21"
-    log-symbols: "npm:^4.0.0"
     semver: "npm:^7.2.1"
   bin:
     create-electron-app: dist/index.js
@@ -7730,7 +7718,6 @@ __metadata:
     "@types/semver": "npm:^7.3.4"
     "@types/which": "npm:^3.0.4"
     "@yarnpkg/types": "npm:^4.0.1"
-    chalk: "npm:^4.0.0"
     debug: "npm:^4.3.1"
     electron: "npm:^41.2.0"
     electron-installer-debian: "npm:^3.2.0"


### PR DESCRIPTION
## Summary

This PR replaces the `chalk` and `log-symbols` dependencies with Node.js's built-in `styleText` utility from the `node:util` module. This reduces external dependencies while maintaining the same terminal styling functionality.

## Changes

- **Removed dependencies**: `chalk` and `log-symbols` from all package.json files
- **Updated imports**: Replaced `import chalk from 'chalk'` with `import { styleText } from 'node:util'`
- **Updated API calls**: 
  - `chalk.color(text)` → `styleText('color', text)`
  - `chalk.color.modifier(text)` → `styleText(['color', 'modifier'], text)` (for combined styles)
  - `logSymbols.warning` → `styleText('yellow', '⚠')`
  - `logSymbols.error` → `styleText('red', '✖')`

## Files Modified

- `packages/plugin/vite/src/VitePlugin.ts`
- `packages/plugin/vite/src/subprocess-worker.ts`
- `packages/plugin/webpack/src/WebpackPlugin.ts`
- `packages/api/core/src/api/make.ts`
- `packages/api/core/src/api/package.ts`
- `packages/api/core/src/api/publish.ts`
- `packages/api/core/src/api/start.ts`
- `packages/api/core/src/util/plugin-interface.ts`
- `packages/api/core/src/util/hook.ts`
- `packages/api/core/src/util/electron-executable.ts`
- `packages/api/cli/src/electron-forge.ts`
- `packages/api/cli/src/electron-forge-make.ts`
- `packages/api/cli/src/electron-forge-publish.ts`
- `packages/api/cli/src/util/terminate.ts`
- `packages/external/create-electron-app/src/create-electron-app.ts`
- `packages/external/create-electron-app/src/index.ts`
- `packages/external/create-electron-app/src/init.ts`
- `packages/external/create-electron-app/src/import.ts`
- `packages/external/create-electron-app/src/init-scripts/init-directory.ts`
- `packages/maker/wix/src/MakerWix.ts`
- `packages/publisher/github/src/PublisherGitHub.ts`
- `tools/test-dist.ts`
- `tools/test-clear.ts`
- All relevant `package.json` files

## Benefits

- Reduces external dependencies (2 fewer packages to maintain)
- Uses Node.js built-in utilities (available since Node.js 21.7.0)
- Maintains full compatibility with existing styling behavior
- Simplifies dependency management

## Testing

Existing tests pass. The changes are straightforward refactoring of styling calls with no functional behavior changes.

https://claude.ai/code/session_01Nz9h7uooUdybS8pNjABMsE