### PR TITLE
build: add `tsconfig.json` to `clean` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "minimatch@7.4.6": "^7.4.8"
   },
   "scripts": {
-    "clean": "node -e \"fs.rmSync('dist', { recursive: true, force: true })\" && lerna exec -- \"node -e \\\"fs.rmSync('dist', { recursive: true, force: true })\\\" && node -e \\\"fs.rmSync('tsconfig.tsbuildinfo', { recursive: true, force: true })\\\"\"",
+    "clean": "node -e \"fs.rmSync('dist', { recursive: true, force: true })\" && node -e \"fs.rmSync('packages/tsconfig.json', { force: true })\" && lerna exec -- \"node -e \\\"fs.rmSync('dist', { recursive: true, force: true })\\\" && node -e \\\"fs.rmSync('tsconfig.tsbuildinfo', { recursive: true, force: true })\\\" && node -e \\\"fs.rmSync('tsconfig.json', { force: true })\\\"\"",
     "build": "tsgo -b packages && tsx tools/test-dist",
     "build:watch": "tsgo -b packages --watch",
     "docs": "yarn build && typedoc",


### PR DESCRIPTION
Small change, removes some auto-generated tsconfig files as part of the `clean` script.