### PR TITLE
fix(core): Disable concurrency for package tasks

### DIFF
--- a/packages/api/core/src/api/package.ts
+++ b/packages/api/core/src/api/package.ts
@@ -671,6 +671,7 @@ export const listrPackage = (
                                     },
                                   ],
                                   {
+                                    concurrent: false,
                                     rendererOptions: {
                                       collapseSubtasks: true,
                                       collapseErrors: false,


### PR DESCRIPTION
- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] ~~The changes are appropriately documented (if applicable).~~
- [ ] ~~The changes have sufficient test coverage (if applicable).~~
- [x] The testsuite passes successfully on my local machine (if applicable).
  - (there are a few tests in the slow suite that fail before and after this change)
  
**Summarize your changes:**

These seem to have been unintentionally inheriting `"concurrent": true` from the list of targets a couple of levels up. The result is that all three subtasks of packaging appear to start simultaneously, even though the underlying work happens sequentially inside `@electron/packager`.

This isn't really a problem in dev, but in CI it's confusing because it makes it look like, for example, the `prepare-native-dependencies` task has started before the `copy-files` task is finished, which isn't true.