### PR TITLE
fix(core): convert absolute paths to file URLs in importSearch

### DIFF
--- a/packages/api/core/spec/fast/util/import-search.spec.ts
+++ b/packages/api/core/spec/fast/util/import-search.spec.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import findConfig from '../../../src/util/forge-config.js';
@@ -22,6 +24,16 @@ describe('import-search', () => {
     await expect(
       importSearch(import.meta.dirname, ['../../fixture/import-search/erick']),
     ).resolves.toBeNull();
+  });
+
+  it('should resolve a file given an absolute path', async () => {
+    const resolved = await importSearch(import.meta.dirname, [
+      path.resolve(
+        import.meta.dirname,
+        '../../fixture/import-search/default-export.js',
+      ),
+    ]);
+    expect(resolved).toEqual('electron-forge');
   });
 
   it('should throw if file exists but fails to load', async () => {

--- a/packages/api/core/spec/fixture/import-search/default-export.js
+++ b/packages/api/core/spec/fixture/import-search/default-export.js
@@ -1,0 +1,1 @@
+export default 'electron-forge';

--- a/packages/api/core/src/util/import-search.ts
+++ b/packages/api/core/src/util/import-search.ts
@@ -67,7 +67,14 @@ async function importSearchRaw<T>(
   for (const testPath of testPaths) {
     try {
       d('testing', testPath);
-      return await import(testPath);
+      // Absolute paths must be passed to `import()` as `file://` URLs, otherwise
+      // Node's ESM loader rejects Windows paths (e.g. `C:\...`) with
+      // `ERR_UNSUPPORTED_ESM_URL_SCHEME`. Bare specifiers are left untouched.
+      return await import(
+        path.isAbsolute(testPath)
+          ? pathToFileURL(testPath).toString()
+          : testPath
+      );
     } catch (err) {
       if (err instanceof Error) {
         const resolutionError = err as ResolutionError;


### PR DESCRIPTION
## Summary

Fixes #4264.

`electron-forge package` (and other commands that load makers, plugins, or hooks) crashed on Windows with:

```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
```

### Root cause

`importSearchRaw` in `packages/api/core/src/util/import-search.ts` builds candidate paths by resolving bare specifiers against the project directory and its `node_modules`, producing **absolute** paths, then passes them directly to `import()`:

```js
.concat(paths.map((mapPath) => path.resolve(relativeTo, mapPath)))
.concat(paths.map((mapPath) => path.resolve(relativeTo, 'node_modules', mapPath)))
...
return await import(testPath); // testPath = "C:\Users\..." on Windows
```

On Windows, Node's ESM loader interprets the `C:` drive letter as a URL scheme and rejects it. Because the resulting error is not `ERR_MODULE_NOT_FOUND`, the loop re-throws instead of moving on to the next candidate, aborting the whole run.

This is the same class of bug fixed for `electron-forge start` in #4214 — that PR even converted line 54 of this file (the monorepo short-circuit), but the candidate-path loop was missed.

### Fix

Convert absolute paths to `file://` URLs before importing, leaving bare specifiers (e.g. `@electron-forge/maker-zip`) and relative specifiers untouched.

## Test plan

- [x] `yarn test:fast packages/api/core/spec/fast/util/import-search.spec.ts` — added a fixture (`spec/fixture/import-search/default-export.js`) and a test that resolves a module via an absolute path; all tests pass
- [x] `yarn lint` (oxfmt + oxlint) is clean
- [x] `yarn build` succeeds
- [ ] On Windows, run `electron-forge package` on a generated app and confirm it completes without `ERR_UNSUPPORTED_ESM_URL_SCHEME`

https://claude.ai/code/session_01TgHWa1UNvb6MNvynuqv6v6

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgHWa1UNvb6MNvynuqv6v6)_