### PR TITLE
feat(maker-dmg)!: write DMGs to platform/arch subdirectories

### DIFF
--- a/packages/maker/dmg/spec/MakerDMG.spec.ts
+++ b/packages/maker/dmg/spec/MakerDMG.spec.ts
@@ -1,7 +1,8 @@
 import fs from 'node:fs/promises';
+import path from 'node:path';
 
 import { MakerOptions } from '@electron-forge/maker-base';
-import { ForgeArch } from '@electron-forge/shared-types';
+import { ForgeArch, ForgePlatform } from '@electron-forge/shared-types';
 import { createDMG } from 'electron-installer-dmg';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -31,6 +32,7 @@ describe('MakerDMG', () => {
   const makeDir = '/my/test/dir/make';
   const appName = 'My Test App';
   const targetArch = process.arch as ForgeArch;
+  const targetPlatform = 'darwin' as ForgePlatform;
   const packageJSON = { version: '1.2.3' };
 
   it('should pass through correct defaults', async () => {
@@ -42,9 +44,37 @@ describe('MakerDMG', () => {
       makeDir,
       appName,
       targetArch,
+      targetPlatform,
       packageJSON,
     });
     expect(vi.mocked(createDMG)).toHaveBeenCalledOnce();
+  });
+
+  it('should output to a platform/arch specific subdirectory to avoid conflicts between parallel makers', async () => {
+    const maker = new MakerDMG({}, []);
+    maker.ensureFile = vi.fn();
+    await maker.prepareConfig(targetArch);
+    const expectedDir = path.resolve(
+      makeDir,
+      'dmg',
+      targetPlatform,
+      targetArch,
+    );
+    await (maker.make as MakeFunction)({
+      dir,
+      makeDir,
+      appName,
+      targetArch,
+      targetPlatform,
+      packageJSON,
+    });
+    expect(vi.mocked(createDMG)).toHaveBeenCalledWith(
+      expect.objectContaining({ out: expectedDir }),
+    );
+    expect(vi.mocked(fs.rename)).toHaveBeenCalledWith(
+      expect.stringContaining(expectedDir),
+      expect.stringContaining(expectedDir),
+    );
   });
 
   it('should attempt to rename the DMG file with version if no custom name is set', async () => {
@@ -56,6 +86,7 @@ describe('MakerDMG', () => {
       makeDir,
       appName,
       targetArch,
+      targetPlatform,
       packageJSON,
     });
     expect(vi.mocked(fs.rename)).toHaveBeenCalledOnce();
@@ -74,6 +105,7 @@ describe('MakerDMG', () => {
       makeDir,
       appName,
       targetArch,
+      targetPlatform,
       packageJSON,
     });
     expect(vi.mocked(fs.rename)).not.toHaveBeenCalled();

--- a/packages/maker/dmg/spec/MakerDMG.spec.ts
+++ b/packages/maker/dmg/spec/MakerDMG.spec.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 
 import { MakerOptions } from '@electron-forge/maker-base';
-import { ForgeArch, ForgePlatform } from '@electron-forge/shared-types';
+import { ForgeArch } from '@electron-forge/shared-types';
 import { createDMG } from 'electron-installer-dmg';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -32,7 +32,6 @@ describe('MakerDMG', () => {
   const makeDir = '/my/test/dir/make';
   const appName = 'My Test App';
   const targetArch = process.arch as ForgeArch;
-  const targetPlatform = 'darwin' as ForgePlatform;
   const packageJSON = { version: '1.2.3' };
 
   it('should pass through correct defaults', async () => {
@@ -44,28 +43,21 @@ describe('MakerDMG', () => {
       makeDir,
       appName,
       targetArch,
-      targetPlatform,
       packageJSON,
     });
     expect(vi.mocked(createDMG)).toHaveBeenCalledOnce();
   });
 
-  it('should output to a platform/arch specific subdirectory to avoid conflicts between parallel makers', async () => {
+  it('should output to an arch-specific subdirectory to avoid conflicts between parallel makers', async () => {
     const maker = new MakerDMG({}, []);
     maker.ensureFile = vi.fn();
     await maker.prepareConfig(targetArch);
-    const expectedDir = path.resolve(
-      makeDir,
-      'dmg',
-      targetPlatform,
-      targetArch,
-    );
+    const expectedDir = path.resolve(makeDir, 'dmg', targetArch);
     await (maker.make as MakeFunction)({
       dir,
       makeDir,
       appName,
       targetArch,
-      targetPlatform,
       packageJSON,
     });
     expect(vi.mocked(createDMG)).toHaveBeenCalledWith(
@@ -86,7 +78,6 @@ describe('MakerDMG', () => {
       makeDir,
       appName,
       targetArch,
-      targetPlatform,
       packageJSON,
     });
     expect(vi.mocked(fs.rename)).toHaveBeenCalledOnce();
@@ -105,7 +96,6 @@ describe('MakerDMG', () => {
       makeDir,
       appName,
       targetArch,
-      targetPlatform,
       packageJSON,
     });
     expect(vi.mocked(fs.rename)).not.toHaveBeenCalled();

--- a/packages/maker/dmg/src/MakerDMG.ts
+++ b/packages/maker/dmg/src/MakerDMG.ts
@@ -27,7 +27,7 @@ export default class MakerDMG extends MakerBase<MakerDMGConfig> {
   }: MakerOptions): Promise<string[]> {
     const { createDMG } = await import('electron-installer-dmg');
 
-    const dmgDir = path.resolve(makeDir, 'dmg', targetPlatform, targetArch);
+    const dmgDir = path.resolve(makeDir, 'dmg', targetArch);
     const outPath = path.resolve(dmgDir, `${this.config.name || appName}.dmg`);
     const forgeDefaultOutPath = path.resolve(
       dmgDir,

--- a/packages/maker/dmg/src/MakerDMG.ts
+++ b/packages/maker/dmg/src/MakerDMG.ts
@@ -23,7 +23,6 @@ export default class MakerDMG extends MakerBase<MakerDMGConfig> {
     appName,
     packageJSON,
     targetArch,
-    targetPlatform,
   }: MakerOptions): Promise<string[]> {
     const { createDMG } = await import('electron-installer-dmg');
 

--- a/packages/maker/dmg/src/MakerDMG.ts
+++ b/packages/maker/dmg/src/MakerDMG.ts
@@ -23,12 +23,14 @@ export default class MakerDMG extends MakerBase<MakerDMGConfig> {
     appName,
     packageJSON,
     targetArch,
+    targetPlatform,
   }: MakerOptions): Promise<string[]> {
     const { createDMG } = await import('electron-installer-dmg');
 
-    const outPath = path.resolve(makeDir, `${this.config.name || appName}.dmg`);
+    const dmgDir = path.resolve(makeDir, 'dmg', targetPlatform, targetArch);
+    const outPath = path.resolve(dmgDir, `${this.config.name || appName}.dmg`);
     const forgeDefaultOutPath = path.resolve(
-      makeDir,
+      dmgDir,
       `${appName}-${packageJSON.version}-${targetArch}.dmg`,
     );
 
@@ -38,7 +40,7 @@ export default class MakerDMG extends MakerBase<MakerDMGConfig> {
       name: appName,
       ...this.config,
       appPath: path.resolve(dir, `${appName}.app`),
-      out: path.dirname(outPath),
+      out: dmgDir,
     };
     await createDMG(dmgConfig);
     if (!this.config.name) {


### PR DESCRIPTION
- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Supersedes #3741, targeting the `next` branch (Forge 8).

`maker-dmg` writes its intermediary `${appName}.dmg` artifact directly into `out/make/`. When Forge runs makers in parallel for multiple architectures (e.g. `darwin/x64` and `darwin/arm64`), both invocations write to the same file and collide (#3517).

This implements [the approach @MarshallOfSound suggested on #3741](https://github.com/electron/forge/pull/3741#pullrequestreview-2380899378): rather than disambiguating via the filename (which would tack an arch suffix onto everyone's DMG — see [the concern raised on #3741](https://github.com/electron/forge/pull/3741#discussion_r1821675922)), write artifacts into a per-target subdirectory `{makeDir}/dmg/{platform}/{arch}/`, mirroring `MakerZIP`. Each parallel maker now gets its own directory, so there is no collision, and DMG filenames are left untouched.

This is a breaking change to the output path (`out/make/App.dmg` → `out/make/dmg/darwin/arm64/App.dmg`), which is why it targets `next` rather than `main` — see [@erickzhao's note on #3741](https://github.com/electron/forge/pull/3741#issuecomment-2550449449).

Co-authored with @lockiechen, the author of the original PR #3741.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnXxToGWmcvXd5vN8D1AXs)_