### PR TITLE
refactor: inline filenamify utility to remove external dependency

### DIFF
--- a/packages/api/core/package.json
+++ b/packages/api/core/package.json
@@ -34,7 +34,6 @@
     "@electron/get": "^5.0.0",
     "@electron/packager": "^20.0.0",
     "debug": "^4.3.1",
-    "filenamify": "^6.0.0",
     "graceful-fs": "^4.2.11",
     "jiti": "^2.4.2",
     "listr2": "^7.0.2"

--- a/packages/api/core/spec/fast/util/filenamify.spec.ts
+++ b/packages/api/core/spec/fast/util/filenamify.spec.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest';
+
+import filenamify from '../../../src/util/filenamify';
+
+describe('filenamify', () => {
+  describe('basic sanitization', () => {
+    it('should leave a valid filename unchanged', () => {
+      expect(filenamify('foo')).toBe('foo');
+      expect(filenamify('my-app')).toBe('my-app');
+      expect(filenamify('My App 1.0')).toBe('My App 1.0');
+    });
+
+    it('should replace reserved POSIX/Windows characters with the default replacement (!)', () => {
+      expect(filenamify('foo/bar')).toBe('foo!bar');
+      expect(filenamify('foo\\bar')).toBe('foo!bar');
+      expect(filenamify('foo:bar')).toBe('foo!bar');
+      expect(filenamify('foo*bar')).toBe('foo!bar');
+      expect(filenamify('foo?bar')).toBe('foo!bar');
+      expect(filenamify('foo"bar')).toBe('foo!bar');
+      expect(filenamify('foo<bar')).toBe('foo!bar');
+      expect(filenamify('foo>bar')).toBe('foo!bar');
+      expect(filenamify('foo|bar')).toBe('foo!bar');
+    });
+
+    it('should collapse runs of reserved characters into a single replacement', () => {
+      expect(filenamify('foo//bar')).toBe('foo!bar');
+      expect(filenamify('//foo//bar//')).toBe('!foo!bar!');
+      expect(filenamify('foo\\\\\\bar')).toBe('foo!bar');
+      expect(filenamify('foo<<>>bar')).toBe('foo!bar');
+    });
+
+    it('should not collapse runs when the replacement is empty', () => {
+      expect(filenamify('foo//bar', { replacement: '' })).toBe('foobar');
+      expect(filenamify('//foo//bar//', { replacement: '' })).toBe('foobar');
+    });
+  });
+
+  describe('replacement option', () => {
+    it('should use a custom replacement string', () => {
+      expect(filenamify('foo/bar', { replacement: '-' })).toBe('foo-bar');
+      expect(filenamify('foo:bar:baz', { replacement: '_' })).toBe(
+        'foo_bar_baz',
+      );
+    });
+
+    it('should support an empty replacement string', () => {
+      expect(filenamify('foo/bar', { replacement: '' })).toBe('foobar');
+      expect(filenamify('a<b>c:d', { replacement: '' })).toBe('abcd');
+    });
+
+    it('should support a multi-character replacement string', () => {
+      expect(filenamify('foo/bar', { replacement: '__' })).toBe('foo__bar');
+    });
+  });
+
+  describe('relative path markers', () => {
+    it('should replace leading relative path segments', () => {
+      expect(filenamify('../foo')).toBe('!foo');
+      expect(filenamify('..\\foo')).toBe('!foo');
+      expect(filenamify('./foo')).toBe('!foo');
+      expect(filenamify('....../foo')).toBe('!foo');
+    });
+
+    it('should replace a name that is only dots', () => {
+      expect(filenamify('.')).toBe('!');
+      expect(filenamify('..')).toBe('!');
+      expect(filenamify('...')).toBe('!');
+    });
+
+    it('should preserve a leading dot that is not a relative path marker', () => {
+      expect(filenamify('.dotfile')).toBe('.dotfile');
+    });
+  });
+
+  describe('trailing periods', () => {
+    it('should strip trailing periods', () => {
+      expect(filenamify('foo.')).toBe('foo');
+      expect(filenamify('foo..')).toBe('foo');
+      expect(filenamify('foo...')).toBe('foo');
+    });
+
+    it('should strip trailing periods after replacement', () => {
+      expect(filenamify('foo/.')).toBe('foo!');
+      expect(filenamify('foo.bar.')).toBe('foo.bar');
+    });
+  });
+
+  describe('control characters', () => {
+    it('should replace C0 control characters', () => {
+      const nul = String.fromCharCode(0);
+      const tab = String.fromCharCode(9);
+      const us = String.fromCharCode(31);
+      expect(filenamify(`foo${nul}bar`)).toBe('foo!bar');
+      expect(filenamify(`foo${tab}bar`)).toBe('foo!bar');
+      expect(filenamify(`foo${us}bar`)).toBe('foo!bar');
+    });
+
+    it('should replace C1 control characters', () => {
+      const c1a = String.fromCharCode(0x80);
+      const c1b = String.fromCharCode(0x9f);
+      expect(filenamify(`foo${c1a}bar`)).toBe('foo!bar');
+      expect(filenamify(`foo${c1b}bar`)).toBe('foo!bar');
+    });
+  });
+
+  describe('Windows reserved device names', () => {
+    it('should append the replacement to reserved names (case-insensitive)', () => {
+      expect(filenamify('con')).toBe('con!');
+      expect(filenamify('CON')).toBe('CON!');
+      expect(filenamify('prn')).toBe('prn!');
+      expect(filenamify('aux')).toBe('aux!');
+      expect(filenamify('nul')).toBe('nul!');
+      expect(filenamify('com1')).toBe('com1!');
+      expect(filenamify('lpt9')).toBe('lpt9!');
+    });
+
+    it('should not modify names that merely contain a reserved name', () => {
+      expect(filenamify('cont')).toBe('cont');
+      expect(filenamify('console')).toBe('console');
+      expect(filenamify('com10')).toBe('com10');
+    });
+
+    it('should leave reserved names unchanged when the replacement is empty', () => {
+      expect(filenamify('con', { replacement: '' })).toBe('con');
+    });
+  });
+
+  describe('unicode normalization', () => {
+    it('should NFD-normalize the result', () => {
+      const composed = String.fromCharCode(0x63, 0x61, 0x66, 0x00e9);
+      const decomposed = String.fromCharCode(0x63, 0x61, 0x66, 0x65, 0x0301);
+      expect(filenamify(composed)).toBe(decomposed);
+    });
+  });
+
+  describe('length truncation', () => {
+    it('should truncate to 100 characters by default', () => {
+      const long = 'a'.repeat(150);
+      expect(filenamify(long)).toBe('a'.repeat(100));
+    });
+
+    it('should preserve the extension when truncating', () => {
+      const long = 'a'.repeat(150) + '.txt';
+      const result = filenamify(long);
+      expect(result.length).toBe(100);
+      expect(result.endsWith('.txt')).toBe(true);
+    });
+
+    it('should respect a custom maxLength', () => {
+      expect(filenamify('abcdefghij', { maxLength: 5 })).toBe('abcde');
+    });
+
+    it('should preserve the extension with a custom maxLength', () => {
+      const result = filenamify('abcdefghij.txt', { maxLength: 8 });
+      expect(result).toBe('abcd.txt');
+    });
+
+    it('should keep at least one base character when the extension is longer than maxLength', () => {
+      const result = filenamify('abc.longextension', { maxLength: 4 });
+      expect(result).toBe('a.longextension');
+    });
+
+    it('should not truncate when under the limit', () => {
+      expect(filenamify('short.txt')).toBe('short.txt');
+    });
+  });
+
+  describe('input validation', () => {
+    it('should throw a TypeError for non-string input', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(() => filenamify(123 as any)).toThrow(TypeError);
+    });
+  });
+
+  describe('Forge usage (replacement: "-")', () => {
+    it('should sanitize a scoped package name', () => {
+      expect(filenamify('@scope/my-app', { replacement: '-' })).toBe(
+        '@scope-my-app',
+      );
+    });
+
+    it('should sanitize a productName with reserved characters', () => {
+      expect(filenamify('My: App / Name', { replacement: '-' })).toBe(
+        'My- App - Name',
+      );
+    });
+
+    it('should collapse repeated separators with a hyphen replacement', () => {
+      expect(filenamify('foo///bar', { replacement: '-' })).toBe('foo-bar');
+    });
+  });
+});

