### PR TITLE
test: retry temp folder removal for tests that spawn Electron

### DIFF
--- a/packages/plugin/fuses/spec/FusesPlugin.slow.verdaccio.spec.ts
+++ b/packages/plugin/fuses/spec/FusesPlugin.slow.verdaccio.spec.ts
@@ -24,6 +24,8 @@ describe('FusesPlugin', () => {
     await fs.promises.rm(outDir, {
       recursive: true,
       force: true,
+      maxRetries: 5,
+      retryDelay: 500,
     });
   });
 

--- a/packages/utils/test-utils/src/template-tests.ts
+++ b/packages/utils/test-utils/src/template-tests.ts
@@ -267,7 +267,12 @@ export function testForgeTemplate({
     );
 
     afterEach(async () => {
-      await fs.promises.rm(tmpDir, { recursive: true, force: true });
+      await fs.promises.rm(tmpDir, {
+        recursive: true,
+        force: true,
+        maxRetries: 5,
+        retryDelay: 500,
+      });
     });
   });
 }


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

When cleaning up temporary folders containing an Electron executable that is spawned by a test, `fs.promises.rm` can sometimes throw `Error: EBUSY: resource busy or locked, unlink 'path\to\electron-app.exe'` on Windows (see https://github.com/electron/forge/actions/runs/28900198935/job/85735026394#step:11:1731 and https://github.com/electron/forge/actions/runs/29090950003/job/86356018118#step:11:1763), failing the test.

This PR sets the `maxRetries` option for `fs.promises.rm` so we can handle this scenario more gracefully in the two tests where it can happen.
