### PR TITLE
chore: exclude git worktrees from tooling

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -3,6 +3,7 @@
   "printWidth": 80,
   "sortPackageJson": false,
   "ignorePatterns": [
+    "**/.claude/**",
     ".nyc_output",
     "dist/",
     "docs/",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -48,6 +48,7 @@
     }
   ],
   "ignorePatterns": [
+    "**/.claude/**",
     "dist",
     "docs/",
     "node_modules",

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     clearMocks: true,
-    exclude: ['**/.links/**', '**/node_modules/**'],
+    exclude: ['**/.links/**', '**/node_modules/**', '**/.claude/**'],
     fileParallelism: false,
     projects: [
       {


### PR DESCRIPTION
## Summary

Enables using git worktrees in this repo without breaking things in the root repository. Worktrees created under `.claude/worktrees/` are full nested checkouts, and several CI tools recursed into them.

I built a fake worktree under `.claude/worktrees/` and ran each CI tool against it to determine which actually descend in (rather than inferring from glob rules). Three tools needed exclusions:

| Tool | Problem |
|------|---------|
| **vitest** | `include: ['**/spec/**/*.spec.ts']` matched specs inside the worktree → every spec runs **twice**, with potential fixture-path collisions |
| **oxlint** | `.claude` not in `ignorePatterns` → lints duplicate source |
| **oxfmt** | `.claude` not in `ignorePatterns` → format-checks duplicate source |

Each now excludes `**/.claude/**`.

## Already safe (verified, no change needed)

markdownlint-cli2 + lint-roller (their `**/*.md` globs don't descend into dot-directories), knip (scoped to `package.json` workspaces), build tooling (`getPackageInfo` only reads `packages/`), the CI artifact upload (`packages/*/*/dist/*`), and `git status` (git auto-excludes *registered* worktrees).

## Notes

- A bare `.claude` entry does **not** work for oxlint/oxfmt — unlike `node_modules`, a hidden directory needs an explicit glob (`**/.claude/**`). Verified the glob form works.
- Nothing under `.claude` is tracked in git, so excluding it wholesale is safe.
- Scope: covers worktrees under `.claude/worktrees/`. Worktrees placed elsewhere in the tree would need their own exclusions.

## Test plan

- [x] Built a probe worktree under `.claude/worktrees/` and confirmed vitest/oxlint/oxfmt each picked up the duplicate files before the fix
- [x] Confirmed all three exclude the probe after the fix
- [x] Confirmed a normal run (no worktree present) is unaffected (oxlint still lints all 255 files)
- [x] Configs remain valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)