### PR TITLE
refactor: replace find-up dependency with internal implementation

### DIFF
--- a/packages/utils/core-utils/package.json
+++ b/packages/utils/core-utils/package.json
@@ -13,7 +13,6 @@
     "@electron/rebuild": "^4.0.1",
     "@malept/cross-spawn-promise": "^2.0.0",
     "debug": "^4.3.1",
-    "find-up": "^5.0.0",
     "fs-extra": "^10.0.0",
     "parse-author": "^2.0.0",
     "semver": "^7.2.1"

--- a/packages/utils/core-utils/spec/find-up.spec.ts
+++ b/packages/utils/core-utils/spec/find-up.spec.ts
@@ -1,0 +1,80 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { findUp } from '../src/find-up';
+
+describe('findUp', () => {
+  let tmpRoot: string;
+  let nestedDir: string;
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'forge-find-up-'));
+    nestedDir = path.join(tmpRoot, 'a', 'b', 'c');
+    await fs.mkdir(nestedDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('finds a file in the starting directory', async () => {
+    const target = path.join(nestedDir, 'yarn.lock');
+    await fs.writeFile(target, '');
+
+    await expect(findUp(['yarn.lock'], { cwd: nestedDir })).resolves.toBe(
+      target,
+    );
+  });
+
+  it('finds a file in an ancestor directory', async () => {
+    const target = path.join(tmpRoot, 'package-lock.json');
+    await fs.writeFile(target, '');
+
+    await expect(
+      findUp(['package-lock.json'], { cwd: nestedDir }),
+    ).resolves.toBe(target);
+  });
+
+  it('returns the closest match when multiple ancestors contain a candidate', async () => {
+    await fs.writeFile(path.join(tmpRoot, 'yarn.lock'), '');
+    const closer = path.join(tmpRoot, 'a', 'yarn.lock');
+    await fs.writeFile(closer, '');
+
+    await expect(findUp(['yarn.lock'], { cwd: nestedDir })).resolves.toBe(
+      closer,
+    );
+  });
+
+  it('respects the order of the names array within a single directory', async () => {
+    const first = path.join(tmpRoot, 'package-lock.json');
+    const second = path.join(tmpRoot, 'yarn.lock');
+    await fs.writeFile(first, '');
+    await fs.writeFile(second, '');
+
+    await expect(
+      findUp(['package-lock.json', 'yarn.lock'], { cwd: nestedDir }),
+    ).resolves.toBe(first);
+    await expect(
+      findUp(['yarn.lock', 'package-lock.json'], { cwd: nestedDir }),
+    ).resolves.toBe(second);
+  });
+
+  it('ignores directories that share a candidate name', async () => {
+    await fs.mkdir(path.join(tmpRoot, 'a', 'yarn.lock'));
+    const target = path.join(tmpRoot, 'yarn.lock');
+    await fs.writeFile(target, '');
+
+    await expect(findUp(['yarn.lock'], { cwd: nestedDir })).resolves.toBe(
+      target,
+    );
+  });
+
+  it('returns undefined when no candidate exists up to the filesystem root', async () => {
+    await expect(
+      findUp(['definitely-not-a-real-forge-file.lock'], { cwd: nestedDir }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/utils/core-utils/spec/package-manager.spec.ts
+++ b/packages/utils/core-utils/spec/package-manager.spec.ts
@@ -1,7 +1,7 @@
 import { spawn } from '@malept/cross-spawn-promise';
-import findUp from 'find-up';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { findUp } from '../src/find-up';
 import {
   resolvePackageManager,
   spawnPackageManager,
@@ -10,13 +10,9 @@ import { pathToFileURL } from 'node:url';
 import path from 'node:path';
 
 vi.mock('@malept/cross-spawn-promise');
-vi.mock('find-up', async (importOriginal) => {
-  const mod = await importOriginal<object>();
-  return {
-    ...mod,
-    default: vi.fn(),
-  };
-});
+vi.mock('../src/find-up', () => ({
+  findUp: vi.fn(),
+}));
 
 describe('package-manager', () => {
   beforeAll(() => {

--- a/packages/utils/core-utils/src/electron-version.ts
+++ b/packages/utils/core-utils/src/electron-version.ts
@@ -1,9 +1,10 @@
 import path from 'node:path';
 
 import debug from 'debug';
-import findUp from 'find-up';
 import fs from 'fs-extra';
 import semver from 'semver';
+
+import { findUp } from './find-up.js';
 
 const d = debug('electron-forge:electron-version');
 
@@ -25,7 +26,7 @@ async function findAncestorNodeModulesPath(
   d('Looking for a lock file to indicate the root of the repo');
   const lockPath = await findUp(
     ['package-lock.json', 'yarn.lock', 'pnpm-lock.yaml'],
-    { cwd: dir, type: 'file' },
+    { cwd: dir },
   );
   if (lockPath) {
     d(`Found lock file: ${lockPath}`);

--- a/packages/utils/core-utils/src/find-up.ts
+++ b/packages/utils/core-utils/src/find-up.ts
@@ -1,0 +1,34 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+/**
+ * Walk up the directory tree from `cwd` looking for the first file whose
+ * basename matches one of `names`. Returns the absolute path, or `undefined`
+ * if the filesystem root is reached without a match.
+ */
+export async function findUp(
+  names: string[],
+  options: { cwd?: string } = {},
+): Promise<string | undefined> {
+  let dir = path.resolve(options.cwd ?? process.cwd());
+  let prev: string | undefined;
+
+  while (dir !== prev) {
+    for (const name of names) {
+      const candidate = path.join(dir, name);
+      try {
+        const stats = await fs.stat(candidate);
+        if (stats.isFile()) {
+          return candidate;
+        }
+      } catch {
+        // file does not exist at this level, keep looking
+      }
+    }
+
+    prev = dir;
+    dir = path.dirname(dir);
+  }
+
+  return undefined;
+}

--- a/packages/utils/core-utils/src/package-manager.ts
+++ b/packages/utils/core-utils/src/package-manager.ts
@@ -6,7 +6,8 @@ import {
   spawn,
 } from '@malept/cross-spawn-promise';
 import debug from 'debug';
-import findUp from 'find-up';
+
+import { findUp } from './find-up.js';
 
 const d = debug('electron-forge:package-manager');
 
@@ -119,10 +120,12 @@ export const resolvePackageManager: (
 
   const executingPM = pmFromUserAgent();
   let lockfilePM;
-  const lockfile = await findUp(
-    ['package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'pnpm-workspace.yaml'],
-    { type: 'file' },
-  );
+  const lockfile = await findUp([
+    'package-lock.json',
+    'yarn.lock',
+    'pnpm-lock.yaml',
+    'pnpm-workspace.yaml',
+  ]);
   if (lockfile) {
     const lockfileName = path.basename(lockfile);
     lockfilePM = PM_FROM_LOCKFILE[lockfileName];

--- a/yarn.lock
+++ b/yarn.lock
@@ -792,7 +792,6 @@ __metadata:
     "@electron/rebuild": "npm:^4.0.1"
     "@malept/cross-spawn-promise": "npm:^2.0.0"
     debug: "npm:^4.3.1"
-    find-up: "npm:^5.0.0"
     fs-extra: "npm:^10.0.0"
     parse-author: "npm:^2.0.0"
     semver: "npm:^7.2.1"


### PR DESCRIPTION
- [ ] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [ ] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This PR removes the external `find-up` dependency and replaces it with an internal implementation in `core-utils`. The new `findUp` function provides the same core functionality—walking up the directory tree to find files—while being simpler and more tailored to the project's needs.

**Changes:**
- Added `src/find-up.ts` with an async `findUp` function that searches for files by walking up the directory tree from a given starting directory
- Added comprehensive test coverage in `spec/find-up.spec.ts` covering:
  - Finding files in the starting directory
  - Finding files in ancestor directories
  - Returning the closest match when multiple ancestors contain a candidate
  - Respecting the order of candidate names within a single directory
  - Ignoring directories that share a candidate name
  - Returning undefined when no candidate exists
- Updated `src/package-manager.ts` and `src/electron-version.ts` to use the new internal implementation
- Updated test mocks in `spec/package-manager.spec.ts` to mock the internal function
- Removed `find-up` from `package.json` dependencies

The new implementation is simpler than the external dependency, removes an external dependency, and provides the exact functionality needed by the codebase.

https://preview.claude.ai/code/session_01VxunirAtie59oe2RTm1DGr