### PR TITLE
fix: declare magic variables in vite-typescript template

### DIFF
--- a/packages/template/vite-typescript/tmpl/main.ts
+++ b/packages/template/vite-typescript/tmpl/main.ts
@@ -2,6 +2,10 @@ import { app, BrowserWindow } from 'electron';
 import path from 'node:path';
 import started from 'electron-squirrel-startup';
 
+// Magic variables from electron-forge
+declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string;
+declare const MAIN_WINDOW_VITE_NAME: string;
+
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (started) {
   app.quit();


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).

**Summarize your changes:**

Declare vite magic variables in vite-typescript template. Without this, I was getting TypeScript errors.

`main` PR: https://github.com/electron/forge/pull/4318