--- a/packages/api/core/src/api/make.ts
+++ b/packages/api/core/src/api/make.ts
@@ -15,9 +15,9 @@ import {
   ResolvedForgeConfig,
 } from '@electron-forge/shared-types';
 import { autoTrace, delayTraceTillSignal } from '@electron-forge/tracer';
-import filenamify from 'filenamify';
 import { Listr, PRESET_TIMER } from 'listr2';
 
+import filenamify from '../util/filenamify.js';
 import getForgeConfig from '../util/forge-config.js';
 import { getHookListrTasks, runMutatingHook } from '../util/hook.js';
 import { importSearch } from '../util/import-search.js';

--- a/packages/api/core/src/util/filenamify.ts
+++ b/packages/api/core/src/util/filenamify.ts
@@ -1,0 +1,73 @@
+/* eslint-disable no-control-regex */
+
+// Inlined from filenamify@6.0.0 (MIT, Sindre Sorhus).
+
+const MAX_FILENAME_LENGTH = 100;
+
+const reRelativePath = /^\.+(\\|\/)|^\.+$/;
+const reTrailingPeriods = /\.+$/;
+
+const filenameReservedRegex = () => /[<>:"/\\|?*\u0000-\u001F]/g;
+const windowsReservedNameRegex = () => /^(con|prn|aux|nul|com\d|lpt\d)$/i;
+
+export interface FilenamifyOptions {
+  replacement?: string;
+  maxLength?: number;
+}
+
+export default function filenamify(
+  string: string,
+  options: FilenamifyOptions = {},
+): string {
+  const reControlChars = /[\u0000-\u001F\u0080-\u009F]/g;
+  const reRepeatedReservedCharacters = /([<>:"/\\|?*\u0000-\u001F]){2,}/g;
+
+  if (typeof string !== 'string') {
+    throw new TypeError('Expected a string');
+  }
+
+  const replacement =
+    options.replacement === undefined ? '!' : options.replacement;
+
+  if (
+    filenameReservedRegex().test(replacement) &&
+    reControlChars.test(replacement)
+  ) {
+    throw new Error(
+      'Replacement string cannot contain reserved filename characters',
+    );
+  }
+
+  if (replacement.length > 0) {
+    string = string.replace(reRepeatedReservedCharacters, '$1');
+  }
+
+  string = string.normalize('NFD');
+  string = string.replace(reRelativePath, replacement);
+  string = string.replace(filenameReservedRegex(), replacement);
+  string = string.replace(reControlChars, replacement);
+  string = string.replace(reTrailingPeriods, '');
+
+  string = windowsReservedNameRegex().test(string)
+    ? string + replacement
+    : string;
+
+  const allowedLength =
+    typeof options.maxLength === 'number'
+      ? options.maxLength
+      : MAX_FILENAME_LENGTH;
+  if (string.length > allowedLength) {
+    const extensionIndex = string.lastIndexOf('.');
+    if (extensionIndex === -1) {
+      string = string.slice(0, allowedLength);
+    } else {
+      const filename = string.slice(0, extensionIndex);
+      const extension = string.slice(extensionIndex);
+      string =
+        filename.slice(0, Math.max(1, allowedLength - extension.length)) +
+        extension;
+    }
+  }
+
+  return string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -822,7 +822,6 @@ __metadata:
     debug: "npm:^4.3.1"
     electron-forge-template-fixture-two: "portal:./spec/fixture/electron-forge-template-fixture"
     electron-installer-common: "npm:^0.10.2"
-    filenamify: "npm:^6.0.0"
     graceful-fs: "npm:^4.2.11"
     jiti: "npm:^2.4.2"
     listr2: "npm:^7.0.2"


### PR DESCRIPTION
- [ ] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [ ] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This PR inlines the `filenamify` utility function (from the `filenamify@6.0.0` package by Sindre Sorhus) directly into the codebase and removes the external dependency. The implementation is added to `packages/api/core/src/util/filenamify.ts` with comprehensive test coverage in `packages/api/core/spec/fast/util/filenamify.spec.ts`.

The utility sanitizes filenames by:
- Replacing reserved POSIX/Windows characters with a configurable replacement string (default: `!`)
- Removing relative path markers (`./`, `../`, etc.)
- Stripping trailing periods
- Replacing control characters
- Appending replacement to Windows reserved device names (CON, PRN, AUX, NUL, COM*, LPT*)
- Normalizing to NFD Unicode form
- Truncating to a maximum length (default: 100 characters) while preserving file extensions

The change updates `packages/api/core/src/api/make.ts` to import from the local utility instead of the external package, and removes the `filenamify` dependency from `package.json`.

**Test Plan:**

The new test suite in `filenamify.spec.ts` provides comprehensive coverage of all functionality including basic sanitization, custom replacements, relative path handling, control characters, Windows reserved names, Unicode normalization, and length truncation. All 192 lines of tests pass successfully.

https://preview.claude.ai/code/session_01UAQq1SBi9z3mhQ42D9kJbf