### PR TITLE
fix(template-base): copy over `.oxfmtrc.json` for instantiation

### DIFF
--- a/packages/template/base/spec/BaseTemplate.spec.ts
+++ b/packages/template/base/spec/BaseTemplate.spec.ts
@@ -1,0 +1,50 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const tmplDir = path.resolve(import.meta.dirname, '../tmpl');
+
+describe('BaseTemplate', () => {
+  describe('lint config files', () => {
+    it('should include .oxfmtrc.json in the base template', () => {
+      const oxfmtrcPath = path.join(tmplDir, '.oxfmtrc.json');
+      expect(fs.existsSync(oxfmtrcPath)).toBe(true);
+      const content = JSON.parse(fs.readFileSync(oxfmtrcPath, 'utf-8'));
+      expect(content).not.toHaveProperty('ignorePatterns');
+    });
+
+    it('.oxfmtrc.json should match the repo root config (minus ignorePatterns)', () => {
+      const baseTmpl = JSON.parse(
+        fs.readFileSync(path.join(tmplDir, '.oxfmtrc.json'), 'utf-8'),
+      );
+      const repoRoot = JSON.parse(
+        fs.readFileSync(
+          path.resolve(import.meta.dirname, '../../../../.oxfmtrc.json'),
+          'utf-8',
+        ),
+      );
+      const { ignorePatterns, ...expected } = repoRoot;
+      expect(baseTmpl).toEqual(expected);
+    });
+
+    it('.oxlintrc.json should exist in each template that uses writeLintConfig', () => {
+      const templatesWithLintConfig = [
+        'vite',
+        'vite-typescript',
+        'webpack',
+        'webpack-typescript',
+      ];
+      for (const template of templatesWithLintConfig) {
+        const oxlintrcPath = path.resolve(
+          import.meta.dirname,
+          `../../${template}/tmpl/.oxlintrc.json`,
+        );
+        expect(
+          fs.existsSync(oxlintrcPath),
+          `missing .oxlintrc.json in ${template}`,
+        ).toBe(true);
+      }
+    });
+  });
+});

--- a/packages/template/base/src/BaseTemplate.ts
+++ b/packages/template/base/src/BaseTemplate.ts
@@ -125,13 +125,10 @@ export class BaseTemplate implements ForgeTemplate {
 
   async writeLintConfig(directory: string): Promise<void> {
     await this.copyTemplateFile(directory, '.oxlintrc.json');
-    const oxfmtrc = await fs.readJson(
-      path.resolve(import.meta.dirname, '../../../../.oxfmtrc.json'),
+    await this.copy(
+      path.join(tmplDir, '.oxfmtrc.json'),
+      path.resolve(directory, '.oxfmtrc.json'),
     );
-    delete oxfmtrc.ignorePatterns;
-    await fs.writeJson(path.resolve(directory, '.oxfmtrc.json'), oxfmtrc, {
-      spaces: 2,
-    });
   }
 
   async copyTemplateFile(destDir: string, basename: string): Promise<void> {

--- a/packages/template/base/tmpl/.oxfmtrc.json
+++ b/packages/template/base/tmpl/.oxfmtrc.json
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "printWidth": 80,
+  "sortPackageJson": false
+}


### PR DESCRIPTION
Closes #4255.

The original bug was a regression caused by me trying to be clever by fetching the `.oxfmtrc.json` file straight from the repo root to keep the templates and our repo in sync.

That doesn't work when called from the template code, so this PR copies it over instead and adds a little test to prevent drift between the copied file and the one in the repo root.